### PR TITLE
chore(ci): use bot token for wait-for-checks

### DIFF
--- a/.github/workflows/wait-for-checks.yaml
+++ b/.github/workflows/wait-for-checks.yaml
@@ -18,7 +18,7 @@ jobs:
       checks: read
     steps:
       - env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}
           CHANGE_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
           IGNORED_JOBS: generateDiffCommentBody,postDiffComment
           CURRENT_JOB: ${{ github.job }}


### PR DESCRIPTION
wait-for-checks could be doing 720 calls per hour per PR, which is 72%
_of the whole budget_ for the github actions bot

This way it's just ~14% for our bot account


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the authentication token used in GitHub workflow for improved integration with GitHub API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->