### PR TITLE
feat(t8s-cluster/cinder-csi-plugin): allow to run on control-plane

### DIFF
--- a/charts/t8s-cluster/templates/workload-cluster/cinder-csi-plugin.yaml
+++ b/charts/t8s-cluster/templates/workload-cluster/cinder-csi-plugin.yaml
@@ -37,3 +37,9 @@ spec:
     secret:
       enabled: true
       name: cloud-config
+    csi:
+      plugin:
+        controllerPlugin:
+          tolerations:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/control-plane


### PR DESCRIPTION
Sometimes the compute-plane might not be available