### PR TITLE
chore(ckan): support external db

### DIFF
--- a/charts/ckan/templates/ckan/post-install.yaml
+++ b/charts/ckan/templates/ckan/post-install.yaml
@@ -19,8 +19,9 @@ spec:
       initContainers:
         - name: wait-for-postgresql
           image: docker.io/bitnami/postgresql:17
-          command: [ 'sh', '-c', 'until pg_isready -U $CKAN_DB_USER -d $CKAN_DB -h {{ printf "%s-%s" (include "ckan.postgresql.fullname" . ) "primary" }} -p 5432; do echo waiting for database; sleep 2; done;' ]
+          command: [ 'sh', '-c', 'until pg_isready -U $CKAN_DB_USER -d $CKAN_DB -h $POSTGRES_HOST -p 5432; do echo waiting for database; sleep 2; done;' ]
           env:
+            {{- if .Values.postgresql.enabled }}
             - name: CKAN_DB_USER
               valueFrom:
                 secretKeyRef:
@@ -31,6 +32,12 @@ spec:
                 secretKeyRef:
                   name: {{ printf "%s-config" (include "ckan.postgresql.fullname" . ) }}
                   key: ckanDatabase
+            - name: POSTGRES_HOST
+              value: {{ printf "%s-%s" (include "ckan.postgresql.fullname" . ) "primary" }}
+            {{- end }}
+            {{- if .Values.ckan.extraEnvVars }}
+              {{- include "common.tplvalues.render" (dict "value" .Values.ckan.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
         - name: ckan-initiate
           image: {{ include "common.images.image" (dict "imageRoot" .Values.ckan.image "global" .Values.global) }}
           command: ["sh","-c","/srv/app/ckan-init.sh"]
@@ -50,6 +57,7 @@ spec:
                 secretKeyRef:
                   name: {{ printf "%s-%s-config" (include "common.names.fullname" $) $name }}
                   key: sysAdminEmail
+            {{- if .Values.postgresql.enabled }}
             - name: POSTGRES_USER
               value: postgres
             - name: POSTGRES_PASSWORD
@@ -97,6 +105,10 @@ spec:
               value: "postgresql://$(CKAN_DB_USER):$(CKAN_DB_PASSWORD)@{{ printf "%s-%s" (include "ckan.postgresql.fullname" . ) "primary" }}/$(DATASTORE_DB)"
             - name: CKAN_DATASTORE_READ_URL
               value: "postgresql://$(DATASTORE_READONLY_USER):$(DATASTORE_READONLY_PASSWORD)@{{ printf "%s-%s" (include "ckan.postgresql.fullname" . ) "read" }}/$(DATASTORE_DB)"
+            {{- end }}
+            {{- if .Values.ckan.extraEnvVars }}
+              {{- include "common.tplvalues.render" (dict "value" .Values.ckan.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
             - name: CKAN_SOLR_URL
               value: "http://{{ printf "%s-%s" (include "ckan.solr.fullname" . ) "headless" }}:{{ include "ckan.solr.service.port" $ }}/solr/ckan"
             {{- if .Values.solr.auth.enabled }}
@@ -169,6 +181,24 @@ spec:
           volumeMounts:
             - mountPath: /api-tokens
               name: api-tokens-volume
+        {{- if and (not .Values.postgresql.enabled) .Values.ckan.postInstall.postgresInit.enabled }}
+        - name: postgres-init
+          image: docker.io/bitnami/postgresql:17
+          command:
+            - "/bin/sh"
+            - "-c"
+            - "psql $PSQL_CONNECTION_STRING -f /script/10_set_permissions.sh"
+          env:
+            - name: PSQL_CONNECTION_STRING
+              value: "postgresql://$(CKAN_DB_USER):$(CKAN_DB_PASSWORD)@${POSTGRES_HOST}/$(CKAN_DB)"
+            {{- if .Values.ckan.postInstall.postgresInit.extraEnvVars }}
+              {{- include "common.tplvalues.render" (dict "value" .Values.ckan.postInstall.postgresInit.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
+          volumeMounts:
+            - mountPath: /script
+              readOnly: true
+              name: script-volume
+        {{- end }}
       containers:
         - name: postinstall-config
           image: docker.io/busybox:1.28
@@ -180,3 +210,8 @@ spec:
             name: {{ printf "%s-%s-configmap" (include "common.names.fullname" .) "ckan" }}
         - name: api-tokens-volume
           emptyDir: {}
+        {{- if and (not .Values.postgresql.enabled) .Values.ckan.postInstall.postgresInit.enabled }}
+        - name: script-volume
+          secret:
+            secretName: {{ printf "%s-initconfig" (include "ckan.postgresql.fullname" . )}}
+        {{- end }}

--- a/charts/ckan/templates/datapusher/deployment.yaml
+++ b/charts/ckan/templates/datapusher/deployment.yaml
@@ -28,8 +28,6 @@ spec:
       containers:
         - name: {{ printf "%s-%s" .Chart.Name $name }}
           #env: TODO Container ned psycopg2
-          #  - name: DATAPUSHER_SQLALCHEMY_DATABASE_URI
-          #    value: "postgresql://{{ .Values.postgresql.auth.username }}:{{ .Values.postgresql.auth.password }}@main-postgresql/{{ .Values.postgresql.auth.database}}"
           securityContext:
           {{- toYaml .Values.datapusher.securityContext | default dict | nindent 12 }}
           image: {{ printf "%s/%s" ($.Values.global.imageRegistry | default (include "ckan.defaultRegistry" (dict))) (include "common.images.image" (dict "imageRoot" .Values.datapusher.image "global" .Values.global)) }}

--- a/charts/ckan/templates/postgresql/initconfig.yaml
+++ b/charts/ckan/templates/postgresql/initconfig.yaml
@@ -7,6 +7,7 @@ metadata:
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: {{ $name }}
 stringData:
+  {{- if .Values.postgresql.enabled }}
   00_initdb.sh: |
     #!/bin/bash
     set -e
@@ -19,11 +20,12 @@ stringData:
       CREATE ROLE ${DATAPUSHER_USER} WITH NOSUPERUSER NOCREATEDB NOCREATEROLE LOGIN PASSWORD '${DATAPUSHER_PASSWORD}';
       CREATE DATABASE ${DATAPUSHER_DB} OWNER ${DATAPUSHER_USER} ENCODING 'utf-8';
     EOSQL
-
+  {{- end }}
   10_set_permissions.sh: |
     #!/bin/bash
     set -e
 
+    {{- if .Values.postgresql.enabled }}
     psql -U postgres -d $DATASTORE_DB <<EOSQL
       -- revoke permissions for the read-only user
       REVOKE CREATE ON SCHEMA public FROM PUBLIC;
@@ -45,7 +47,10 @@ stringData:
       -- grant access to new tables and views by default
       ALTER DEFAULT PRIVILEGES FOR USER ${CKANDB_USER} IN SCHEMA public
       GRANT SELECT ON TABLES TO ${DATASTORE_USER};
+      {{ else }}
+    psql -U $CKANDB_USER -d $DATASTORE_DB <<EOSQL
 
+      {{- end }}
       -- a view for listing valid table (resource id) and view names
       CREATE OR REPLACE VIEW "_table_metadata" AS
           SELECT DISTINCT

--- a/charts/ckan/templates/postgresql/secret.yaml
+++ b/charts/ckan/templates/postgresql/secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.postgresql.enabled }}
 {{- $name := (printf "%s-config" (include "ckan.postgresql.fullname" .)) -}}
 {{- $postgresPassword := include "common.secrets.passwords.manage" (dict "secret" $name "length" 42 "strong" false "key" "postgresPassword" "providedValues" (list "postgresql.ckanDbs.postgresPassword") "skipB64enc" true "context" (dict "Values" .Values "Release" ((dict "IsUpgrade" false "IsInstall" true "Namespace" .Release.Namespace) | mergeOverwrite (deepCopy .Release)))) }}
 {{- $replicationPassword := include "common.secrets.passwords.manage" (dict "secret" $name "length" 42 "strong" false "key" "replicationPassword" "providedValues" (list "postgresql.ckanDbs.replicationPassword") "skipB64enc" true "context" (dict "Values" .Values "Release" ((dict "IsUpgrade" false "IsInstall" true "Namespace" .Release.Namespace) | mergeOverwrite (deepCopy .Release)))) }}
@@ -27,3 +28,4 @@ stringData:
   datapusherUsername: {{ .Values.postgresql.ckanDbs.datapusher.username | default "datapusher" | quote}}
   datapusherPassword: {{ $datapusherPassword }}
   datapusherDatabase: {{ .Values.postgresql.ckanDbs.datapusher.db | default "datapusherdb" | quote}}
+{{- end }}

--- a/charts/ckan/values.schema.json
+++ b/charts/ckan/values.schema.json
@@ -54,6 +54,29 @@
         }
       },
       "properties": {
+        "postInstall": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "postgresInit": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "extraEnvVars": {
+                  "type": [
+                    "array",
+                    "string"
+                  ],
+                  "default": [],
+                  "items": {}
+                }
+              }
+            }
+          }
+        },
         "locales": {
           "type": "object",
           "additionalProperties": false,

--- a/charts/ckan/values.yaml
+++ b/charts/ckan/values.yaml
@@ -62,6 +62,24 @@ ckan:
   extraEnvVars: []
   extraVolumeMounts: []
   extraVolumes: []
+  postInstall:
+    postgresInit:
+      enabled: false
+      extraEnvVars:
+        - name: CKAN_DB_USER
+          valueFrom:
+            secretKeyRef:
+              name: ""
+              key: username
+        - name: CKAN_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: ""
+              key: password
+        - name: CKAN_DB
+          value: ckan
+        - name: POSTGRES_HOST
+          value: HOST
   ingress:
     ingressClassName: ""
     annotations: {}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for an optional PostgreSQL initialization step during post-install when using an external database, with configurable environment variables.
  - Introduced new configuration options under `ckan.postInstall.postgresInit` to control this behavior.

- **Improvements**
  - Enhanced flexibility by conditionally including environment variables, init containers, and scripts based on whether PostgreSQL is enabled or managed externally.
  - Secret creation and initialization scripts are now only included when relevant, reducing unnecessary resource creation.

- **Cleanup**
  - Removed obsolete commented environment variable lines from the datapusher deployment configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->