### PR TITLE
feat(base-cluster/ingress-nginx): use risk-level Critical when annotations are enabled

### DIFF
--- a/charts/base-cluster/templates/ingress/nginx.yaml
+++ b/charts/base-cluster/templates/ingress/nginx.yaml
@@ -40,6 +40,9 @@ spec:
         use-proxy-protocol: {{ .Values.ingress.useProxyProtocol }}
         use-gzip: true
         enable-brotli: true
+        {{- if .Values.ingress.allowNginxConfigurationSnippets }}
+        annotations-risk-level: Critical
+        {{- end }}
         enable-underscores-in-headers: true
         {{- if $telemetryConf.enabled }}
         enable-opentelemetry: true


### PR DESCRIPTION
This sets `annotations-risk-level` to Critical when nginx configuration snippets are enabled, restoring the default setting from before ingress-nginx release 1.12.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a conditional risk level configuration that automatically applies a "Critical" status when snippet-based annotations are enabled, enhancing overall risk management without affecting other existing settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->