### PR TITLE
fix(ci/licenseScanning): ignore `null` Results

### DIFF
--- a/.github/scripts/scan-for-licenses.sh
+++ b/.github/scripts/scan-for-licenses.sh
@@ -59,7 +59,7 @@ WHITELIST=(
 )
 
 # shellcheck disable=SC2016
-licenseConversionJq='map({Image: (.Metadata.RepoTags // .Metadata.RepoDigests)[0], License: (.Results[] | .Licenses[]? | .Name)} as $licenseInfo | $licenseInfo+{PackageOrPath: (.Results[] | .Licenses[]? | select(.Name == $licenseInfo.License) | if .PkgName != "" then .PkgName else .FilePath end)}) | group_by(.License) | map({(.[0].License): (map(del(.License)) | group_by(.Image) | map({(.[0].Image): map(.PackageOrPath) | unique}) | add) }) | add // {}'
+licenseConversionJq='map({Image: (.Metadata.RepoTags // .Metadata.RepoDigests)[0], License: (.Results[]? | .Licenses[]? | .Name)} as $licenseInfo | $licenseInfo+{PackageOrPath: (.Results[] | .Licenses[]? | select(.Name == $licenseInfo.License) | if .PkgName != "" then .PkgName else .FilePath end)}) | group_by(.License) | map({(.[0].License): (map(del(.License)) | group_by(.Image) | map({(.[0].Image): map(.PackageOrPath) | unique}) | add) }) | add // {}'
 function scanLicenses() {
   local chart="${1?}"
   local licenseMap


### PR DESCRIPTION
otherwise jq can't iterate over it
