### PR TITLE
feat(t8s-cluster/workload-cluster): latch onto legacy cni when used

### DIFF
--- a/charts/t8s-cluster/templates/_helpers.tpl
+++ b/charts/t8s-cluster/templates/_helpers.tpl
@@ -14,3 +14,15 @@
   {{- end -}}
   {{- $hasGPUFlavor | ternary true "" -}}
 {{- end -}}
+
+{{- define "t8s-cluster.cni" -}}
+  {{- if eq .Values.cni "auto" -}}
+    {{- if lookup "kustomize.toolkit.fluxcd.io/v1" "Kustomization" .Release.Namespace (printf "%s-cni" .Release.Name) -}}
+      calico
+    {{- else -}}
+      cilium
+    {{- end -}}
+  {{- else -}}
+    {{- .Values.cni -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/t8s-cluster/templates/management-cluster/repositories/cni-calico.yaml
+++ b/charts/t8s-cluster/templates/management-cluster/repositories/cni-calico.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.cni "calico" }}
+{{- if eq (include "t8s-cluster.cni" .) "calico" }}
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:

--- a/charts/t8s-cluster/templates/workload-cluster/cinder-csi-plugin.yaml
+++ b/charts/t8s-cluster/templates/workload-cluster/cinder-csi-plugin.yaml
@@ -16,7 +16,7 @@ spec:
   interval: 1h
   driftDetection:
     mode: enabled
-  {{- if eq .Values.cni "cilium" }}
+  {{- if eq (include "t8s-cluster.cni" .) "cilium" }}
   dependsOn:
     - name: {{ printf "%s-cni" .Release.Name }}
       namespace: {{ .Release.Namespace }}

--- a/charts/t8s-cluster/templates/workload-cluster/cloud-controller-manager.yaml
+++ b/charts/t8s-cluster/templates/workload-cluster/cloud-controller-manager.yaml
@@ -16,7 +16,7 @@ spec:
   interval: 1h
   driftDetection:
     mode: enabled
-  {{- if eq .Values.cni "cilium" }}
+  {{- if eq (include "t8s-cluster.cni" .) "cilium" }}
   dependsOn:
     - name: {{ printf "%s-cni" .Release.Name }}
       namespace: {{ .Release.Namespace }}

--- a/charts/t8s-cluster/templates/workload-cluster/cni-calico.yaml
+++ b/charts/t8s-cluster/templates/workload-cluster/cni-calico.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.cni "calico" }}
+{{- if eq (include "t8s-cluster.cni" .) "calico" }}
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/charts/t8s-cluster/templates/workload-cluster/cni-cilium.yaml
+++ b/charts/t8s-cluster/templates/workload-cluster/cni-cilium.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.cni "cilium" }}
+{{- if eq (include "t8s-cluster.cni" .) "cilium" }}
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/charts/t8s-cluster/templates/workload-cluster/pre-install/uninstall-cni.yaml
+++ b/charts/t8s-cluster/templates/workload-cluster/pre-install/uninstall-cni.yaml
@@ -1,3 +1,3 @@
-{{- if eq .Values.cni "cilium" -}}
+{{- if eq (include "t8s-cluster.cni" .) "cilium" -}}
 {{ include "t8s-cluster.workload.uninstall-job" (dict "name" "cni" "context" . "clusterResourceSet" "cni") }}
 {{- end -}}

--- a/charts/t8s-cluster/values.schema.json
+++ b/charts/t8s-cluster/values.schema.json
@@ -232,8 +232,10 @@
     },
     "cni": {
       "type": "string",
+      "description": "The CNI plugin to use. `auto` means to keep the current one or use cilium for a new cluster.",
       "enum": [
         "cilium",
+        "auto",
         "calico"
       ]
     },

--- a/charts/t8s-cluster/values.yaml
+++ b/charts/t8s-cluster/values.yaml
@@ -66,6 +66,6 @@ containerRegistryMirror:
 
 sshKeyName: null
 
-cni: cilium
+cni: auto
 
 openstackImageNamePrefix: ""


### PR DESCRIPTION
This should allow us to adopt the legacy clusters into our customer portal