### PR TITLE
feat(base-cluster): disable PrometheusNotConnectedToAlertman…

### DIFF
--- a/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_config.yaml
+++ b/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_config.yaml
@@ -165,6 +165,7 @@ prometheusOperator:
 defaultRules:
   disabled:
     etcdHighNumberOfFailedGRPCRequests: true
+    PrometheusNotConnectedToAlertmanagers: true # TODO dependent on Alertmanagers
   rules:
     kubeApiserverAvailability: false
 kubelet:


### PR DESCRIPTION
…agers rule, as alertmanagers are disabled

In future, this should be dependent on routes and receivers (https://github.com/teutonet/teutonet-helm-charts/issues/70)