### PR TITLE
feat(base-cluster/descheduler): update descheduler supported versions

### DIFF
--- a/charts/base-cluster/templates/descheduler/descheduler.yaml
+++ b/charts/base-cluster/templates/descheduler/descheduler.yaml
@@ -1,16 +1,7 @@
 {{- if .Values.descheduler.enabled -}}
 {{- $kubeMinorVersion := .Capabilities.KubeVersion.Minor -}}
-{{- $versionMatrix := dict 18 "0.20.x" 19 "0.21.x" 20 "0.22.x" 21 "0.21.x" 22 "0.22.x" 23 "0.23.x" 24 "0.24.x" 25 "0.25.x" 26 "0.26.x" -}}
-{{- $highestVersionIndex := $versionMatrix | keys | first | int -}}
-{{- range $index := $versionMatrix | keys -}}
-  {{- if gt ($index | int) $highestVersionIndex -}}
-    {{- $highestVersionIndex = $index | int -}}
-  {{- end -}}
-{{- end -}}
-{{- $latestVersion := index $versionMatrix ($highestVersionIndex | toString) -}}
-{{- if eq $latestVersion nil -}}
-  {{- fail (printf "descheduler's $latestVersion should never be nil") -}}
-{{- end -}}
+{{- $versionMatrix := dict 18 "0.20.x" 19 "0.21.x" 20 "0.22.x" 21 "0.23.x" 22 "0.24.x" 23 "0.25.x" -}}
+{{- $latestVersion := .Values.global.helmRepositories.descheduler.charts.descheduler -}}
 {{- $selectedVersion := (hasKey $versionMatrix $kubeMinorVersion) | ternary (index $versionMatrix $kubeMinorVersion) $latestVersion -}}
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease

--- a/charts/base-cluster/values.yaml
+++ b/charts/base-cluster/values.yaml
@@ -100,6 +100,8 @@ global:
         external-dns: 6.x.x
     descheduler:
       url: https://kubernetes-sigs.github.io/descheduler
+      charts:
+        descheduler: 0.26.x
       condition: '{{ .Values.descheduler.enabled }}'
     jetstack:
       url: https://charts.jetstack.io


### PR DESCRIPTION
add main version to values.yaml

each descheduler's minor version supports (d minor)-2 k8s minor versions, therefore we can use (k8s minor)+2 as the descheduler version