### PR TITLE
✨: Add betterstack alertmanager receiver

### DIFF
--- a/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_alertmanager-config.yaml
+++ b/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_alertmanager-config.yaml
@@ -51,6 +51,16 @@ config:
       )
     -}}
   {{- end -}}
+  {{- if .Values.monitoring.prometheus.alertmanager.receivers.betterstack.enabled -}}
+    {{- $receivers = set $receivers "betterstack" (dict
+          "webhook_configs" (list
+            (dict
+              "url" (printf "https://uptime.betterstack.com/api/v1/prometheus/webhook/%s" (.Values.monitoring.prometheus.alertmanager.receivers.betterstack.webhookKey | required "You need to provide the `.Values.monitoring.prometheus.alertmanager.receivers.betterstack.webhookKey`"))
+            )
+          )
+      )
+    -}}
+  {{- end -}}
   {{- if and .Values.monitoring.deadMansSwitch.enabled .Values.global.baseDomain .Values.global.clusterName -}}
     {{- $receivers = set $receivers "healthchecks.io" (dict
           "webhook_configs" (list
@@ -68,11 +78,14 @@ config:
   {{- end }}
   receivers: {{- toYaml $receiversList | nindent 4 }}
   route: {{- if hasKey $receivers "pagerduty" }}
-    receiver: pagerduty
+    - receiver: pagerduty
+    {{- end }}
+    {{- if hasKey $receivers "betterstack" }}
+    - receiver: betterstack
     {{- end }}
     {{- $routes := list (dict "match" (dict "alertname" "InfoInhibitor") "receiver" "null") -}}
     {{- $routes = append $routes (dict "match" (dict "alertname" "Watchdog") "receiver" (hasKey $receivers "healthchecks.io" | ternary "healthchecks.io" "null") "group_interval" "1m" "repeat_interval" "1m") }}
-    routes: {{- toYaml $routes | nindent 6 }}
+    routes  : {{- toYaml $routes | nindent 6 }}
 {{- else }}
 enabled: false
 {{- end }}

--- a/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_alertmanager-config.yaml
+++ b/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_alertmanager-config.yaml
@@ -85,7 +85,7 @@ config:
     {{- end }}
     {{- $routes := list (dict "match" (dict "alertname" "InfoInhibitor") "receiver" "null") -}}
     {{- $routes = append $routes (dict "match" (dict "alertname" "Watchdog") "receiver" (hasKey $receivers "healthchecks.io" | ternary "healthchecks.io" "null") "group_interval" "1m" "repeat_interval" "1m") }}
-    routes  : {{- toYaml $routes | nindent 6 }}
+    routes: {{- toYaml $routes | nindent 6 }}
 {{- else }}
 enabled: false
 {{- end }}

--- a/charts/base-cluster/values.schema.json
+++ b/charts/base-cluster/values.schema.json
@@ -703,6 +703,18 @@
                         }
                       },
                       "additionalProperties": false
+                    },
+                    "betterstack": {
+                      "type": "object",
+                      "properties": {
+                        "enabled": {
+                          "type": "boolean"
+                        },
+                        "webhookKey": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
                     }
                   },
                   "additionalProperties": false

--- a/charts/base-cluster/values.yaml
+++ b/charts/base-cluster/values.yaml
@@ -298,6 +298,9 @@ monitoring:
           enabled: false
           integrationKey: ""
           url: https://events.pagerduty.com/v2/enqueue
+        betterstack:
+          enabled: false
+          webhookKey: ""
       ingress:
         host: alertmanager
         customDomain: ""


### PR DESCRIPTION
Suggestion for adding BetterStack as Prometheus alertmanager receiver as mentioned in this [issue](https://github.com/teutonet/teutonet-helm-charts/issues/1207).
[BetterStack Documentation about Prometheus integration](https://betterstack.com/docs/uptime/prometheus/)