### PR TITLE
chore(base-cluster): migrate kyverno registries

### DIFF
--- a/.github/image_licenses.yaml
+++ b/.github/image_licenses.yaml
@@ -95,24 +95,9 @@ licenses:
   ghcr.io/jimmidyson/configmap-reload:
     license: Apache-2.0
     licenseLink: https://github.com/jimmidyson/configmap-reload/pkgs/container/configmap-reload
-  ghcr.io/kyverno/background-controller:
-    license: Apache-2.0
-    licenseLink: https://github.com/kyverno/kyverno/pkgs/container/background-controller
-  ghcr.io/kyverno/cleanup-controller:
-    license: Apache-2.0
-    licenseLink: https://github.com/kyverno/kyverno/pkgs/container/cleanup-controller
-  ghcr.io/kyverno/kyverno:
-    license: Apache-2.0
-    licenseLink: https://github.com/kyverno/kyverno/pkgs/container/kyverno
   ghcr.io/kyverno/kyverno-cli:
     license: Apache-2.0
     licenseLink: https://github.com/kyverno/kyverno/pkgs/container/kyverno-cli
-  ghcr.io/kyverno/kyvernopre:
-    license: Apache-2.0
-    licenseLink: https://github.com/kyverno/kyverno/pkgs/container/kyvernopre
-  ghcr.io/kyverno/reports-controller:
-    license: Apache-2.0
-    licenseLink: https://github.com/kyverno/kyverno/pkgs/container/reports-controller
   ghcr.io/teutonet/oci-images/ckan:
     license: MIT
     licenseLink: https://github.com/teutonet/oci-images/blob/main/LICENSE
@@ -185,6 +170,21 @@ licenses:
   quay.io/prometheus/prometheus:
     license: Apache-2.0
     licenseLink: https://github.com/prometheus/prometheus/blob/main/LICENSE
+  reg.kyverno.io/kyverno/background-controller:
+    license: Apache-2.0
+    licenseLink: https://github.com/kyverno/kyverno/pkgs/container/background-controller
+  reg.kyverno.io/kyverno/cleanup-controller:
+    license: Apache-2.0
+    licenseLink: https://github.com/kyverno/kyverno/pkgs/container/cleanup-controller
+  reg.kyverno.io/kyverno/kyverno:
+    license: Apache-2.0
+    licenseLink: https://github.com/kyverno/kyverno/pkgs/container/kyverno
+  reg.kyverno.io/kyverno/kyvernopre:
+    license: Apache-2.0
+    licenseLink: https://github.com/kyverno/kyverno/pkgs/container/kyvernopre
+  reg.kyverno.io/kyverno/reports-controller:
+    license: Apache-2.0
+    licenseLink: https://github.com/kyverno/kyverno/pkgs/container/reports-controller
   registry-gitlab.teuto.net/4teuto/dev/teuto-portal/teuto-portal-k8s-worker/teuto-portal-k8s-worker:
     license: Apache-2.0
     licenseLink: https://gitlab.teuto.net/4teuto/dev/teuto-portal/teuto-portal-k8s-worker/-/blob/main/gradlew?ref_type=heads

--- a/.github/trusted_registries.yaml
+++ b/.github/trusted_registries.yaml
@@ -28,10 +28,11 @@ mirror.gcr.io:
   aquasec: ALL_IMAGES
 ghcr.io:
   aquasecurity: ALL_IMAGES
-  kyverno: ALL_IMAGES
   teutonet: ALL_IMAGES
   jimmidyson:
     configmap-reload: ALL_TAGS
+reg.kyverno.io:
+  kyverno: ALL_IMAGES
 quay.io:
   cilium: ALL_IMAGES
   jetstack: ALL_IMAGES

--- a/.github/trusted_registries.yaml
+++ b/.github/trusted_registries.yaml
@@ -29,6 +29,8 @@ mirror.gcr.io:
 ghcr.io:
   aquasecurity: ALL_IMAGES
   teutonet: ALL_IMAGES
+  kyverno:
+    kyverno-cli: ALL_TAGS
   jimmidyson:
     configmap-reload: ALL_TAGS
 reg.kyverno.io:

--- a/.github/workflows/release-update-metadata.yaml
+++ b/.github/workflows/release-update-metadata.yaml
@@ -86,7 +86,6 @@ jobs:
 
       - run: ./.github/scripts/prepare-values.sh "charts/$CHART"
       - run: ./.github/scripts/extract-artifacthub-images.sh "charts/$CHART"
-      - run: ./.github/scripts/enforce-trusted-registries.sh "charts/$CHART"
       - name: Commit artifacthub images
         uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9
         with:


### PR DESCRIPTION
chore(ci): remove unnecessary enforce-trusted-registries call


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated trusted registries by moving kyverno images to a new registry.
  - Simplified the release workflow by removing a step related to enforcing trusted registries.
  - Updated image license declarations to reflect the new registry location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->