### PR TITLE
feat(t8s-cluster/management-cluster)!: migrate to new secret naming

### DIFF
--- a/charts/t8s-cluster/templates/management-cluster/clusterClass/_helpers.tpl
+++ b/charts/t8s-cluster/templates/management-cluster/clusterClass/_helpers.tpl
@@ -8,7 +8,7 @@ openstack
 
 {{- define "t8s-cluster.clusterClass.getIdentityRefSecretName" -}}
   {{- $_ := set . "Release" .context.Release -}}
-  {{- printf "cloud-config-%s" .Release.Name -}}
+  {{- printf "%s-cloud-config" .Release.Name -}}
 {{- end -}}
 
 {{- define "t8s-cluster.clusterClass.tlsCipherSuites" -}}


### PR DESCRIPTION
requires t8s-engine v2.0.0