### PR TITLE
feat(ci): activate merge groups

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -1,6 +1,9 @@
 name: lint github workflows
 
 on:
+  merge_group:
+    types:
+      - checks_requested
   pull_request:
     paths:
       - ".github/**/*.ya?ml"

--- a/.github/workflows/wait-for-checks.yaml
+++ b/.github/workflows/wait-for-checks.yaml
@@ -4,6 +4,9 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  merge_group:
+    types:
+      - checks_requested
   pull_request:
     types:
       - opened


### PR DESCRIPTION
see <https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue>

this should take care of conflicting PRs... in case of incompatible
changes by running CI on the merged state


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced our automation workflows to trigger additional checks during merge events, ensuring more reliable validation of changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->