### PR TITLE
fix(ci/artifacthub-images): skip charts without artifacthub-values.yaml

### DIFF
--- a/.github/workflows/update-artifacthub-images.yaml
+++ b/.github/workflows/update-artifacthub-images.yaml
@@ -21,7 +21,7 @@ jobs:
           (
             echo -n charts=
             for chart in charts/*; do
-              if [[ "$chart" != "charts/*" ]]; then
+              if [[ "$chart" != "charts/*" ]] && [[ -f "$chart/ci/artifacthub-values.yaml" ]]; then
                 echo "$chart"
               fi
             done | cut -d / -f 2 | jq -c -Rn '[inputs]'


### PR DESCRIPTION
This allows the teuto-portal-k8s-worker to not be scanned, as it won't be deployed publicly anyways