### PR TITLE
feat(base-cluster/ingress): support hetzner cloud loadbalancer

### DIFF
--- a/charts/base-cluster/templates/ingress/nginx.yaml
+++ b/charts/base-cluster/templates/ingress/nginx.yaml
@@ -28,6 +28,8 @@ spec:
       service:
         annotations:
           loadbalancer.openstack.org/proxy-protocol: "true"
+          load-balancer.hetzner.cloud/uses-proxyprotocol: "true"
+          load-balancer.hetzner.cloud/disable-private-ingress: "true"
         {{- if .Values.ingress.IP }}
           loadbalancer.openstack.org/keep-floatingip: "true"
         {{- end }}


### PR DESCRIPTION
This

- enables the proxy protocol for the HCLB
- removes private IPs from the ingress service
  - This "fixes" the external-dns, without it it creates DNS records with internal IPs