### PR TITLE
fix(t8s-cluster): remove unnecessary require for openstackImageNamePrefix

### DIFF
--- a/charts/t8s-cluster/values.schema.json
+++ b/charts/t8s-cluster/values.schema.json
@@ -245,7 +245,6 @@
     "metadata",
     "version",
     "controlPlane",
-    "openstackImageNamePrefix",
     "nodePools"
   ],
   "additionalProperties": false,


### PR DESCRIPTION
this is not needed, as the type is `string` anyways and set to an empty string by default
