### PR TITLE
chore(ci): improve scripts

### DIFF
--- a/.github/scripts/enforce-trusted-registries.sh
+++ b/.github/scripts/enforce-trusted-registries.sh
@@ -39,12 +39,12 @@ function enforceTrustedImages() {
   fi
 }
 
-if [[ "$#" == 1 ]] && [[ -d "$1" ]]; then
+if [[ "$#" == 1 && -d "$1" ]]; then
   enforceTrustedImages "$1"
 else
   result=0
   for chart in charts/*; do
-    [[ "$chart" == "charts/*" ]] && continue
+    [[ -d "$chart" ]] || continue
 
     if ! enforceTrustedImages "$chart"; then
       result=1

--- a/.github/scripts/extract-artifacthub-images.sh
+++ b/.github/scripts/extract-artifacthub-images.sh
@@ -13,7 +13,7 @@ function getImages() {
   local chart="$1"
   local tmpDir
   tmpDir="$(mktemp -d -p "$TMP_DIR")"
-  if [[ -v 2 ]] && [[ -n "$2" ]]; then
+  if [[ -v 2 && -n "$2" ]]; then
     cp -r "$2/artifacthub-values" "$tmpDir/helmRelease"
   else
     "$(dirname "$0")/templateLocalHelmChart" -1 "$chart" >"$tmpDir/helmRelease.yaml"
@@ -77,14 +77,14 @@ if [[ "$#" -ge 1 ]]; then
     echo "There is no 'artifacthub-values.yaml' in 'charts/$1/ci', exiting" >&2
     exit 1
   fi
-  if [[ -v 2 ]] && ! [[ -d "$2/artifacthub-values" ]]; then
+  if [[ -v 2 && ! -d "$2/artifacthub-values" ]]; then
     echo "Missing artifacthub-values directory '$2', exiting" >&2
     exit 1
   fi
   updateChartYaml "$1" "${2:-}"
 else
   for chart in charts/*; do
-    [[ "$chart" == "charts/*" ]] && continue
+    [[ -d "$chart" ]] || continue
     [[ -f "$chart/ci/artifacthub-values.yaml" ]] || continue
 
     if yq -e '.type == "library"' "$chart/Chart.yaml" >/dev/null; then

--- a/.github/scripts/sync-codeowners.sh
+++ b/.github/scripts/sync-codeowners.sh
@@ -5,8 +5,8 @@
 
 echo "* @teutonet/k8s"
 
-for DIR in ./charts/*; do
-  [[ "$DIR" = "./charts/*" ]] && continue
+for DIR in charts/*; do
+  [[ -f "$DIR/Chart.yaml" ]] || continue
   FILE="$DIR/Chart.yaml"
   DIR="${DIR//\./}"
   MAINTAINERS="$(yq e '.maintainers.[].name' "$FILE" | sed 's/^/@/' | sort --ignore-case | tr '\r\n' ' ')"

--- a/.github/scripts/templateHelmChartRecursivelyToFolder.sh
+++ b/.github/scripts/templateHelmChartRecursivelyToFolder.sh
@@ -11,10 +11,10 @@ targetDir=${2?You need to provide the target directory}
 
 if yq -e '.type == "library"' "$chart/Chart.yaml" >/dev/null; then
   echo "Skipping library chart '$chart'" >&2
-  [[ -v GITHUB_OUTPUT ]] && [[ -f "$GITHUB_OUTPUT" ]] && echo "skipped=true" | tee -a "$GITHUB_OUTPUT"
+  [[ -v GITHUB_OUTPUT && -f "$GITHUB_OUTPUT" ]] && echo "skipped=true" | tee -a "$GITHUB_OUTPUT"
   exit 0
 else
-  [[ -v GITHUB_OUTPUT ]] && [[ -f "$GITHUB_OUTPUT" ]] && echo "skipped=false" | tee -a "$GITHUB_OUTPUT"
+  [[ -v GITHUB_OUTPUT && -f "$GITHUB_OUTPUT" ]] && echo "skipped=false" | tee -a "$GITHUB_OUTPUT"
 fi
 
 [[ ! -d "$targetDir" ]] && mkdir -p "$targetDir"

--- a/.github/workflows/update-artifacthub-images.yaml
+++ b/.github/workflows/update-artifacthub-images.yaml
@@ -21,7 +21,7 @@ jobs:
           (
             echo -n charts=
             for chart in charts/*; do
-              if [[ "$chart" != "charts/*" ]] && [[ -f "$chart/ci/artifacthub-values.yaml" ]]; then
+              if [[ "$chart" != "charts/*" && -f "$chart/ci/artifacthub-values.yaml" ]]; then
                 echo "$chart"
               fi
             done | cut -d / -f 2 | jq -c -Rn '[inputs]'


### PR DESCRIPTION
inlining the `&&` or `||` is more performant checking for existance of files or directories is safer than string comparing
