### PR TITLE
fix(teuto-cnpg): replace `_` in database name with `-`

### DIFF
--- a/charts/teuto-cnpg/templates/databases.yaml
+++ b/charts/teuto-cnpg/templates/databases.yaml
@@ -1,10 +1,14 @@
 {{- $databases := dict -}}
+{{- $databaseRegex := "^[a-z_]([a-z0-9_]*[a-z0-9])?$" -}}
 {{- if kindIs "string" .Values.databases -}}
   {{- $databases = .Values.databases | fromYaml -}}
 {{- else -}}
   {{- $databases = .Values.databases -}}
 {{- end -}}
 {{- range $name, $owner := $databases -}}
+  {{- if not (mustRegexMatch $databaseRegex $name) -}}
+    {{- fail (printf "database name '%s' must match '%s'" $name $databaseRegex) -}}
+  {{- end -}}
 apiVersion: postgresql.cnpg.io/v1
 kind: Database
 metadata:

--- a/charts/teuto-cnpg/templates/databases.yaml
+++ b/charts/teuto-cnpg/templates/databases.yaml
@@ -8,7 +8,7 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Database
 metadata:
-  name: {{ printf "%s-%s" $.Release.Name $name }}
+  name: {{ printf "%s-%s" $.Release.Name ($name | replace "_" "-") }}
   namespace: {{ $.Release.Namespace }}
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
 spec:


### PR DESCRIPTION
this is not breaking, as this wouldn't have been rolled out with a `_`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated the naming convention for database resources so that names now use hyphens instead of underscores, ensuring consistency in how resource identifiers are displayed.
  - Introduced a validation mechanism for database names to ensure they conform to a specified format, improving error handling for invalid entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->