### PR TITLE
fix(base-cluster): only `toYaml` if field exists

### DIFF
--- a/charts/base-cluster/templates/_helmRelease.yaml
+++ b/charts/base-cluster/templates/_helmRelease.yaml
@@ -6,9 +6,7 @@ metadata:
   name: {{ .name }}
   namespace: {{ .namespace | default .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    {{- with .additionalLabels }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
+    {{- with .additionalLabels }}{{- toYaml . | nindent 4 }}{{- end }}
 spec:
   chart:
     spec: {{- include "base-cluster.helm.chartSpec" (dict "repo" "cetic" "chart" "static" "context" .context) | nindent 6 }}

--- a/charts/base-cluster/templates/cert-manager/rules/certificate-expiration.yaml
+++ b/charts/base-cluster/templates/cert-manager/rules/certificate-expiration.yaml
@@ -9,7 +9,7 @@ metadata:
   name: certificate-expiration
   namespace: cert-manager
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    {{- toYaml .Values.monitoring.labels | nindent 4 }}
+    {{- with .Values.monitoring.labels }}{{ toYaml . | nindent 4 }}{{- end }}
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/part-of: cert-manager
 spec:

--- a/charts/base-cluster/templates/flux/podMonitor.yaml
+++ b/charts/base-cluster/templates/flux/podMonitor.yaml
@@ -9,7 +9,7 @@ metadata:
   name: flux
   namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    {{- toYaml .Values.monitoring.labels | nindent 4 }}
+    {{- with .Values.monitoring.labels }}{{- toYaml . | nindent 4 }}{{- end }}
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/part-of: flux
 spec:

--- a/charts/base-cluster/templates/flux/rules/flux-status.yaml
+++ b/charts/base-cluster/templates/flux/rules/flux-status.yaml
@@ -9,7 +9,7 @@ metadata:
   name: flux-status
   namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    {{- toYaml .Values.monitoring.labels | nindent 4 }}
+    {{- with .Values.monitoring.labels }}{{- toYaml . | nindent 4 }}{{- end }}
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/part-of: flux
 spec:

--- a/charts/base-cluster/templates/global/namespaces.yaml
+++ b/charts/base-cluster/templates/global/namespaces.yaml
@@ -4,9 +4,7 @@ kind: Namespace
 metadata:
   name: {{ $name }}
   labels: {{- include "common.labels.standard" $ | nindent 4 -}}
-  {{- with $namespace.additionalLabels -}}
-    {{- toYaml . | nindent 4 -}}
-  {{- end }}
+    {{- with $namespace.additionalLabels -}}{{- toYaml . | nindent 4 -}}{{- end }}
 ---
 apiVersion: v1
 kind: LimitRange

--- a/charts/base-cluster/templates/nfs-server-provisioner/rules/storage-size.yaml
+++ b/charts/base-cluster/templates/nfs-server-provisioner/rules/storage-size.yaml
@@ -9,7 +9,7 @@ metadata:
   name: storage-size
   namespace: nfs-server-provisioner
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
-    {{- toYaml .Values.monitoring.labels | nindent 4 }}
+    {{- with .Values.monitoring.labels }}{{- toYaml . | nindent 4 }}{{- end }}
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/part-of: nfs-server-provisioner
 spec:


### PR DESCRIPTION
otherwise `{}` will be inserted, breaking everything
