### PR TITLE
fix(ci/cve-scanning): override sarif_file location

### DIFF
--- a/.github/workflows/scan-for-cves.yaml
+++ b/.github/workflows/scan-for-cves.yaml
@@ -42,5 +42,7 @@ jobs:
       - run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           ./.github/scripts/generate-sarif-reports.sh ${{ matrix.chart }}
-      - uses: github/codeql-action/upload-sarif@366883a76d75dcee5428da5c3ae7abf9386e35ac # v3
+      - uses: github/codeql-action/upload-sarif@f0f3afee809481da311ca3a6ff1ff51d81dbeb24 # v3
+        with:
+          sarif_file: reports
           # TODO: github dependency tree?


### PR DESCRIPTION
One would imagine that the default would make more sense than being _outside the workfolder_

chore(ci/cve-scanning): update action
