### PR TITLE
fix(base-cluster/oauth-proxy): use correct secretName for certificate

### DIFF
--- a/charts/base-cluster/templates/monitoring/kube-prometheus-stack/oauth-proxy.yaml
+++ b/charts/base-cluster/templates/monitoring/kube-prometheus-stack/oauth-proxy.yaml
@@ -10,6 +10,7 @@
   {{- $host := $backend.host -}}
   {{- $port := $backend.port -}}
   {{- $targetServiceName := printf "%s-%s" (include "common.names.dependency.fullname" (dict "chartName" "kube-prometheus-stack" "chartValues" (dict) "context" (dict "Release" (dict "Name" "kube-prometheus-stack")))) $host -}}
+  {{- $ingress := include "base-cluster.monitoring.ingress.config" (dict "name" $host "context" $) | fromYaml -}}
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
@@ -35,7 +36,7 @@ spec:
       extraTls: |-
         - hosts:
           - {{ "{{ .Values.ingress.hostname }}" }}
-          secretName: cluster-wildcard-certificate
+          secretName: {{ include "base-cluster.certificate" (dict "name" $host "customDomain" $ingress.customDomain "context" $) }}
     replicaCount: 2
     pdb:
       create: true


### PR DESCRIPTION
especially if no wildcard certificate is available