### PR TITLE
fix(ci): update release please path

### DIFF
--- a/.github/workflows/create-release-prs.yaml
+++ b/.github/workflows/create-release-prs.yaml
@@ -12,7 +12,7 @@ jobs:
   createReleasePR:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         with:
           skip-github-release: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}

--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -15,7 +15,7 @@ jobs:
       releases_created: ${{ steps.release.outputs.releases_created }}
       paths_released: ${{ steps.release.outputs.paths_released }}
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         id: release
         with:
           skip-github-pull-request: true


### PR DESCRIPTION
now that google has moved the release please repository, the actions are also updated from the deprecated to the upstream repo.

https://github.com/google-github-actions/release-please-action?tab=readme-ov-file