### PR TITLE
fix(ci/renovate): add missing `-`-suffix

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,7 +4,7 @@
   "assigneesSampleSize": 1,
   "platformAutomerge": true,
   "semanticCommitScope": "{{parentDir}}/dependencies",
-  "additionalBranchPrefix": "{{parentDir}}",
+  "additionalBranchPrefix": "{{parentDir}}-",
   "separateMinorPatch": true,
   "packageRules": [
     {


### PR DESCRIPTION
See https://github.com/teutonet/teutonet-helm-charts/pull/507

I somehow thought renovate would join it with a `-`