### PR TITLE
feat(ci): revert: adjust scripts to run safely for external PRs

### DIFF
--- a/.github/workflows/check-licenses.yaml
+++ b/.github/workflows/check-licenses.yaml
@@ -1,7 +1,7 @@
 name: Check used licenses
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited
@@ -35,8 +35,6 @@ jobs:
     needs: getChangedChart
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - run: pip install yq
       - env:
           chart: ${{ needs.getChangedChart.outputs.chart }}

--- a/.github/workflows/pr-comment-diff.yaml
+++ b/.github/workflows/pr-comment-diff.yaml
@@ -4,7 +4,7 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - charts/**
     branches-ignore:
@@ -15,38 +15,16 @@ jobs:
     uses: ./.github/workflows/get-changed-chart.yaml
     with:
       pr_number: ${{ github.event.pull_request.number }}
-  generateDiffCommentBody:
+  postDiffComment:
     runs-on: ubuntu-latest
     needs: getChangedChart
-    permissions:
-      contents: read
-      pull-requests: read
     env:
       CT_TARGET_BRANCH: ${{ github.event.pull_request.base.ref || github.event.repository.default_branch }}
+      GITHUB_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - run: pip install yq
       - name: Install sponge
         run: sudo apt-get -yq install moreutils
-      - run: ./.github/scripts/prepare-values.sh "pr/charts/${{ needs.getChangedChart.outputs.chart }}"
-      - run: ./.github/scripts/create-values-diff.sh ${{ github.event.number }} "pr/charts/${{ needs.getChangedChart.outputs.chart }}" --dry-run > comment_body.md
-      - uses: actions/upload-artifact@v4
-        with:
-          name: comment_body
-          path: comment_body.md
-          if-no-files-found: error
-          retention-days: 1
-  postDiffComment:
-    runs-on: ubuntu-latest
-    needs:
-      - getChangedChart
-      - generateDiffCommentBody
-    env:
-      GITHUB_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: comment_body
-      - run: ./.github/scripts/create-values-diff.sh ${{ github.event.number }} "charts/${{ needs.getChangedChart.outputs.chart }}" --body comment_body.md
+      - run: ./.github/scripts/prepare-values.sh "charts/${{ needs.getChangedChart.outputs.chart }}"
+      - run: ./.github/scripts/create-values-diff.sh ${{ github.event.number }} "charts/${{ needs.getChangedChart.outputs.chart }}"


### PR DESCRIPTION
Reverts teutonet/teutonet-helm-charts#1269

I thought the path `pr/..` was some filesystem trick to mimic the pr in the filesystem, but there simply not existing. 

I don't know how @cwrau thought this to work, so i revert it for now.