### PR TITLE
fix(ci/artifacthub-images): the artifacthub-ignore comments get lost,

### DIFF
--- a/.github/scripts/create-values-diff.sh
+++ b/.github/scripts/create-values-diff.sh
@@ -39,8 +39,9 @@ GITHUB_WORKSPACE="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel)}"
 GITHUB_DEFAULT_BRANCH="${GITHUB_DEFAULT_BRANCH:-main}"
 GITHUB_SERVER_URL="${GITHUB_SERVER_URL:-https://github.com}"
 GITHUB_REPO_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
-TMP_DIR="$(mktemp -d)"
-trap 'rm -rf "$TMP_DIR"' EXIT
+
+[[ ! -v TMP_DIR ]] && trap 'rm -rf "$TMP_DIR"' EXIT
+TMP_DIR="${TMP_DIR:-$(mktemp -d)}"
 
 cd "$GITHUB_WORKSPACE"
 

--- a/.github/scripts/extract-artifacthub-images.sh
+++ b/.github/scripts/extract-artifacthub-images.sh
@@ -36,7 +36,7 @@ function getImages() {
   (
     cd "$tmpDir/helmRelease"
     rm -f -- */HelmRelease/*.yaml
-    grep -Er '\s+image: \S+' |
+    grep -Er '\s+image: \S+$' |
       grep -v 'artifacthub-ignore' |
       awk '{print $3 " # " $1}' |
       tr -d '"' |

--- a/.github/scripts/extract-artifacthub-images.sh
+++ b/.github/scripts/extract-artifacthub-images.sh
@@ -6,8 +6,8 @@
 set -eu
 set -o pipefail
 
-TMP_DIR=$(mktemp -d)
-trap 'rm -rf "$TMP_DIR"' EXIT
+[[ ! -v TMP_DIR ]] && trap 'rm -rf "$TMP_DIR"' EXIT
+TMP_DIR="${TMP_DIR:-$(mktemp -d)}"
 
 function templateHelmChart() {
   local chart="$1"

--- a/.github/scripts/templateHelmChart.sh
+++ b/.github/scripts/templateHelmChart.sh
@@ -6,8 +6,8 @@
 set -eu
 set -o pipefail
 
-TMP_DIR="$(mktemp -d)"
-trap 'rm -rf "$TMP_DIR"' EXIT
+[[ ! -v TMP_DIR ]] && trap 'rm -rf "$TMP_DIR"' EXIT
+TMP_DIR="${TMP_DIR:-$(mktemp -d)}"
 
 function templateGitHelmRelease() {
   local gitUrl="$1"

--- a/.github/workflows/release-update-metadata.yaml
+++ b/.github/workflows/release-update-metadata.yaml
@@ -29,11 +29,9 @@ jobs:
         run: sudo apt-get -yq install moreutils
 
       - run: ./.github/scripts/prepare-values.sh "charts/$CHART"
-      - name: extract images
-        run: ./.github/scripts/extract-artifacthub-images.sh "charts/$CHART"
+      - run: ./.github/scripts/extract-artifacthub-images.sh "charts/$CHART"
 
-      - name: enforce trusted registries
-        run: ./.github/scripts/enforce-trusted-registries.sh "charts/$CHART"
+      - run: ./.github/scripts/enforce-trusted-registries.sh "charts/$CHART"
 
       - name: Commit artifacthub images
         uses: EndBug/add-and-commit@v9


### PR DESCRIPTION
therefore the developer should just override the image via the artifacthub-values.yaml to `artifacthub-ignore`

This also forces the detected images to end the line, which conveniently throws out the `charts/t8s-cluster/templates/management-cluster/clusterClass/openStackClusterTemplate/_openStackClusterTemplateSpec.yaml` ignored image