### PR TITLE
feat(t8s-cluster)!: migrate to new image names

### DIFF
--- a/charts/t8s-cluster/values.yaml
+++ b/charts/t8s-cluster/values.yaml
@@ -70,5 +70,5 @@ sshKeyName: null
 cni: cilium
 
 imageNameTemplate:
-  computePlane: t8s-engine-2004-kube-{{ .builtin.machineDeployment.version }}
-  controlPlane: t8s-engine-2004-kube-{{ .builtin.controlPlane.version }}
+  computePlane: t8s-engine-{{ .builtin.machineDeployment.version }}
+  controlPlane: t8s-engine-{{ .builtin.controlPlane.version }}


### PR DESCRIPTION
This is only compatible with the new t8s-engine operator