### PR TITLE
chore(base-cluster/dependencies): update helm release descheduler to 0.31.x

### DIFF
--- a/charts/base-cluster/Chart.yaml
+++ b/charts/base-cluster/Chart.yaml
@@ -215,6 +215,7 @@ dependencies:
 description: A common base for every kubernetes cluster
 home: https://teuto.net
 icon: https://teuto.net/favicon.ico
+kubeVersion: ">=1.27.0-0"
 maintainers:
   - email: cwr@teuto.net
     name: cwrau

--- a/charts/base-cluster/templates/descheduler/descheduler.yaml
+++ b/charts/base-cluster/templates/descheduler/descheduler.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.descheduler.enabled -}}
 {{- $kubeMinorVersion := .Capabilities.KubeVersion.Minor -}}
-{{- $versionMatrix := dict 18 "0.20.x" 19 "0.21.x" 20 "0.22.x" 21 "0.23.x" 22 "0.24.x" 23 "0.25.x" 24 "0.26.x" 25 "0.27.x" 26 "0.28.x" -}}
+{{- $versionMatrix := dict 27 "0.29.x" 28 "0.30.x" -}}
 {{- $latestVersion := .Values.global.helmRepositories.descheduler.charts.descheduler -}}
 {{- $selectedVersion := (hasKey $versionMatrix $kubeMinorVersion) | ternary (index $versionMatrix $kubeMinorVersion) $latestVersion -}}
 apiVersion: helm.toolkit.fluxcd.io/v2


### PR DESCRIPTION
chore(base-cluster/descheduler): up the minimum kubernetes version to 1.27.x
this should've already happened, but renovate force-pushed this over,
see <https://github.com/teutonet/teutonet-helm-charts/pull/1173#event-15001996224>
