### PR TITLE
chore(ckan): remove ext postgres config

### DIFF
--- a/charts/ckan/templates/ckan/post-install.yaml
+++ b/charts/ckan/templates/ckan/post-install.yaml
@@ -181,22 +181,6 @@ spec:
           volumeMounts:
             - mountPath: /api-tokens
               name: api-tokens-volume
-        {{- if and (not .Values.postgresql.enabled) .Values.ckan.postInstall.postgresInit.enabled }}
-        - name: postgres-init
-          image: docker.io/bitnami/postgresql:17
-          command:
-            - "/bin/sh"
-            - "-c"
-            - "psql -U $CKAN_DB_USER -d $CKAN_DB -h $POSTGRES_HOST -p 5432 -f /script/10_set_permissions.sh"
-          env:
-            {{- if .Values.ckan.postInstall.postgresInit.extraEnvVars }}
-              {{- include "common.tplvalues.render" (dict "value" .Values.ckan.postInstall.postgresInit.extraEnvVars "context" $) | nindent 12 }}
-            {{- end }}
-          volumeMounts:
-            - mountPath: /script
-              readOnly: true
-              name: script-volume
-        {{- end }}
       containers:
         - name: postinstall-config
           image: docker.io/busybox:1.28
@@ -208,8 +192,3 @@ spec:
             name: {{ printf "%s-%s-configmap" (include "common.names.fullname" .) "ckan" }}
         - name: api-tokens-volume
           emptyDir: {}
-        {{- if and (not .Values.postgresql.enabled) .Values.ckan.postInstall.postgresInit.enabled }}
-        - name: script-volume
-          secret:
-            secretName: {{ printf "%s-initconfig" (include "ckan.postgresql.fullname" . )}}
-        {{- end }}

--- a/charts/ckan/templates/postgresql/initconfig.yaml
+++ b/charts/ckan/templates/postgresql/initconfig.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.postgresql.enabled }}
 {{- $name := "postgresql" -}}
 apiVersion: v1
 kind: Secret
@@ -7,7 +8,6 @@ metadata:
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: {{ $name }}
 stringData:
-  {{- if .Values.postgresql.enabled }}
   00_initdb.sh: |
     #!/bin/bash
     set -e
@@ -20,12 +20,10 @@ stringData:
       CREATE ROLE ${DATAPUSHER_USER} WITH NOSUPERUSER NOCREATEDB NOCREATEROLE LOGIN PASSWORD '${DATAPUSHER_PASSWORD}';
       CREATE DATABASE ${DATAPUSHER_DB} OWNER ${DATAPUSHER_USER} ENCODING 'utf-8';
     EOSQL
-  {{- end }}
   10_set_permissions.sh: |
     #!/bin/bash
     set -e
 
-    {{- if .Values.postgresql.enabled }}
     psql -U postgres -d $DATASTORE_DB <<EOSQL
       -- revoke permissions for the read-only user
       REVOKE CREATE ON SCHEMA public FROM PUBLIC;
@@ -47,10 +45,7 @@ stringData:
       -- grant access to new tables and views by default
       ALTER DEFAULT PRIVILEGES FOR USER ${CKANDB_USER} IN SCHEMA public
       GRANT SELECT ON TABLES TO ${DATASTORE_USER};
-      {{ else }}
-    psql -U $CKANDB_USER -d $DATASTORE_DB <<EOSQL
 
-      {{- end }}
       -- a view for listing valid table (resource id) and view names
       CREATE OR REPLACE VIEW "_table_metadata" AS
           SELECT DISTINCT
@@ -108,3 +103,4 @@ stringData:
           END;
       \$\$;
     EOSQL
+  {{- end }}

--- a/charts/ckan/values.schema.json
+++ b/charts/ckan/values.schema.json
@@ -54,29 +54,6 @@
         }
       },
       "properties": {
-        "postInstall": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "postgresInit": {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "enabled": {
-                  "type": "boolean"
-                },
-                "extraEnvVars": {
-                  "type": [
-                    "array",
-                    "string"
-                  ],
-                  "default": [],
-                  "items": {}
-                }
-              }
-            }
-          }
-        },
         "locales": {
           "type": "object",
           "additionalProperties": false,

--- a/charts/ckan/values.yaml
+++ b/charts/ckan/values.yaml
@@ -62,24 +62,6 @@ ckan:
   extraEnvVars: []
   extraVolumeMounts: []
   extraVolumes: []
-  postInstall:
-    postgresInit:
-      enabled: false
-      extraEnvVars:
-        - name: CKAN_DB_USER
-          valueFrom:
-            secretKeyRef:
-              name: ""
-              key: username
-        - name: CKAN_DB_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: ""
-              key: password
-        - name: CKAN_DB
-          value: ckan
-        - name: POSTGRES_HOST
-          value: HOST
   ingress:
     ingressClassName: ""
     annotations: {}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed configuration options and related logic for post-install PostgreSQL initialization.
	- Simplified post-installation process by eliminating conditional steps and associated settings.
	- Streamlined configuration files by removing unused schema and values related to post-install database setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->