### PR TITLE
feat(base-cluster/tracing): simplify tracingConfig

### DIFF
--- a/charts/base-cluster/templates/kyverno/kyverno.yaml
+++ b/charts/base-cluster/templates/kyverno/kyverno.yaml
@@ -43,13 +43,8 @@ spec:
     admissionController: &tracingConfig
       tracing:
         enabled: true
-        address: $(HOST_IP)
+        address: open-telemetry-collector-opentelemetry-collector.monitoring
         port: 14250 # jaeger-grpc
-      extraEnvVars:
-        - name: HOST_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
     backgroundController: *tracingConfig
     cleanupController: *tracingConfig
     reportsController: *tracingConfig


### PR DESCRIPTION
this basically doesn't change anything, as the
open-telemetry-collector-opentelemetry-collector service' internalTrafficPolicy is local anyway