### PR TITLE
fix(ci): use correct field for repository parameter

### DIFF
--- a/.github/workflows/release-update-metadata.yaml
+++ b/.github/workflows/release-update-metadata.yaml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
-          repository: ${{ github.event.pull_request.head.repo.clone_url }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
       - name: Install sponge
         run: sudo apt-get -yq install moreutils
@@ -60,7 +60,7 @@ jobs:
           exit 1
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
-          repository: ${{ github.event.pull_request.head.repo.clone_url }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}


### PR DESCRIPTION
apparently, `repository` needs `$owner/$repo` instead of a full URL...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated repository referencing in the continuous integration workflow to ensure smoother internal operations without impacting the application’s user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->