### PR TITLE
feat(t8s-cluster/management-cluster): make field availabilityZone optional

### DIFF
--- a/charts/t8s-cluster/templates/management-cluster/cluster.yaml
+++ b/charts/t8s-cluster/templates/management-cluster/cluster.yaml
@@ -30,7 +30,9 @@ spec:
   clusterClass: {{ $.Release.Name }}
   workers: {{- range $name, $machineDeploymentClass := .Values.workers }}
     {{ $name -}}:
+      {{- if $machineDeploymentClass.availabilityZone }}
       availabilityZone: {{ $machineDeploymentClass.availabilityZone | quote }}
+      {{- end }}
       flavor: {{ $machineDeploymentClass.flavor | quote }}
       replicas: {{ $machineDeploymentClass.replicas }}
   {{- end }}

--- a/charts/t8s-cluster/templates/management-cluster/clusterClass/_helpers.tpl
+++ b/charts/t8s-cluster/templates/management-cluster/clusterClass/_helpers.tpl
@@ -1,5 +1,5 @@
 {{- define "t8s-cluster.clusterClass.infrastructureApiVersion" -}}
-infrastructure.cluster.x-k8s.io/v1alpha6
+infrastructure.cluster.x-k8s.io/v1alpha7
 {{- end -}}
 
 {{- define "t8s-cluster.clusterClass.cloudName" -}}

--- a/charts/t8s-cluster/templates/management-cluster/clusterClass/openStackClusterTemplate/openStackClusterTemplate.yaml
+++ b/charts/t8s-cluster/templates/management-cluster/clusterClass/openStackClusterTemplate/openStackClusterTemplate.yaml
@@ -1,5 +1,5 @@
 {{- if false }}
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha7
 {{- else }}
 apiVersion: {{ include "t8s-cluster.clusterClass.infrastructureApiVersion" $ }}
 {{- end }}

--- a/charts/t8s-cluster/templates/management-cluster/clusterClass/openStackMachineTemplates/openStackMachineTemplates.yaml
+++ b/charts/t8s-cluster/templates/management-cluster/clusterClass/openStackMachineTemplates/openStackMachineTemplates.yaml
@@ -1,6 +1,6 @@
 {{- range $name, $machineDeploymentClass := (merge (deepCopy .Values.workers) (dict "control-plane" .Values.controlPlane)) }}
 {{- if false }}
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha7
 {{- else }}
 apiVersion: {{ include "t8s-cluster.clusterClass.infrastructureApiVersion" $ }}
 {{- end }}

--- a/charts/t8s-cluster/values.schema.json
+++ b/charts/t8s-cluster/values.schema.json
@@ -190,7 +190,6 @@
         "additionalProperties": false,
         "required": [
           "replicas",
-          "availabilityZone",
           "flavor"
         ]
       }


### PR DESCRIPTION
This allows [OpenStack to distribute it better](https://gitlab.teuto.net/4teuto/ops/k8s/t8s-engine/-/issues/9#note_122490) 

And more often than not the user doesn't care about the availabilityZone anyways

Depends on https://gitlab.teuto.net/4teuto/ops/k8s/t8s-engine/-/merge_requests/659