### PR TITLE
fix(base-cluster/kyverno): fix excluded namespaces

### DIFF
--- a/charts/base-cluster/templates/kyverno/kyverno.yaml
+++ b/charts/base-cluster/templates/kyverno/kyverno.yaml
@@ -83,10 +83,11 @@ spec:
     # This only works in clusters >=1.22 because it relies on the
     # kubernetes.io/metadata.name label on namespaces, which is active by
     # default since 1.22.
-    webhooks:
-      - namespaceSelector:
-          matchExpressions:
-            - key: kubernetes.io/metadata.name
-              operator: NotIn
-              values: {{- include "base-cluster.kyverno.ignoredNamespaces" . | nindent 18 }}
+    config:
+      webhooks:
+        - namespaceSelector:
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values: {{- include "base-cluster.kyverno.ignoredNamespaces" . | nindent 18 }}
 {{- end }}


### PR DESCRIPTION
Kyverno decided to add a key before the excluded namespaces..