### PR TITLE
feat(t8s-cluster/management-cluster): cleanup for uninstallation

### DIFF
--- a/charts/t8s-cluster/templates/management-cluster/uninstall.yaml
+++ b/charts/t8s-cluster/templates/management-cluster/uninstall.yaml
@@ -1,0 +1,109 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-uninstall-cleanup
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/part-of: uninstall-cleanup
+  annotations:
+    helm.sh/hook: pre-delete,post-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsGroup: 1000
+        runAsUser: 1000
+        fsGroup: 1000
+      serviceAccountName: {{ .Release.Name }}-uninstall-cleanup
+      enableServiceLinks: false
+      containers:
+        - name: uninstall-cleanup
+          image: {{ include "common.images.image" (dict "imageRoot" .Values.global.kubectl.image "global" .Values.global) }}
+          {{- if .Values.global.kubectl.image.digest }}
+          imagePullPolicy: IfNotPresent
+          {{- else }}
+          imagePullPolicy: Always
+          {{- end }}
+          securityContext:
+            readOnlyRootFilesystem: true
+            privileged: false
+            capabilities:
+              drop:
+                - ALL
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: RELEASE_NAME
+              value: {{ .Release.Name }}
+          command:
+            - bash
+            - -ex
+            - -c
+            - |-
+              set -o pipefail
+              for type in kustomization helmrelease; do
+                kubectl -n $NAMESPACE get $type -l app.kubernetes.io/instance=$RELEASE_NAME -o name |
+                  xargs -r -IRESOURCE kubectl -n $NAMESPACE patch RESOURCE --patch '{"metadata":{"finalizers":[]}}' --type merge
+              done
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-uninstall-cleanup
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/part-of: uninstall-cleanup
+  annotations:
+    helm.sh/hook: pre-delete,post-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-uninstall-cleanup
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/part-of: uninstall-cleanup
+  annotations:
+    helm.sh/hook: pre-delete,post-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - verbs: &verbs
+      - get
+      - patch
+      - list
+    resources:
+      - helmreleases
+    apiGroups:
+      - helm.toolkit.fluxcd.io
+  - verbs: *verbs
+    resources:
+      - kustomizations
+    apiGroups:
+      - kustomize.toolkit.fluxcd.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-uninstall-cleanup
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/part-of: uninstall-cleanup
+  annotations:
+    helm.sh/hook: pre-delete,post-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-uninstall-cleanup
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-uninstall-cleanup


### PR DESCRIPTION
The HelmReleases might be leftover if flux isn't fast enough to delete them or has errors during the uninstallation. Especially the latter happened quite a lot during testing.