### PR TITLE
feat(t8s-cluster/management-cluster): adjust machineHealthCheck

### DIFF
--- a/charts/t8s-cluster/templates/management-cluster/clusterClass/clusterClass.yaml
+++ b/charts/t8s-cluster/templates/management-cluster/clusterClass/clusterClass.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   controlPlane:
     machineHealthCheck:
-      maxUnhealthy: 33%
+      maxUnhealthy: 1
       nodeStartupTimeout: 10m
       unhealthyConditions:
         - status: Unknown
@@ -133,7 +133,6 @@ spec:
       {{- range $name, $machineDeploymentClass := .Values.workers }}
       - class: {{ $name }}
         machineHealthCheck:
-          maxUnhealthy: 50%
           nodeStartupTimeout: 8m
           unhealthyConditions:
             - status: Unknown


### PR DESCRIPTION
If during initial cluster creation problems occur, the controlPlane won't be fixed, as `1/2` => `50%` of nodes are unhealthy.

`33%` of a healthy controlPlane are `1`, so changing this value /essentially/ doesn't change anything except in the case of a new cluster.

The same goes for the machineDeployments, in the initial startup phase nothing gets fixed, as the percentage is always hit. And as machineDeployments aren't as critical as the controlPlane we can just recycle broken nodes whenever.