### PR TITLE
chore(ckan): use primary valkey instance

### DIFF
--- a/charts/ckan/templates/ckan/deployment.yaml
+++ b/charts/ckan/templates/ckan/deployment.yaml
@@ -153,7 +153,7 @@ spec:
                   name: {{ printf "%s" (include "ckan.valkey.fullname" . ) }}
                   key: valkey-password
             - name: CKAN_REDIS_URL
-              value: "redis://default:$(VALKEY_PASSWORD)@{{ printf "%s-%s" (include "ckan.valkey.fullname" . ) "headless" }}:{{ include "ckan.valkey.service.port" $}}/0"
+              value: "redis://default:$(VALKEY_PASSWORD)@{{ printf "%s-%s" (include "ckan.valkey.fullname" . ) "primary" }}:{{ include "ckan.valkey.service.port" $}}/0"
             - name: CKAN_DATAPUSHER_URL
               value: "http://{{ printf "%s-%s" (include "common.names.fullname" $) "datapusher" }}:{{ include "ckan.datapusher.service.port" $ }}"
             - name: CKAN_DATAPUSHER_FORMATS


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Redis connection configuration to use a different service endpoint within the deployment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->