### PR TITLE
feat(ci): replace action with little script

### DIFF
--- a/.github/workflows/wait-for-checks.yaml
+++ b/.github/workflows/wait-for-checks.yaml
@@ -17,7 +17,19 @@ jobs:
     permissions:
       checks: read
     steps:
-      - uses: poseidon/wait-for-status-checks@899c768d191b56eef585c18f8558da19e1f3e707 # v0.6.0
-        with:
-          token: ${{ github.token }}
-          ignore: generateDiffCommentBody,postDiffComment
+      - env:
+          GH_TOKEN: ${{ github.token }}
+          CHANGE_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+          IGNORED_JOBS: generateDiffCommentBody,postDiffComment
+          CURRENT_JOB: ${{ github.job }}
+        timeout-minutes: 60
+        run: |
+          [[ "$RUNNER_DEBUG" == 1 ]] && set -x
+          set -e
+          set -o pipefail
+
+          until ! unfinished_jobs="$(gh api --paginate "/repos/${GITHUB_REPOSITORY}/commits/${CHANGE_SHA}/check-runs" | jq --arg ignored "$IGNORED_JOBS,$CURRENT_JOB" -e '.check_runs | map(select(([.conclusion] | inside(["success","skipped"]) | not) and ([.name] | inside($ignored | split(",")) | not))) | map("\(.name) (\(.conclusion // .status))") | if length == 0 then halt_error(1) end')"; do
+            echo "The following jobs are not (successfully) finished yet:" >&2
+            echo "$unfinished_jobs" >&2
+            sleep 5
+          done


### PR DESCRIPTION
since <https://github.com/poseidon/wait-for-status-checks/issues/383>
apparently won't be addressed, this should implement that

No checks aside from `IGNORED_JOBS` and `CURRENT_JOB` (self-ref loop)
are allowed to be not `SUCCESS` or `SKIPPED`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Enhanced our automated process for monitoring pull request updates, ensuring more reliable and timely status reports during job execution with a direct script implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->