### PR TITLE
fix(t8s-cluster): only `toYaml` if field exists

### DIFF
--- a/charts/t8s-cluster/templates/workload-cluster/_helmRelease.yaml
+++ b/charts/t8s-cluster/templates/workload-cluster/_helmRelease.yaml
@@ -6,9 +6,7 @@ metadata:
   name: {{ printf "%s-%s" .Release.Name .name }}
   namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    {{- with .additionalLabels }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
+    {{- with .additionalLabels }}{{- toYaml . | nindent 4 }}{{- end }}
 spec:
   chart:
     spec:


### PR DESCRIPTION
otherwise `{}` will be inserted, breaking everything
