### PR TITLE
fix(t8s-cluster): me be stupid I guess

### DIFF
--- a/charts/t8s-cluster/templates/management-cluster/clusterClass/openStackClusterTemplate/_openStackClusterTemplateSpec.yaml
+++ b/charts/t8s-cluster/templates/management-cluster/clusterClass/openStackClusterTemplate/_openStackClusterTemplateSpec.yaml
@@ -51,7 +51,7 @@ identityRef:
   {{- range $name, $securityGroupRule := $cniSecurityGroupRules -}}
     {{- $_securityGroupRule := dict
       "name" (printf "%s %s" $cni $name)
-      "direction" "Ingress"
+      "direction" "ingress"
       "etherType" "IPv4"
       "protocol" ($securityGroupRule.protocol | required "security group rule protocol is required")
       "remoteManagedGroups" $remoteManagedGroups


### PR DESCRIPTION
I could've _sworn_ that the docs had these values in uppercase...
