### PR TITLE
fix(ci/cve-scanning): skip uploading if no reports exist

### DIFF
--- a/.github/workflows/scan-for-cves.yaml
+++ b/.github/workflows/scan-for-cves.yaml
@@ -43,6 +43,7 @@ jobs:
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           ./.github/scripts/generate-sarif-reports.sh ${{ matrix.chart }}
       - uses: github/codeql-action/upload-sarif@f0f3afee809481da311ca3a6ff1ff51d81dbeb24 # v3
+        if: ${{ hashFiles('reports/*.json') != '' }}
         with:
           sarif_file: reports
           # TODO: github dependency tree?

--- a/.github/workflows/scan-for-cves.yaml
+++ b/.github/workflows/scan-for-cves.yaml
@@ -31,7 +31,7 @@ jobs:
     permissions:
       security-events: write
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         chart: ${{ fromJson(needs.getAllCharts.outputs.charts) }}
     steps:


### PR DESCRIPTION
upload-sarif action is not smart enough to not throw an error...
