### PR TITLE
fix(ci): set output has been deprecated

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -22,13 +22,15 @@ jobs:
       - name: Extract helm repos
         id: helm-repos
         run: |
-          echo -n "::set-output name=repos::"
-          for DIR in ./charts/*; do
-            FILE="$DIR/Chart.yaml"
-            DIR="${DIR//\./}"
-            yq e '.dependencies.[].repository' "$FILE"
-          done | sort -u | awk '{printf (NR>1 ? "," : "") NR "=" $1}'
-          echo
+          (
+            echo -n "repos="
+            for DIR in ./charts/*; do
+              FILE="$DIR/Chart.yaml"
+              DIR="${DIR//\./}"
+              yq e '.dependencies.[].repository' "$FILE"
+            done | sort -u | awk '{printf (NR>1 ? "," : "") NR "=" $1}'
+            echo
+          ) > $GITHUB_OUTPUT
 
       - name: Set up Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
instead use $GITHUB_OUTPUT, see https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/#patching-your-actions-and-workflows