### PR TITLE
fix(ckan): Revert "chore(ckan): add missing valkey license"

### DIFF
--- a/charts/ckan/Chart.yaml
+++ b/charts/ckan/Chart.yaml
@@ -46,4 +46,3 @@ annotations:
     - image: ghcr.io/teutonet/oci-images/ckan:1.0.14@sha256:a7486198683ea62f8b264775fd4162d0bdb403d9914c1dd95f9c364be097d63b       #  default/Deployment/ckan-ckan.yaml
     - image: ghcr.io/teutonet/oci-images/ckan:1.0.14@sha256:a7486198683ea62f8b264775fd4162d0bdb403d9914c1dd95f9c364be097d63b       #  default/Job/ckan-ckan-post-install.yaml
     - image: ghcr.io/teutonet/oci-images/solr-ckan:1.0.25@sha256:cf36ee93a50ffeeb3dc53298ed0e7d92152896c6fcb1e1ac199363eb883dc971  #  default/StatefulSet/ckan-solr.yaml
-  artifacthub.io/image-licenses.docker.io/bitnami/valkey: Apache-2.0


### PR DESCRIPTION
Reverts teutonet/teutonet-helm-charts#1472

This is not how this is done, see https://github.com/teutonet/teutonet-helm-charts/pull/1471, nor is this even supposed to be done at all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed the license annotation for the Docker image "docker.io/bitnami/valkey" from the chart metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->