### PR TITLE
feat(base-cluster/monitoring): remove unnecessary labels from monitoring components

### DIFF
--- a/charts/base-cluster/templates/backup/velero.yaml
+++ b/charts/base-cluster/templates/backup/velero.yaml
@@ -90,11 +90,11 @@ spec:
       uploaderType: restic
     metrics:
       serviceMonitor:
-        additionalLabels: {{- include "common.tplvalues.render" (dict "value" .Values.monitoring.labels "context" .) | nindent 10 }}
+        additionalLabels:
+          monitoring/managed-by: teutonet
         enabled: true
       prometheusRule:
         enabled: true
-        additionalLabels: {{- include "common.tplvalues.render" (dict "value" .Values.monitoring.labels "context" .) | nindent 10 }}
         spec:
           - alert: VeleroBackupFailures
             annotations:

--- a/charts/base-cluster/templates/backup/velero.yaml
+++ b/charts/base-cluster/templates/backup/velero.yaml
@@ -91,7 +91,7 @@ spec:
     metrics:
       serviceMonitor:
         additionalLabels:
-          monitoring/managed-by: teutonet
+          monitoring/provisioned-by: base-cluster
         enabled: true
       prometheusRule:
         enabled: true

--- a/charts/base-cluster/templates/cert-manager/cert-manager.yaml
+++ b/charts/base-cluster/templates/cert-manager/cert-manager.yaml
@@ -72,4 +72,4 @@ spec:
       servicemonitor:
         enabled: {{ .Values.monitoring.prometheus.enabled }}
         labels:
-          monitoring/managed-by: teutonet
+          monitoring/provisioned-by: base-cluster

--- a/charts/base-cluster/templates/cert-manager/cert-manager.yaml
+++ b/charts/base-cluster/templates/cert-manager/cert-manager.yaml
@@ -71,4 +71,5 @@ spec:
       enabled: {{ .Values.monitoring.prometheus.enabled }}
       servicemonitor:
         enabled: {{ .Values.monitoring.prometheus.enabled }}
-        labels: {{- include "common.tplvalues.render" (dict "value" .Values.monitoring.labels "context" .) | nindent 10 }}
+        labels:
+          monitoring/managed-by: teutonet

--- a/charts/base-cluster/templates/cert-manager/rules/certificate-expiration.yaml
+++ b/charts/base-cluster/templates/cert-manager/rules/certificate-expiration.yaml
@@ -9,7 +9,7 @@ metadata:
   name: certificate-expiration
   namespace: cert-manager
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    monitoring/managed-by: teutonet
+    monitoring/provisioned-by: base-cluster
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/part-of: cert-manager
 spec:

--- a/charts/base-cluster/templates/cert-manager/rules/certificate-expiration.yaml
+++ b/charts/base-cluster/templates/cert-manager/rules/certificate-expiration.yaml
@@ -9,7 +9,7 @@ metadata:
   name: certificate-expiration
   namespace: cert-manager
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    {{- with .Values.monitoring.labels }}{{- include "common.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}{{- end }}
+    monitoring/managed-by: teutonet
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/part-of: cert-manager
 spec:

--- a/charts/base-cluster/templates/descheduler/descheduler.yaml
+++ b/charts/base-cluster/templates/descheduler/descheduler.yaml
@@ -36,7 +36,7 @@ spec:
     serviceMonitor:
       enabled: true
       additionalLabels:
-        monitoring/managed-by: teutonet
+        monitoring/provisioned-by: base-cluster
     {{- end }}
     deschedulerPolicy: {{- $telemetryConf := include "common.telemetry.conf" (dict "protocol" "otlp") | fromYaml }}
       {{- if and $telemetryConf.enabled .Values.monitoring.prometheus.enabled }}

--- a/charts/base-cluster/templates/descheduler/descheduler.yaml
+++ b/charts/base-cluster/templates/descheduler/descheduler.yaml
@@ -35,7 +35,8 @@ spec:
       enabled: true
     serviceMonitor:
       enabled: true
-      additionalLabels: {{- include "common.tplvalues.render" (dict "value" .Values.monitoring.labels "context" .) | nindent 8 }}
+      additionalLabels:
+        monitoring/managed-by: teutonet
     {{- end }}
     deschedulerPolicy: {{- $telemetryConf := include "common.telemetry.conf" (dict "protocol" "otlp") | fromYaml }}
       {{- if and $telemetryConf.enabled .Values.monitoring.prometheus.enabled }}

--- a/charts/base-cluster/templates/dns/external-dns.yaml
+++ b/charts/base-cluster/templates/dns/external-dns.yaml
@@ -81,5 +81,5 @@ spec:
       serviceMonitor:
         enabled: {{ .Values.monitoring.prometheus.enabled }}
         labels:
-          monitoring/managed-by: teutonet
+          monitoring/provisioned-by: base-cluster
 {{- end -}}

--- a/charts/base-cluster/templates/dns/external-dns.yaml
+++ b/charts/base-cluster/templates/dns/external-dns.yaml
@@ -80,5 +80,6 @@ spec:
       enabled: {{ .Values.monitoring.prometheus.enabled }}
       serviceMonitor:
         enabled: {{ .Values.monitoring.prometheus.enabled }}
-        labels: {{- include "common.tplvalues.render" (dict "value" .Values.monitoring.labels "context" .) | nindent 10 }}
+        labels:
+          monitoring/managed-by: teutonet
 {{- end -}}

--- a/charts/base-cluster/templates/flux/podMonitor.yaml
+++ b/charts/base-cluster/templates/flux/podMonitor.yaml
@@ -9,7 +9,7 @@ metadata:
   name: flux
   namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    monitoring/managed-by: teutonet
+    monitoring/provisioned-by: base-cluster
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/part-of: flux
 spec:

--- a/charts/base-cluster/templates/flux/podMonitor.yaml
+++ b/charts/base-cluster/templates/flux/podMonitor.yaml
@@ -9,7 +9,7 @@ metadata:
   name: flux
   namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    {{- with .Values.monitoring.labels }}{{- include "common.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}{{- end }}
+    monitoring/managed-by: teutonet
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/part-of: flux
 spec:

--- a/charts/base-cluster/templates/flux/rules/flux-status.yaml
+++ b/charts/base-cluster/templates/flux/rules/flux-status.yaml
@@ -9,7 +9,7 @@ metadata:
   name: flux-status
   namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    {{- with .Values.monitoring.labels }}{{- include "common.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}{{- end }}
+    monitoring/managed-by: teutonet
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/part-of: flux
 spec:

--- a/charts/base-cluster/templates/flux/rules/flux-status.yaml
+++ b/charts/base-cluster/templates/flux/rules/flux-status.yaml
@@ -9,7 +9,7 @@ metadata:
   name: flux-status
   namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    monitoring/managed-by: teutonet
+    monitoring/provisioned-by: base-cluster
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/part-of: flux
 spec:

--- a/charts/base-cluster/templates/ingress/nginx.yaml
+++ b/charts/base-cluster/templates/ingress/nginx.yaml
@@ -27,7 +27,7 @@ spec:
         serviceMonitor:
           enabled: {{ .Values.monitoring.prometheus.enabled }}
           additionalLabels:
-            monitoring/managed-by: teutonet
+            monitoring/provisioned-by: base-cluster
       {{- $telemetryConf := include "common.telemetry.conf" (dict "protocol" "otlp") | fromYaml }}
       {{- if and $telemetryConf.enabled .Values.monitoring.prometheus.enabled }}
       opentelemetry:

--- a/charts/base-cluster/templates/ingress/nginx.yaml
+++ b/charts/base-cluster/templates/ingress/nginx.yaml
@@ -26,7 +26,8 @@ spec:
         enabled: {{ .Values.monitoring.prometheus.enabled }}
         serviceMonitor:
           enabled: {{ .Values.monitoring.prometheus.enabled }}
-          additionalLabels: {{- include "common.tplvalues.render" (dict "value" .Values.monitoring.labels "context" .) | nindent 12 }}
+          additionalLabels:
+            monitoring/managed-by: teutonet
       {{- $telemetryConf := include "common.telemetry.conf" (dict "protocol" "otlp") | fromYaml }}
       {{- if and $telemetryConf.enabled .Values.monitoring.prometheus.enabled }}
       opentelemetry:

--- a/charts/base-cluster/templates/ingress/traefik.yaml
+++ b/charts/base-cluster/templates/ingress/traefik.yaml
@@ -62,7 +62,8 @@ spec:
       enabled: {{ .Values.monitoring.prometheus.enabled }}
       serviceMonitor:
         enabled: {{ .Values.monitoring.prometheus.enabled }}
-        additionalLabels: {{- include "common.tplvalues.render" (dict "value" .Values.monitoring.labels "context" .) | nindent 12 }}
+        additionalLabels:
+          monitoring/provisioned-by: base-cluster
     providers:
       kubernetesCRD:
         enabled: false

--- a/charts/base-cluster/templates/kyverno/kyverno.yaml
+++ b/charts/base-cluster/templates/kyverno/kyverno.yaml
@@ -58,7 +58,7 @@ spec:
     serviceMonitor:
       enabled: {{ .Values.monitoring.prometheus.enabled }}
       additionalLabels:
-        monitoring/managed-by: teutonet
+        monitoring/provisioned-by: base-cluster
     priorityClassName: system-cluster-critical
     # this only works in version 3
     admissionController:

--- a/charts/base-cluster/templates/kyverno/kyverno.yaml
+++ b/charts/base-cluster/templates/kyverno/kyverno.yaml
@@ -57,7 +57,8 @@ spec:
       {{- end }}
     serviceMonitor:
       enabled: {{ .Values.monitoring.prometheus.enabled }}
-      additionalLabels: {{- include "common.tplvalues.render" (dict "value" .Values.monitoring.labels "context" .) | nindent 8 }}
+      additionalLabels:
+        monitoring/managed-by: teutonet
     priorityClassName: system-cluster-critical
     # this only works in version 3
     admissionController:

--- a/charts/base-cluster/templates/monitoring/alloy.yaml
+++ b/charts/base-cluster/templates/monitoring/alloy.yaml
@@ -277,5 +277,5 @@ spec:
     serviceMonitor:
       enabled: true
       additionalLabels:
-        monitoring/managed-by: teutonet
+        monitoring/provisioned-by: base-cluster
 {{- end -}}

--- a/charts/base-cluster/templates/monitoring/alloy.yaml
+++ b/charts/base-cluster/templates/monitoring/alloy.yaml
@@ -276,5 +276,6 @@ spec:
       internalTrafficPolicy: Local
     serviceMonitor:
       enabled: true
-      additionalLabels: {{- include "common.tplvalues.render" (dict "value" .Values.monitoring.labels "context" .) | nindent 10 }}
+      additionalLabels:
+        monitoring/managed-by: teutonet
 {{- end -}}

--- a/charts/base-cluster/templates/monitoring/kdave/kdave.yaml
+++ b/charts/base-cluster/templates/monitoring/kdave/kdave.yaml
@@ -42,7 +42,7 @@ metadata:
   name: kdave
   namespace: monitoring
   labels: {{- include "common.helm.labels" (dict) | nindent 4 }}
-    monitoring/managed-by: teutonet
+    monitoring/provisioned-by: base-cluster
     app.kubernetes.io/component: kdave
     app.kubernetes.io/part-of: monitoring
 spec:

--- a/charts/base-cluster/templates/monitoring/kdave/kdave.yaml
+++ b/charts/base-cluster/templates/monitoring/kdave/kdave.yaml
@@ -41,7 +41,8 @@ kind: ServiceMonitor
 metadata:
   name: kdave
   namespace: monitoring
-  labels: {{- include "common.helm.labels" (dict) | nindent 4 }}{{- include "common.tplvalues.render" (dict "value" .Values.monitoring.labels "context" .) | nindent 4 }}
+  labels: {{- include "common.helm.labels" (dict) | nindent 4 }}
+    monitoring/managed-by: teutonet
     app.kubernetes.io/component: kdave
     app.kubernetes.io/part-of: monitoring
 spec:

--- a/charts/base-cluster/templates/monitoring/kdave/rules/releases-with-deprecation.yaml
+++ b/charts/base-cluster/templates/monitoring/kdave/rules/releases-with-deprecation.yaml
@@ -9,7 +9,7 @@ metadata:
   name: releases-with-deprecated-apis
   namespace: monitoring
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    monitoring/managed-by: teutonet
+    monitoring/provisioned-by: base-cluster
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/part-of: kdave
 spec:

--- a/charts/base-cluster/templates/monitoring/kdave/rules/releases-with-deprecation.yaml
+++ b/charts/base-cluster/templates/monitoring/kdave/rules/releases-with-deprecation.yaml
@@ -9,7 +9,7 @@ metadata:
   name: releases-with-deprecated-apis
   namespace: monitoring
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    {{- with .Values.monitoring.labels }}{{- include "common.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}{{- end }}
+    monitoring/managed-by: teutonet
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/part-of: kdave
 spec:

--- a/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_alertmanager-config.yaml
+++ b/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_alertmanager-config.yaml
@@ -31,8 +31,6 @@ alertmanagerSpec:
         resources:
           requests:
             storage: {{ .Values.monitoring.prometheus.alertmanager.persistence.size }}
-  alertmanagerConfigSelector:
-    matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.monitoring.labels "context" .) | nindent 6 }}
 config:
   {{- if .Values.monitoring.prometheus.alertmanager.receivers.pagerduty.enabled }}
   global:

--- a/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_grafana-config.yaml
+++ b/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_grafana-config.yaml
@@ -55,7 +55,7 @@ deploymentStrategy:
 serviceMonitor:
   interval: "30s"
   labels:
-    monitoring/managed-by: teutonet
+    monitoring/provisioned-by: base-cluster
 podAnnotations:
   # This might change on every `template` call, this can be ignored
   checksum/secret: {{ include "common.utils.checksumTemplate" (dict "path" "/monitoring/kube-prometheus-stack/grafana-secret.yaml" "context" $) }}

--- a/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_grafana-config.yaml
+++ b/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_grafana-config.yaml
@@ -54,7 +54,8 @@ deploymentStrategy:
 {{- end }}
 serviceMonitor:
   interval: "30s"
-  labels: {{- include "common.tplvalues.render" (dict "value" .Values.monitoring.labels "context" .) | nindent 4 }}
+  labels:
+    monitoring/managed-by: teutonet
 podAnnotations:
   # This might change on every `template` call, this can be ignored
   checksum/secret: {{ include "common.utils.checksumTemplate" (dict "path" "/monitoring/kube-prometheus-stack/grafana-secret.yaml" "context" $) }}

--- a/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_kube-state-metrics-config.yaml
+++ b/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_kube-state-metrics-config.yaml
@@ -110,5 +110,5 @@ containerSecurityContext: {{- include "base-cluster.prometheus-stack.containerSe
 prometheus:
   monitor:
     additionalLabels:
-      monitoring/managed-by: teutonet
+      monitoring/provisioned-by: base-cluster
 {{- end -}}

--- a/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_kube-state-metrics-config.yaml
+++ b/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_kube-state-metrics-config.yaml
@@ -109,5 +109,6 @@ securityContext:
 containerSecurityContext: {{- include "base-cluster.prometheus-stack.containerSecurityContext" (dict) | nindent 2 }}
 prometheus:
   monitor:
-    additionalLabels: {{- include "common.tplvalues.render" (dict "value" .Values.monitoring.labels "context" .) | nindent 6 }}
+    additionalLabels:
+      monitoring/managed-by: teutonet
 {{- end -}}

--- a/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_node-exporter-config.yaml
+++ b/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_node-exporter-config.yaml
@@ -12,5 +12,5 @@ containerSecurityContext: {{- include "base-cluster.prometheus-stack.containerSe
 prometheus:
   monitor:
     additionalLabels:
-      monitoring/managed-by: teutonet
+      monitoring/provisioned-by: base-cluster
 {{- end -}}

--- a/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_node-exporter-config.yaml
+++ b/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_node-exporter-config.yaml
@@ -11,5 +11,6 @@ securityContext:
 containerSecurityContext: {{- include "base-cluster.prometheus-stack.containerSecurityContext" (dict) | nindent 2 }}
 prometheus:
   monitor:
-    additionalLabels: {{- include "common.tplvalues.render" (dict "value" .Values.monitoring.labels "context" .) | nindent 6 }}
+    additionalLabels:
+      monitoring/managed-by: teutonet
 {{- end -}}

--- a/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_prometheus-stack-config.yaml
+++ b/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_prometheus-stack-config.yaml
@@ -22,7 +22,8 @@ defaultRules:
 kubelet:
   serviceMonitor:
     resource: false
-commonLabels: {{- include "common.tplvalues.render" (dict "value" .Values.monitoring.labels "context" .) | nindent 2 }}
+commonLabels:
+  monitoring/managed-by: teutonet
 grafana: {{- include "base-cluster.prometheus-stack.grafana.config" . | nindent 2 }}
 kube-state-metrics: {{- include "base-cluster.prometheus-stack.kube-state-metrics.config" . | nindent 2 }}
 prometheus-node-exporter: {{- include "base-cluster.prometheus-stack.node-exporter.config" . | nindent 2 }}

--- a/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_prometheus-stack-config.yaml
+++ b/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_prometheus-stack-config.yaml
@@ -23,7 +23,7 @@ kubelet:
   serviceMonitor:
     resource: false
 commonLabels:
-  monitoring/managed-by: teutonet
+  monitoring/provisioned-by: base-cluster
 grafana: {{- include "base-cluster.prometheus-stack.grafana.config" . | nindent 2 }}
 kube-state-metrics: {{- include "base-cluster.prometheus-stack.kube-state-metrics.config" . | nindent 2 }}
 prometheus-node-exporter: {{- include "base-cluster.prometheus-stack.node-exporter.config" . | nindent 2 }}

--- a/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_prometheus_config.yaml
+++ b/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_prometheus_config.yaml
@@ -33,14 +33,6 @@ prometheusSpec:
           requests:
             storage: {{ .Values.monitoring.prometheus.persistence.size }}
   replicas: {{ .Values.monitoring.prometheus.replicas }}
-  ruleSelector:
-    matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.monitoring.labels "context" .) | nindent 6 }}
-  serviceMonitorSelector:
-    matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.monitoring.labels "context" .) | nindent 6 }}
-  podMonitorSelector:
-    matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.monitoring.labels "context" .) | nindent 6 }}
-  probeSelector:
-    matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.monitoring.labels "context" .) | nindent 6 }}
   additionalAlertRelabelConfigs:
     {{- if not .Values.monitoring.monitorAllNamespaces }}
       {{- $namespaces := list .Release.Namespace "kube-node-lease" "kube-public" "kube-system" -}}

--- a/charts/base-cluster/templates/monitoring/logs/loki.yaml
+++ b/charts/base-cluster/templates/monitoring/logs/loki.yaml
@@ -99,5 +99,6 @@ spec:
     monitoring:
       serviceMonitor:
         enabled: true
-        additionalLabels: {{- include "common.tplvalues.render" (dict "value" .Values.monitoring.labels "context" .) | nindent 10 }}
+        additionalLabels:
+          monitoring/managed-by: teutonet
 {{- end -}}

--- a/charts/base-cluster/templates/monitoring/logs/loki.yaml
+++ b/charts/base-cluster/templates/monitoring/logs/loki.yaml
@@ -100,5 +100,5 @@ spec:
       serviceMonitor:
         enabled: true
         additionalLabels:
-          monitoring/managed-by: teutonet
+          monitoring/provisioned-by: base-cluster
 {{- end -}}

--- a/charts/base-cluster/templates/monitoring/security/trivy.yaml
+++ b/charts/base-cluster/templates/monitoring/security/trivy.yaml
@@ -73,5 +73,5 @@ spec:
     serviceMonitor:
       enabled: {{ .Values.monitoring.prometheus.enabled }}
       labels:
-        monitoring/managed-by: teutonet
+        monitoring/provisioned-by: base-cluster
 {{- end }}

--- a/charts/base-cluster/templates/monitoring/security/trivy.yaml
+++ b/charts/base-cluster/templates/monitoring/security/trivy.yaml
@@ -72,5 +72,6 @@ spec:
     excludeNamespaces: ""
     serviceMonitor:
       enabled: {{ .Values.monitoring.prometheus.enabled }}
-      labels: {{- include "common.tplvalues.render" (dict "value" .Values.monitoring.labels "context" .) | nindent 8 }}
+      labels:
+        monitoring/managed-by: teutonet
 {{- end }}

--- a/charts/base-cluster/templates/monitoring/tracing/grafana-tempo.yaml
+++ b/charts/base-cluster/templates/monitoring/tracing/grafana-tempo.yaml
@@ -57,7 +57,7 @@ spec:
       serviceMonitor:
         enabled: true
         labels:
-          monitoring/managed-by: teutonet
+          monitoring/provisioned-by: base-cluster
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/charts/base-cluster/templates/monitoring/tracing/grafana-tempo.yaml
+++ b/charts/base-cluster/templates/monitoring/tracing/grafana-tempo.yaml
@@ -56,7 +56,8 @@ spec:
       enabled: true
       serviceMonitor:
         enabled: true
-        labels: {{- include "common.tplvalues.render" (dict "value" .Values.monitoring.labels "context" .) | nindent 10 }}
+        labels:
+          monitoring/managed-by: teutonet
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/charts/base-cluster/templates/nfs-server-provisioner/rules/storage-size.yaml
+++ b/charts/base-cluster/templates/nfs-server-provisioner/rules/storage-size.yaml
@@ -9,7 +9,7 @@ metadata:
   name: storage-size
   namespace: nfs-server-provisioner
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
-    {{- with .Values.monitoring.labels }}{{- include "common.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}{{- end }}
+    monitoring/managed-by: teutonet
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/part-of: nfs-server-provisioner
 spec:

--- a/charts/base-cluster/templates/nfs-server-provisioner/rules/storage-size.yaml
+++ b/charts/base-cluster/templates/nfs-server-provisioner/rules/storage-size.yaml
@@ -9,7 +9,7 @@ metadata:
   name: storage-size
   namespace: nfs-server-provisioner
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
-    monitoring/managed-by: teutonet
+    monitoring/provisioned-by: base-cluster
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/part-of: nfs-server-provisioner
 spec:

--- a/charts/base-cluster/templates/tetragon/tetragon.yaml
+++ b/charts/base-cluster/templates/tetragon/tetragon.yaml
@@ -44,6 +44,6 @@ spec:
         serviceMonitor:
           enabled: true
           labelsOverride:
-            monitoring/managed-by: teutonet
+            monitoring/provisioned-by: base-cluster
       {{- end }}
   {{- end }}

--- a/charts/base-cluster/templates/tetragon/tetragon.yaml
+++ b/charts/base-cluster/templates/tetragon/tetragon.yaml
@@ -43,6 +43,7 @@ spec:
       prometheus:
         serviceMonitor:
           enabled: true
-          labelsOverride: {{- include "common.tplvalues.render" (dict "value" .Values.monitoring.labels "context" .) | nindent 12 }}
+          labelsOverride:
+            monitoring/managed-by: teutonet
       {{- end }}
   {{- end }}

--- a/charts/base-cluster/values.schema.json
+++ b/charts/base-cluster/values.schema.json
@@ -585,13 +585,6 @@
         "monitorAllNamespaces": {
           "type": "boolean"
         },
-        "labels": {
-          "type": "object",
-          "description": "The labels to set on ServiceMonitors, ... and which the prometheus uses to search for",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
         "deadMansSwitch": {
           "type": "object",
           "description": "This needs `.global.clusterName` to be set up as an integration in healthchecks.io. Also, `.global.baseDomain` has to be set.",

--- a/charts/base-cluster/values.yaml
+++ b/charts/base-cluster/values.yaml
@@ -218,8 +218,6 @@ kyverno:
 
 monitoring:
   monitorAllNamespaces: true
-  labels:
-    managed.by/monitoring: teutonet
   grafana:
     adminPassword: ""
     ingress:


### PR DESCRIPTION
that way the user doesn't need to add labels to their \*Monitors

for internal alert routing we should select on `monitoring/managed-by: teutonet`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Standardized monitoring configurations by replacing dynamic label assignments with a fixed label ("monitoring/provisioned-by: base-cluster") across various monitoring resources to ensure consistent identification.

- **Chore**
  - Simplified settings by removing obsolete label selectors and redundant monitoring configuration properties from schemas and values, streamlining resource management and future customization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->