### PR TITLE
fix(base-cluster/ingress): change "kind" of default

### DIFF
--- a/charts/base-cluster/templates/ingress/nginx.yaml
+++ b/charts/base-cluster/templates/ingress/nginx.yaml
@@ -16,8 +16,7 @@ spec:
   {{- end }}
   values:
     controller:
-      ingressClassResource:
-        default: true
+      watchIngressWithoutClass: true
       metrics:
         enabled: {{ .Values.monitoring.prometheus.enabled }}
         serviceMonitor:


### PR DESCRIPTION
the `ingressClassResource.default` only "configures" a mutatingwebhook that sets the `.spec.ingressClassName` on new ingresses, whereas the `watchIngressWithoutClass` makes nginx just watch ingresses without a defined IngressClass.

The first one only works if the IngressClass exists before the ingress does, while the second works with all ingresses, whenever they are created and leaves more flexibility to the user to swap the ingress without having to change all ingresses

Closes #375