### PR TITLE
feat(t8s-cluster/management-cluster): add friendlyName field instead of cluster name

### DIFF
--- a/charts/t8s-cluster/templates/management-cluster/cluster.yaml
+++ b/charts/t8s-cluster/templates/management-cluster/cluster.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace}}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     t8s.teuto.net/sla: {{ .Values.metadata.serviceLevelAgreement | quote }}
-    t8s.teuto.net/cluster: {{ .Release.Name | trimPrefix (printf "%d-" .Values.metadata.customerID) | quote}}
+    t8s.teuto.net/cluster: {{ .Values.metadata.friendlyName | default (.Release.Name | trimPrefix (printf "%d-" .Values.metadata.customerID)) | quote }}
     t8s.teuto.net/customer-id: {{ required "You need to set the `customerID`" .Values.metadata.customerID | quote }}
     t8s.teuto.net/customer-name: {{ required "You need to set the `customerName`" .Values.metadata.customerName | quote }}
     t8s.teuto.net/internal-name: {{ .Release.Name | quote }}

--- a/charts/t8s-cluster/values.schema.json
+++ b/charts/t8s-cluster/values.schema.json
@@ -79,6 +79,9 @@
         "customerName": {
           "type": "string"
         },
+        "friendlyName": {
+          "type": "string"
+        },
         "supportProjectUrl": {
           "type": "string"
         },

--- a/charts/t8s-cluster/values.yaml
+++ b/charts/t8s-cluster/values.yaml
@@ -26,6 +26,7 @@ metadata:
   configGroupUrl: ""
   gopassName: ""
   remarks: ""
+  friendlyName: ""
 
 controlPlane:
   flavor: standard.2.1905


### PR DESCRIPTION
This is in preparation for our internal teuto-portal -> k8s worker