### PR TITLE
fix(t8s-cluster/clusterClass): fix redundant rolling of machines

### DIFF
--- a/charts/t8s-cluster/templates/management-cluster/clusterClass/_helpers.tpl
+++ b/charts/t8s-cluster/templates/management-cluster/clusterClass/_helpers.tpl
@@ -6,10 +6,6 @@ infrastructure.cluster.x-k8s.io/v1alpha6
 openstack
 {{- end -}}
 
-{{- define "t8s-cluster.clusterClass.imageVersion" -}}
-  {{- printf "t8s-engine-2004-kube-%s" (include "t8s-cluster.k8s-version" $) -}}
-{{- end -}}
-
 {{- define "t8s-cluster.clusterClass.getIdentityRefSecretName" -}}
   {{- printf "cloud-config-%s" .Release.Name -}}
 {{- end -}}

--- a/charts/t8s-cluster/templates/management-cluster/clusterClass/clusterClass.yaml
+++ b/charts/t8s-cluster/templates/management-cluster/clusterClass/clusterClass.yaml
@@ -103,6 +103,31 @@ spec:
                 names: {{- .Values.workers | keys | sortAlpha | toYaml | nindent 18 }}
       description: Sets the ServerGroupID for MachineDeployment machines.
       name: machineDeploymentServerGroupID
+    - definitions:
+        - jsonPatches:
+            - op: add
+              path: /spec/template/spec/image
+              valueFrom:
+                template: {{ .Values.imageNameTemplate.workers }}
+          selector:
+            apiVersion: {{ include "t8s-cluster.clusterClass.infrastructureApiVersion" $ }}
+            kind: OpenStackMachineTemplate
+            matchResources:
+              machineDeploymentClass:
+                names: {{- .Values.workers | keys | sortAlpha | toYaml | nindent 18 }}
+        - jsonPatches:
+            - op: add
+              path: /spec/template/spec/image
+              valueFrom:
+                template: {{ .Values.imageNameTemplate.controlPlane }}
+          selector:
+            apiVersion: {{ include "t8s-cluster.clusterClass.infrastructureApiVersion" $ }}
+            kind: OpenStackMachineTemplate
+            matchResources:
+              controlPlane: true
+
+      description: Sets the image version for machines.
+      name: imageVersion
     - name: controlPlaneAvailabilityZones
       enabledIf: {{ `{{ if .controlPlaneAvailabilityZones }}true{{ end }}` | quote }}
       definitions:

--- a/charts/t8s-cluster/templates/management-cluster/clusterClass/openStackMachineTemplates/_openstackMachineTemplateSpec.yaml
+++ b/charts/t8s-cluster/templates/management-cluster/clusterClass/openStackMachineTemplates/_openstackMachineTemplateSpec.yaml
@@ -9,7 +9,6 @@ flavor: {{ .machineDeploymentClass.flavor }}
 identityRef:
   name: {{ include "t8s-cluster.clusterClass.getIdentityRefSecretName" .context }}
   kind: Secret
-image: {{ include "t8s-cluster.clusterClass.imageVersion" .context }} # artifacthub-ignore
 securityGroups: {{- include "t8s-cluster.clusterClass.securityGroups" .machineDeploymentClass | nindent 2 }}
   {{- with .Values.sshKeyName }}
 sshKeyName: {{ . }}

--- a/charts/t8s-cluster/values.schema.json
+++ b/charts/t8s-cluster/values.schema.json
@@ -217,6 +217,22 @@
         "calico"
       ]
     },
+    "imageNameTemplate": {
+      "type": "object",
+      "properties": {
+        "workers": {
+          "type": "string"
+        },
+        "controlPlane": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "workers",
+        "controlPlane"
+      ],
+      "additionalItems": false
+    },
     "common": {
       "type": "object",
       "description": "Values for sub-chart"

--- a/charts/t8s-cluster/values.yaml
+++ b/charts/t8s-cluster/values.yaml
@@ -48,3 +48,7 @@ containerRegistryProxy:
 sshKeyName: null
 
 cni: cilium
+
+imageNameTemplate:
+  workers: t8s-engine-2004-kube-{{ .builtin.machineDeployment.version }}
+  controlPlane: t8s-engine-2004-kube-{{ .builtin.controlPlane.version }}


### PR DESCRIPTION
Changing the openStackMachineTemplates resulted in a rolling of the machines in the old version and then again in the new version.

As now the openStackMachineTemplates are not touched this doesn't happen anymore.