### PR TITLE
feat(base-cluster): enable brotli and gzip

### DIFF
--- a/charts/base-cluster/templates/ingress/nginx.yaml
+++ b/charts/base-cluster/templates/ingress/nginx.yaml
@@ -29,8 +29,8 @@ spec:
           additionalLabels: {{- .Values.monitoring.labels | toYaml | nindent 12 }}
       config:
         use-proxy-protocol: "true"
-		use-gzip: "true"
-		enable-brotli: "true"
+        use-gzip: "true"
+        enable-brotli: "true"
       service:
         annotations:
           loadbalancer.openstack.org/proxy-protocol: "true"

--- a/charts/base-cluster/templates/ingress/nginx.yaml
+++ b/charts/base-cluster/templates/ingress/nginx.yaml
@@ -29,6 +29,8 @@ spec:
           additionalLabels: {{- .Values.monitoring.labels | toYaml | nindent 12 }}
       config:
         use-proxy-protocol: "true"
+		use-gzip: "true"
+		enable-brotli: "true"
       service:
         annotations:
           loadbalancer.openstack.org/proxy-protocol: "true"


### PR DESCRIPTION
As this has no downside we enable brotli and gzip compression for the nginx.