### PR TITLE
fix(ci): use current PR's branch

### DIFF
--- a/.github/workflows/validate-and-label-pullrequest.yaml
+++ b/.github/workflows/validate-and-label-pullrequest.yaml
@@ -30,7 +30,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: helm/chart-testing-action@v2.4.0
       - run: .github/scripts/validate-and-label-pullrequest.sh


### PR DESCRIPTION
As we don't have the required checks anymore, this will only ever be executed on the PR and therefore work without having to fall back to the default_branch