### PR TITLE
feat(t8s-cluster/management-cluster): validate new k8s version before upgrade

### DIFF
--- a/charts/t8s-cluster/templates/management-cluster/check-k8s-version.yaml
+++ b/charts/t8s-cluster/templates/management-cluster/check-k8s-version.yaml
@@ -1,0 +1,49 @@
+{{- $cluster := include (print $.Template.BasePath "/management-cluster/cluster.yaml") . | fromYaml }}
+{{- $existingCluster := lookup $cluster.apiVersion $cluster.kind $cluster.metadata.namespace $cluster.metadata.name }}
+{{/* Should always pass, just doesn't work for local diffs 😥 */}}
+{{- if $existingCluster }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: check-k8s-version
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsGroup: 1000
+        runAsUser: 1000
+        fsGroup: 1000
+      containers:
+        - name: check-k8s-version
+          image: {{ include "common.images.image" (dict "imageRoot" .Values.global.semver.image "global" .Values.global) }}
+          {{- if .Values.global.semver.image.digest }}
+          imagePullPolicy: IfNotPresent
+          {{- else }}
+          imagePullPolicy: Always
+          {{- end }}
+          securityContext:
+            readOnlyRootFilesystem: true
+            privileged: false
+            capabilities:
+              drop:
+                - ALL
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
+          command:
+            - semver
+            - --range
+            - '>={{ $existingCluster.spec.version }}'
+            {{- with .Values.version }}
+            - {{ printf "v%d.%d.%d" (.major | int) (.minor | int) (.patch | int) }}
+            {{- end }}
+{{- end }}

--- a/charts/t8s-cluster/values.schema.json
+++ b/charts/t8s-cluster/values.schema.json
@@ -46,6 +46,16 @@
           },
           "additionalProperties": false
         },
+        "semver": {
+          "type": "object",
+          "description": "Image with `semver` binary",
+          "properties": {
+            "image": {
+              "$ref": "#/$defs/image"
+            }
+          },
+          "additionalProperties": false
+        },
         "injectedCertificateAuthorities": {
           "type": "string"
         },

--- a/charts/t8s-cluster/values.yaml
+++ b/charts/t8s-cluster/values.yaml
@@ -15,6 +15,11 @@ global:
       registry: docker.io
       repository: bitnami/kubectl
       tag: 1.27.4
+  semver:
+    image:
+      registry: docker.io
+      repository: alpine/semver
+      tag: 7.5.4
   injectedCertificateAuthorities: ""
   kubeletExtraConfig:
     # This is only used when using 1.27 or later


### PR DESCRIPTION
Currently the user can (accidentally) downgrade the k8s version, which is of course not supported

This job checks the new version against the running version and fails it is lower