### PR TITLE
fix(ci): use latest release specific to chart, properly label release PRs

### DIFF
--- a/.github/workflows/label-release-pr.yaml
+++ b/.github/workflows/label-release-pr.yaml
@@ -1,0 +1,29 @@
+name: Label release PR
+
+on:
+  pull_request_target:
+    types:
+      - closed
+
+jobs:
+  labelling:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-22.04
+    steps:
+      - name: remove old label
+        run: |
+          set -x
+          curl --silent --fail-with-body \
+            -X DELETE \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'Authorization: token ${{ github.token }}' \
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/issues/${{ github.event.number }}/labels/autorelease:%20pending"
+      - name: add new label
+        run: |
+          set -x
+          curl --silent --fail-with-body \
+            -X POST \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'Authorization: token ${{ github.token }}' \
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/issues/${{ github.event.number }}/labels" \
+            -d '{"labels":["autorelease: tagged"]}'

--- a/.github/workflows/semver.yaml
+++ b/.github/workflows/semver.yaml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch: {}
 
 jobs:
-  changeFinder:
+  createReleasePR:
     runs-on: ubuntu-latest
     env:
       CT_TARGET_BRANCH: ${{ github.event.repository.default_branch }}
@@ -20,18 +20,21 @@ jobs:
       - uses: helm/chart-testing-action@v2.3.1
 
       - id: getChangedChart
+        name: Get changed chart in this commit
         run: |
           set -x
           set -o pipefail
           (
-            echo -n changedChart=
-            ct list-changed --since "HEAD~" | cut -d / -f 2 | jq -c -Rn '[inputs]'
+            echo -n chart=
+            ct list-changed --since "HEAD~" | cut -d / -f 2
           ) | tee $GITHUB_OUTPUT
       - id: getLatestReleaseHash
+        name: Get latest release for the changed chart
         run: |
           set -x
           set -o pipefail
-          chart="${{ steps.getChangedChart.changedChart }}"
+          chart="${{ steps.getChangedChart.outputs.chart }}"
+          chart=${chart:?chart variable is empty}
           (
             echo -n hash=
             (
@@ -48,11 +51,11 @@ jobs:
 
       - uses: google-github-actions/release-please-action@v3
         with:
-          path: charts/${{ steps.getChangedChart.changedChart }}
+          path: charts/${{ steps.getChangedChart.outputs.chart }}
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
           release-type: helm
           monorepo-tags: true
           separate-pull-requests: true
-          package-name: ${{ steps.getChangedChart.changedChart }}
+          package-name: ${{ steps.getChangedChart.outputs.chart }}
           command: release-pr
-          last-release-sha: ${{ steps.getLatestReleaseHash.hash }}
+          last-release-sha: ${{ steps.getLatestReleaseHash.outputs.hash }}

--- a/.github/workflows/semver.yaml
+++ b/.github/workflows/semver.yaml
@@ -11,46 +11,48 @@ on:
 jobs:
   changeFinder:
     runs-on: ubuntu-latest
-    outputs:
-      changedCharts: ${{ steps.getChangedCharts.outputs.changedCharts }}
     env:
       CT_TARGET_BRANCH: ${{ github.event.repository.default_branch }}
     steps:
-      - id: latestRelease
-        uses: pozetroninc/github-action-get-latest-release@master
-        with:
-          repository: ${{ github.repository }}
-        continue-on-error: true
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - uses: helm/chart-testing-action@v2.3.1
 
-      - id: getChangedCharts
+      - id: getChangedChart
         run: |
           set -x
           set -o pipefail
-          LATEST_RELEASE="${{ steps.latestRelease.release }}"
-          LATEST_RELEASE="${LATEST_RELEASE:-$(git rev-list HEAD | tail -n 1)}"
           (
-            echo -n changedCharts=
-            ct list-changed --since "$LATEST_RELEASE" | cut -d / -f 2 | jq -c -Rn '[inputs]'
+            echo -n changedChart=
+            ct list-changed --since "HEAD~" | cut -d / -f 2 | jq -c -Rn '[inputs]'
           ) | tee $GITHUB_OUTPUT
-  release-please:
-    runs-on: ubuntu-latest
-    needs:
-      - changeFinder
-    strategy:
-      fail-fast: false
-      matrix:
-        chart: ${{ fromJson(needs.changeFinder.outputs.changedCharts) }}
-    steps:
+      - id: getLatestReleaseHash
+        run: |
+          set -x
+          set -o pipefail
+          chart="${{ steps.getChangedChart.changedChart }}"
+          (
+            echo -n hash=
+            (
+              curl -H "Authorization: Bearer ${{ secrets.ACTIONS_BOT_TOKEN }}" "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/releases" \
+                | jq -r ".[] | select(.name | startswith(\"${chart}-\")) | \"\\(.published_at)\\t\\(.target_commitish)\"" \
+                | sort -k 1 \
+                | tail -n 1 \
+                | cut -f 2 \
+                | grep -E .
+            ) || (
+              git rev-list HEAD "charts/$chart" | tail -n 1
+            )
+          ) | tee $GITHUB_OUTPUT
+
       - uses: google-github-actions/release-please-action@v3
         with:
-          path: charts/${{ matrix.chart }}
+          path: charts/${{ steps.getChangedChart.changedChart }}
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
           release-type: helm
           monorepo-tags: true
           separate-pull-requests: true
-          package-name: ${{ matrix.chart }}
+          package-name: ${{ steps.getChangedChart.changedChart }}
           command: release-pr
+          last-release-sha: ${{ steps.getLatestReleaseHash.hash }}


### PR DESCRIPTION
also, there can only be one chart changed per commit, so we don't have
to run a matrix job