### PR TITLE
feat(base-cluster/monitoring): rename alloy to be a generic name

### DIFF
--- a/charts/base-cluster/templates/monitoring/alloy.yaml
+++ b/charts/base-cluster/templates/monitoring/alloy.yaml
@@ -2,7 +2,7 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: alloy
+  name: telemetry-collector
   namespace: monitoring
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
     app.kubernetes.io/component: alloy
@@ -23,6 +23,7 @@ spec:
     - name: kube-prometheus-stack
       namespace: monitoring
   values:
+    fullnameOverride: telemetry-collector
     {{- if .Values.global.imageRegistry }}
     global:
       image:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

The release updates the monitoring configuration to ensure greater consistency and clarity across deployments. End-users will notice a unified naming approach that enhances overall system integration.

- **Chores**
  - Renamed a key monitoring component to "telemetry-collector" for improved identification.
  - Introduced an override setting within the configuration to ensure consistent resource naming across various deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->