### PR TITLE
fix(t8s-cluster/cni): otherwise for >=1.30 there is no version

### DIFF
--- a/charts/t8s-cluster/templates/management-cluster/repositories/cni-calico.yaml
+++ b/charts/t8s-cluster/templates/management-cluster/repositories/cni-calico.yaml
@@ -10,7 +10,7 @@ spec:
   url: https://github.com/projectcalico/calico
   ref:
     {{- with .Values.version }}
-    semver: {{ printf "v3.%d.x" (.minor | int) }}
+    semver: {{ printf ">=v3.%d.x <=v3.%d.x" (sub (.minor | int) 2) (.minor | int) | quote }}
     {{- end }}
   ignore: |
     /manifests/**


### PR DESCRIPTION
see <https://docs.tigera.io/calico/latest/getting-started/kubernetes/requirements#supported-versions>
