### PR TITLE
fix(ci): add missing prepare-values for release metadata

### DIFF
--- a/.github/workflows/release-update-metadata.yaml
+++ b/.github/workflows/release-update-metadata.yaml
@@ -27,6 +27,7 @@ jobs:
       - name: Install sponge
         run: sudo apt-get -yq install moreutils
 
+      - run: ./.github/scripts/prepare-values.sh
       - name: extract images
         run: ./.github/scripts/extract-artifacthub-images.sh "charts/$CHART"
 


### PR DESCRIPTION
Should fix https://github.com/teutonet/teutonet-helm-charts/actions/runs/4817708418/jobs/8578769369?pr=320