### PR TITLE
feat(t8s-cluster/workload-cluster): add a higher timeout for upgrading

### DIFF
--- a/charts/t8s-cluster/templates/workload-cluster/cinder-csi-plugin.yaml
+++ b/charts/t8s-cluster/templates/workload-cluster/cinder-csi-plugin.yaml
@@ -25,6 +25,8 @@ spec:
   install:
     remediation:
       retries: -1
+  upgrade:
+    timeout: 5m
   storageNamespace: kube-system
   targetNamespace: kube-system
   releaseName: csi

--- a/charts/t8s-cluster/templates/workload-cluster/cloud-controller-manager.yaml
+++ b/charts/t8s-cluster/templates/workload-cluster/cloud-controller-manager.yaml
@@ -25,6 +25,8 @@ spec:
   install:
     remediation:
       retries: -1
+  upgrade:
+    timeout: 5m
   storageNamespace: kube-system
   targetNamespace: kube-system
   releaseName: ccm

--- a/charts/t8s-cluster/templates/workload-cluster/cni-cilium.yaml
+++ b/charts/t8s-cluster/templates/workload-cluster/cni-cilium.yaml
@@ -15,6 +15,8 @@ spec:
   install:
     remediation:
       retries: -1
+  upgrade:
+    timeout: 5m
   storageNamespace: kube-system
   targetNamespace: kube-system
   releaseName: cni

--- a/charts/t8s-cluster/templates/workload-cluster/gpu-operator.yaml
+++ b/charts/t8s-cluster/templates/workload-cluster/gpu-operator.yaml
@@ -15,6 +15,8 @@ spec:
   install:
     remediation:
       retries: -1
+  upgrade:
+    timeout: 5m
   storageNamespace: kube-system
   targetNamespace: kube-system
   releaseName: gpu-operator


### PR DESCRIPTION
during cluster upgrades the rolling nodes can lead to `upgrade retries exhausted` because the daemonsets can't roll quick enough