### PR TITLE
fix(base-cluster/kdave): image 2.x.x is unsupported by the helm chart

### DIFF
--- a/charts/base-cluster/templates/monitoring/kdave/kdave.yaml
+++ b/charts/base-cluster/templates/monitoring/kdave/kdave.yaml
@@ -24,7 +24,7 @@ spec:
     helmBinary: helm3
     image:
       repository: {{ printf "%s/aelbakry/kdave-server" ($.Values.global.imageRegistry | default (include "base-cluster.defaultRegistry" (dict))) }}
-      tag: 1.0.3
+      tag: 1.0.4
     rbac:
       pspEnabled: false
     apiVersionsInspector:

--- a/charts/base-cluster/templates/monitoring/kdave/kdave.yaml
+++ b/charts/base-cluster/templates/monitoring/kdave/kdave.yaml
@@ -24,7 +24,7 @@ spec:
     helmBinary: helm3
     image:
       repository: {{ printf "%s/aelbakry/kdave-server" ($.Values.global.imageRegistry | default (include "base-cluster.defaultRegistry" (dict))) }}
-      tag: 2.1.5
+      tag: 1.0.3
     rbac:
       pspEnabled: false
     apiVersionsInspector:


### PR DESCRIPTION
The kdave helm chart does not support image version 2.x.x.

So either we use 1.x.x (probably 1.0.3 as it's the default) or we disable kdave alltogether.