### PR TITLE
feat(t8s-cluster)!: change `proxy` to `mirror`

### DIFF
--- a/charts/t8s-cluster/templates/management-cluster/clusterClass/kubeadmConfigTemplate/_helpers.tpl
+++ b/charts/t8s-cluster/templates/management-cluster/clusterClass/kubeadmConfigTemplate/_helpers.tpl
@@ -2,7 +2,7 @@
 [plugins]
   [plugins."io.containerd.grpc.v1.cri"]
   {{- $_ := set . "Values" .context.Values -}}
-  {{- if .Values.containerRegistryProxy.proxyRegistryEndpoint }}
+  {{- if .Values.containerRegistryMirror.mirrorEndpoint }}
     [plugins."io.containerd.grpc.v1.cri".registry]
       config_path = "/etc/containerd/registries.conf.d"
   {{- end }}
@@ -25,9 +25,9 @@
   {{- end -}}
 {{- end -}}
 
-{{- define "t8s-cluster.clusterClass.containerdConfig.containerRegistryProxyConfigs" -}}
+{{- define "t8s-cluster.clusterClass.containerdConfig.containerRegistryMirrorConfigs" -}}
   {{- $_ := set . "Values" .context.Values -}}
-  {{- $defaultProxiedRegistries := list
+  {{- $defaultMirroredRegistries := list
     "gcr.io"
     "ghcr.io"
     "k8s.gcr.io"
@@ -38,22 +38,22 @@
     "registry.opensource.zalan.do"
     "registry.teuto.io"
     -}}
-  {{- $proxiedRegistries := concat $defaultProxiedRegistries (.Values.containerRegistryProxy.additionallyProxiedRegistries | default list) | sortAlpha | uniq -}}
-  {{- range $registry := $proxiedRegistries }}
+  {{- $mirroredRegistries := concat $defaultMirroredRegistries (.Values.containerRegistryMirror.additionallyMirroredRegistries | default list) | sortAlpha | uniq -}}
+  {{- range $registry := $mirroredRegistries }}
 - content: |-
     server = {{ printf "https://%s" $registry | quote }}
-    {{ printf `[host."%s"]` $.Values.containerRegistryProxy.proxyRegistryEndpoint }}
+    {{ printf `[host."%s"]` $.Values.containerRegistryMirror.mirrorEndpoint }}
       capabilities = ["pull", "resolve"]
   path: {{ printf `/etc/containerd/registries.conf.d/%s/hosts.toml` $registry }}
   {{- end }}
 - content: |-
     server = "registry-1.docker.io"
-    {{ printf `[host."%s"]` $.Values.containerRegistryProxy.proxyRegistryEndpoint }}
+    {{ printf `[host."%s"]` $.Values.containerRegistryMirror.mirrorEndpoint }}
       capabilities = ["pull", "resolve"]
   path: /etc/containerd/registries.conf.d/docker.io/hosts.toml
 - content: |- # this only works with containerd >=1.7.0, that's why the above still exists
     server = "*"
-    {{ printf `[host."%s"]` $.Values.containerRegistryProxy.proxyRegistryEndpoint }}
+    {{ printf `[host."%s"]` $.Values.containerRegistryMirror.mirrorEndpoint }}
       capabilities = ["pull", "resolve"]
   path: /etc/containerd/registries.conf.d/_default/hosts.toml
 {{- end -}}

--- a/charts/t8s-cluster/templates/management-cluster/clusterClass/kubeadmConfigTemplate/_kubeadmConfigTemplateSpec.yaml
+++ b/charts/t8s-cluster/templates/management-cluster/clusterClass/kubeadmConfigTemplate/_kubeadmConfigTemplateSpec.yaml
@@ -7,8 +7,8 @@ joinConfiguration:
   patches:
     directory: /etc/kubernetes/patches
 files: {{- include "t8s-cluster.patches.kubelet.patches" .context | nindent 2 }}
-    {{- if .Values.containerRegistryProxy.proxyRegistryEndpoint }}
-      {{- include "t8s-cluster.clusterClass.containerdConfig.containerRegistryProxyConfigs" (dict "context" .context) | nindent 2 }}
+    {{- if .Values.containerRegistryMirror.mirrorEndpoint }}
+      {{- include "t8s-cluster.clusterClass.containerdConfig.containerRegistryMirrorConfigs" (dict "context" .context) | nindent 2 }}
     {{- end }}
   - content: |- {{- include "t8s-cluster.clusterClass.containerdConfig.plugins" (dict "context" .context "gpu" .gpu) | nindent 6 }}
     path: /etc/containerd/conf.d/plugins.toml

--- a/charts/t8s-cluster/templates/management-cluster/clusterClass/kubeadmnControlPlaneTemplate/_kubeadmControlPlaneTemplateSpec.yaml
+++ b/charts/t8s-cluster/templates/management-cluster/clusterClass/kubeadmnControlPlaneTemplate/_kubeadmControlPlaneTemplateSpec.yaml
@@ -46,8 +46,8 @@ files: {{- include "t8s-cluster.patches.kubelet.patches" $ | nindent 2 }}
     permissions: "0700"
   - content: |- {{- .Files.Get "files/kube-proxy.config.yaml" | nindent 6 }}
     path: /etc/kube-proxy-config.yaml
-  {{- if .Values.containerRegistryProxy.proxyRegistryEndpoint }}
-    {{- include "t8s-cluster.clusterClass.containerdConfig.containerRegistryProxyConfigs" (dict "context" $) | nindent 2 }}
+  {{- if .Values.containerRegistryMirror.mirrorEndpoint }}
+    {{- include "t8s-cluster.clusterClass.containerdConfig.containerRegistryMirrorConfigs" (dict "context" $) | nindent 2 }}
   {{- end }}
   - content: |- {{- include "t8s-cluster.clusterClass.containerdConfig.plugins" (dict "context" $ "gpu" false) | nindent 6 }}
     path: /etc/containerd/conf.d/plugins.toml

--- a/charts/t8s-cluster/values.schema.json
+++ b/charts/t8s-cluster/values.schema.json
@@ -216,16 +216,16 @@
       },
       "additionalProperties": false
     },
-    "containerRegistryProxy": {
+    "containerRegistryMirror": {
       "type": "object",
       "properties": {
-        "additionallyProxiedRegistries": {
+        "additionallyMirroredRegistries": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "proxyRegistryEndpoint": {
+        "mirrorEndpoint": {
           "type": "string"
         }
       },

--- a/charts/t8s-cluster/values.yaml
+++ b/charts/t8s-cluster/values.yaml
@@ -60,9 +60,9 @@ bastion:
   availabilityZone: null
   sshKeyName: null
 
-containerRegistryProxy:
-  additionallyProxiedRegistries: []
-  proxyRegistryEndpoint: https://mirror.teuto.net
+containerRegistryMirror:
+  additionallyMirroredRegistries: []
+  mirrorEndpoint: https://mirror.teuto.net
 
 sshKeyName: null
 


### PR DESCRIPTION
As now we're not really proxying anymore, we're just mirroring.

This means that the nodes are allowed to pull directly from upstream if something is wrong with the mirror.