### PR TITLE
chore(ckan): add valkey license to json

### DIFF
--- a/.github/image_licenses.yaml
+++ b/.github/image_licenses.yaml
@@ -26,9 +26,9 @@ licenses:
   docker.io/bitnami/postgresql:
     license: PostgreSQL
     licenseLink: https://www.postgresql.org/about/licence/
-  docker.io/bitnami/redis:
-    license: SSPL-1.0
-    licenseLink: https://redis.io/legal/licenses/
+  docker.io/bitnami/valkey:
+    license: Apache-2.0
+    licenseLink: https://hub.docker.com/r/bitnami/valkey
   docker.io/bitnami/zookeeper:
     license: Apache-2.0
     licenseLink: https://zookeeper.apache.org/


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated license information for Docker images, replacing the Redis image entry with the Valkey image and its associated license details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->