### PR TITLE
chore(base-cluster): remove pause container image configuration

### DIFF
--- a/charts/base-cluster/templates/_images.tpl
+++ b/charts/base-cluster/templates/_images.tpl
@@ -2,10 +2,6 @@
 {{- include "common.images.image" (dict "imageRoot" .Values.global.kubectl.image "global" .Values.global) -}}
 {{- end -}}
 
-{{- define "base-cluster.pause.image" -}}
-{{- include "common.images.image" (dict "imageRoot" .Values.global.pause.image "global" .Values.global) -}}
-{{- end -}}
-
 {{- define "base-cluster.flux.image" -}}
 {{- include "common.images.image" (dict "imageRoot" .Values.global.flux.image "global" .Values.global) -}}
 {{- end -}}

--- a/charts/base-cluster/values.yaml
+++ b/charts/base-cluster/values.yaml
@@ -56,11 +56,6 @@ global:
       registry: docker.io
       repository: bitnami/kubectl
       tag: 1.27.4
-  pause:
-    image:
-      registry: k8s.gcr.io
-      repository: pause
-      tag: "3.9"
   flux:
     image:
       registry: docker.io


### PR DESCRIPTION
this has been unneeded since https://github.com/teutonet/teutonet-helm-charts/pull/178