### PR TITLE
feat(base-cluster/nginx): enable underscores in headers

### DIFF
--- a/charts/base-cluster/templates/ingress/nginx.yaml
+++ b/charts/base-cluster/templates/ingress/nginx.yaml
@@ -26,6 +26,7 @@ spec:
         use-proxy-protocol: "true"
         use-gzip: "true"
         enable-brotli: "true"
+        enable-underscores-in-headers: true
       service:
         annotations:
           loadbalancer.openstack.org/proxy-protocol: "true"


### PR DESCRIPTION
In preparation of the migration of customer clusters this change is needed.