### PR TITLE
fix(base-cluster): set correct label for workinghours

### DIFF
--- a/charts/base-cluster/values.schema.json
+++ b/charts/base-cluster/values.schema.json
@@ -12,7 +12,7 @@
           "enum": [
             "None",
             "24x7",
-            "Working-Hours"
+            "WorkingHours"
           ],
           "default": "None"
         },


### PR DESCRIPTION
There were working-hours alerts at night, which should happen.

The reason seems to be that the label definition in our alertmanager is `WorkingHours` and not `Working-Hours`.