### PR TITLE
chore(ckan): change env order

### DIFF
--- a/charts/ckan/templates/ckan/post-install.yaml
+++ b/charts/ckan/templates/ckan/post-install.yaml
@@ -189,11 +189,11 @@ spec:
             - "-c"
             - "psql $PSQL_CONNECTION_STRING -f /script/10_set_permissions.sh"
           env:
-            - name: PSQL_CONNECTION_STRING
-              value: "postgresql://$(CKAN_DB_USER):$(CKAN_DB_PASSWORD)@${POSTGRES_HOST}/$(CKAN_DB)"
             {{- if .Values.ckan.postInstall.postgresInit.extraEnvVars }}
               {{- include "common.tplvalues.render" (dict "value" .Values.ckan.postInstall.postgresInit.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
+            - name: PSQL_CONNECTION_STRING
+              value: "postgresql://$(CKAN_DB_USER):$(CKAN_DB_PASSWORD)@${POSTGRES_HOST}/$(CKAN_DB)"
           volumeMounts:
             - mountPath: /script
               readOnly: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Adjusted the order of environment variables in the post-install configuration to ensure custom variables are listed before the default PostgreSQL connection string. No changes to functionality or values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->