### PR TITLE
fix(t8s-cluster/management-cluster): fix kubelet configuration

### DIFF
--- a/charts/t8s-cluster/templates/management-cluster/clusterClass/kubeadmConfigTemplate/kubeadmConfigTemplate.yaml
+++ b/charts/t8s-cluster/templates/management-cluster/clusterClass/kubeadmConfigTemplate/kubeadmConfigTemplate.yaml
@@ -11,7 +11,9 @@ spec:
         nodeRegistration:
           kubeletExtraArgs: {{- include "t8s-cluster.clusterClass.kubeletExtraArgs" $ | nindent 12 }}
           name: '{{ `{{ local_hostname }}` }}'
-      files:
+        patches:
+          directory: /etc/kubernetes/patches
+      files: {{- include "t8s-cluster.patches.kubelet.patches" . | nindent 8 }}
         {{- if .Values.containerRegistryProxy.proxyRegistryEndpoint }}
         - content: |- {{- include "t8s-cluster.clusterClass.containerRegistryProxies" (dict "context" $) | nindent 12 }}
           path: /etc/containerd/conf.d/teuto-mirror.toml
@@ -24,3 +26,4 @@ spec:
       preKubeadmCommands:
         - update-ca-certificates
       {{- end }}
+      postKubeadmCommands: {{- include "t8s-cluster.clusterClass.postKubeadmCommands" (dict) | nindent 8 }}

--- a/charts/t8s-cluster/templates/management-cluster/clusterClass/kubeadmnControlPlaneTemplate/_kubeadmControlPlaneTemplateSpec.yaml
+++ b/charts/t8s-cluster/templates/management-cluster/clusterClass/kubeadmnControlPlaneTemplate/_kubeadmControlPlaneTemplateSpec.yaml
@@ -36,7 +36,7 @@ clusterConfiguration:
       authorization-always-allow-paths: /healthz,/readyz,/livez,/metrics
       bind-address: 0.0.0.0
       profiling: 'false'
-files:
+files: {{- include "t8s-cluster.patches.kubelet.patches" . | nindent 2 }}
   - content: |- {{- .Files.Get "files/admission-control-config.yaml" | nindent 6 }}
     path: *admissionControlConfigFilePath
   - content: |- {{- .Files.Get "files/event-rate-limit-config.yaml" | nindent 6 }}
@@ -58,9 +58,14 @@ initConfiguration:
   nodeRegistration:
     kubeletExtraArgs: {{- include "t8s-cluster.clusterClass.kubeletExtraArgs" $ | nindent 6 }}
     name: '{{ `{{ local_hostname }}` }}'
+  patches:
+    directory: {{ include "t8s-cluster.patches.directory" (dict) }}
 joinConfiguration:
   nodeRegistration:
     kubeletExtraArgs: {{- include "t8s-cluster.clusterClass.kubeletExtraArgs" $ | nindent 6 }}
     name: '{{ `{{ local_hostname }}` }}'
-preKubeadmCommands: {{- include "t8s-cluster.clusterClass.preKudeadmCommands" $ | nindent 2 }}
+  patches:
+    directory: {{ include "t8s-cluster.patches.directory" (dict) }}
+preKubeadmCommands: {{- include "t8s-cluster.clusterClass.preKubeadmCommands" $ | nindent 2 }}
+postKubeadmCommands: {{- include "t8s-cluster.clusterClass.postKubeadmCommands" (dict) | nindent 2 }}
 {{- end -}}

--- a/charts/t8s-cluster/templates/management-cluster/clusterClass/patches/_kubelet.tpl
+++ b/charts/t8s-cluster/templates/management-cluster/clusterClass/patches/_kubelet.tpl
@@ -1,0 +1,21 @@
+{{- define "t8s-cluster.patches.kubelet.imagePulls" -}}
+  {{- include "t8s-cluster.patches.patchFile" (dict "values" (dict "serializeImagePulls" false "maxParallelImagePulls" .Values.global.kubeletExtraConfig.maxParallelImagePulls) "target" "kubeletconfiguration" "component" "imagePulls") -}}
+{{- end -}}
+
+{{- define "t8s-cluster.patches.kubelet.default" -}}
+  {{- $values := dict -}}
+  {{- $values = set $values "eventRecordQPS" 0 -}}
+  {{- $values = set $values "protectKernelDefaults" true -}}
+  {{- $values = set $values "featureGates" (dict "SeccompDefault" true) -}}
+  {{- $values = set $values "SeccompDefault" true -}}
+  {{- $values = set $values "tlsCipherSuites" (include "t8s-cluster.clusterClass.tlsCipherSuites" (dict) | splitList ",") -}}
+  {{- include "t8s-cluster.patches.patchFile" (dict "values" $values "target" "kubeletconfiguration" "component" "default") -}}
+{{- end -}}
+
+{{- define "t8s-cluster.patches.kubelet.patches" -}}
+  {{- $patches := list (include "t8s-cluster.patches.kubelet.default" . | fromYaml) -}}
+  {{- if and (eq (int .Values.version.major) 1) (ge (int .Values.version.minor) 27) (gt (int .Values.global.kubeletExtraConfig.maxParallelImagePulls) 1) -}}
+    {{- $patches = append $patches (include "t8s-cluster.patches.kubelet.imagePulls" . | fromYaml) -}}
+  {{- end }}
+  {{- $patches | toYaml -}}
+{{- end -}}

--- a/charts/t8s-cluster/templates/management-cluster/clusterClass/patches/_patches.tpl
+++ b/charts/t8s-cluster/templates/management-cluster/clusterClass/patches/_patches.tpl
@@ -1,0 +1,8 @@
+{{- define "t8s-cluster.patches.patchFile" -}}
+content: |- {{- .values | toYaml | nindent 2 }}
+path: {{ printf "%s/%s-%s.yaml" (include "t8s-cluster.patches.directory" (dict)) .target .component }}
+{{- end -}}
+
+{{- define "t8s-cluster.patches.directory" -}}
+/etc/kubernetes/patches
+{{- end -}}


### PR DESCRIPTION
The kubelet doesn't have that flag, it has to be configured via the config file.

While doing this I also switched from flags to config file for the other variables, as they are also deprecated.

---

feat(t8s-cluster/management-cluster): ease troubleshooting by printing the kubelet journal on error