### PR TITLE
revert(ci): "fix(ci): add busybox as trusted image"

### DIFF
--- a/.github/trusted_registries.yaml
+++ b/.github/trusted_registries.yaml
@@ -20,7 +20,6 @@ registries:
     aquasecurity: ALL_IMAGES
     kyverno: ALL_IMAGES
     teutonet: ALL_IMAGES
-    busybox: ALL_TAGS
   quay.io:
     cilium: ALL_IMAGES
     jetstack: ALL_IMAGES


### PR DESCRIPTION
Reverts teutonet/teutonet-helm-charts#994

This image doesn't exist, the correct way to have "fixed" this, would've been to adjust the registry replacement