### PR TITLE
chore(base-cluster): use tag instead of digest for gpg image

### DIFF
--- a/charts/base-cluster/values.yaml
+++ b/charts/base-cluster/values.yaml
@@ -83,7 +83,7 @@ global:
     image:
       registry: docker.io
       repository: vladgh/gpg
-      digest: sha256:8514acc9c94607895e3dea724bd85d885252666212567f6632d2654580539ed3
+      tag: 1.3.5
   curl:
     image:
       registry: docker.io


### PR DESCRIPTION
that way renovate can detect and update it