### PR TITLE
feat(base-cluster/monitoring): allow upsizing tempo storage

### DIFF
--- a/charts/base-cluster/templates/monitoring/tracing/grafana-tempo.yaml
+++ b/charts/base-cluster/templates/monitoring/tracing/grafana-tempo.yaml
@@ -22,6 +22,8 @@ spec:
       imageRegistry: {{ $.Values.global.imageRegistry }}
     {{- end }}
     ingester: {{- include "common.resourcesWithPreset" .Values.monitoring.tracing.ingester | nindent 6 }}
+      persistence:
+        size: {{ .Values.monitoring.tracing.ingester.persistence.size }}
       networkPolicy:
         allowExternalEgress: false
     compactor:

--- a/charts/base-cluster/values.schema.json
+++ b/charts/base-cluster/values.schema.json
@@ -985,6 +985,15 @@
                 },
                 "resources": {
                   "$ref": "#/$defs/resourceRequirements"
+                },
+                "persistence": {
+                  "type": "object",
+                  "properties": {
+                    "size": {
+                      "$ref": "#/$defs/quantity"
+                    }
+                  },
+                  "additionalProperties": false
                 }
               },
               "additionalProperties": false

--- a/charts/base-cluster/values.yaml
+++ b/charts/base-cluster/values.yaml
@@ -341,6 +341,8 @@ monitoring:
     ingester:
       resourcesPreset: small
       resources: {}
+      persistence:
+        size: 10Gi
 
 descheduler:
   enabled: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable persistent storage size for the tracing ingester component in monitoring settings.
- **Documentation**
  - Updated configuration schema and default values to include the new persistence option for the tracing ingester.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->