### PR TITLE
feat(ci/renovate): split PRs by project

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,13 +3,15 @@
   "assigneesFromCodeOwners": true,
   "assigneesSampleSize": 1,
   "platformAutomerge": true,
+  "semanticCommitScope": "{{parentDir}}/dependencies",
+  "additionalBranchPrefix": "{{parentDir}}",
+  "separateMinorPatch": true,
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true
     }
   ],
-  "separateMinorPatch": true,
   "regexManagers": [
     {
       "fileMatch": ["(^|/)values\\.yaml$"],

--- a/.github/scripts/validate-and-label-pullrequest.sh
+++ b/.github/scripts/validate-and-label-pullrequest.sh
@@ -13,10 +13,6 @@ if [[ -z "$changed" ]]; then
   exit 0
 fi
 
-if [[ "$PR_TITLE" =~ chore(deps)* ]]; then
-  exit 0
-fi
-
 num_changed=$(wc -l <<<"$changed")
 
 if ((num_changed > 1)); then


### PR DESCRIPTION
this also allows us to better check the PR and also label it

This also makes PRs like https://github.com/teutonet/teutonet-helm-charts/pull/503 work, see failed check