### PR TITLE
fix(ci): stupid github docs

### DIFF
--- a/.github/workflows/check-licenses.yaml
+++ b/.github/workflows/check-licenses.yaml
@@ -1,6 +1,6 @@
 name: Check used licenses
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/label-pullrequest.yaml
+++ b/.github/workflows/label-pullrequest.yaml
@@ -1,6 +1,6 @@
 name: Label Chart Pull Request
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/pr-comment-diff.yaml
+++ b/.github/workflows/pr-comment-diff.yaml
@@ -1,6 +1,6 @@
 name: Add comment with diff for PR
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/release-update-metadata.yaml
+++ b/.github/workflows/release-update-metadata.yaml
@@ -1,6 +1,6 @@
 name: Update metadata files for release
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/validate-pullrequest.yaml
+++ b/.github/workflows/validate-pullrequest.yaml
@@ -1,6 +1,6 @@
 name: Validate Pull Request
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/wait-for-checks.yaml
+++ b/.github/workflows/wait-for-checks.yaml
@@ -1,6 +1,6 @@
 name: Wait for checks
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 on:


### PR DESCRIPTION
<https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context:~:text=branch%2D1.-,github.ref_name,-string> should include the pr_number, but alas it does not...
