### PR TITLE
fix(base-cluster/monitoring): use correct condition for grafana ingress

### DIFF
--- a/charts/base-cluster/templates/NOTES.txt
+++ b/charts/base-cluster/templates/NOTES.txt
@@ -20,7 +20,7 @@
 ===
 You can access your grafana instance via
 
-{{- if and .Values.certManager.email .Values.monitoring.grafana.ingress.enabled }}
+{{- if and .Values.ingress.enabled .Values.monitoring.grafana.ingress.enabled .Values.certManager.email (or .Values.global.baseDomain .Values.monitoring.grafana.ingress.customDomain) }}
 {{- printf "https://%s" (include "base-cluster.grafana.host" $) | nindent 2 }}
 {{- else }}
 {{- printf "$ kubectl -n monitoring port-forward svc/kube-prometheus-stack-grafana 3000:http-web" | nindent 2 }}


### PR DESCRIPTION
otherwise the validation fails with `baseDomain needed`
