### PR TITLE
fix(base-cluster/metrics-server): remove mount, as it's fixed via chart

### DIFF
--- a/charts/base-cluster/templates/monitoring/metrics-server/metrics-server.yaml
+++ b/charts/base-cluster/templates/monitoring/metrics-server/metrics-server.yaml
@@ -42,11 +42,4 @@ spec:
       - --kubelet-preferred-address-types=InternalIP
       - --kubelet-insecure-tls=true
       - --cert-dir=/tmp
-    extraVolumeMounts:
-      - mountPath: /tmp
-        name: tmpdir
-    extraVolumes:
-      - emptyDir:
-          sizeLimit: 32Mi
-        name: tmpdir
   {{- end -}}


### PR DESCRIPTION
bitnami added the mounts in the chart.

See: https://github.com/bitnami/charts/commit/ed5f202f815cedcba8be48fb5625740e2f309079#diff-a2153e7977c449270b42f938ff99c46858cc203858d4c367f82a1d5b61d74727R149