### PR TITLE
fix(renovate): use https:// URL for oci instead of oci://

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,12 +24,13 @@
     {
       "fileMatch": ["(^|/)values\\.yaml$"],
       "matchStrings": [
-        " {4}\\S+:\\n {6}url: (?<registryUrl>oci://\\S+)\\n {6}charts:(?:\\s+\\S+: [0-9.x]+\\s)+",
+        " {4}\\S+:\\n {6}url: oci://(?<ociUrl>\\S+)\\n {6}charts:(?:\\s+\\S+: [0-9.x]+\\s)+",
         " {8}(?<depName>\\S+): (?<currentValue>\\S+)\\s"
       ],
       "matchStringsStrategy": "recursive",
       "versioningTemplate": "helm",
-      "datasourceTemplate": "docker"
+      "datasourceTemplate": "docker",
+      "registryUrlTemplate": "https://{{{ociUrl}}}"
     }
   ]
 }


### PR DESCRIPTION
This should fix https://app.renovatebot.com/dashboard#github/teutonet/teutonet-helm-charts/1080333285