### PR TITLE
fix(ckan/license): set correct license

### DIFF
--- a/.github/image_licenses.yaml
+++ b/.github/image_licenses.yaml
@@ -27,7 +27,7 @@ licenses:
     license: PostgreSQL
     licenseLink: https://www.postgresql.org/about/licence/
   docker.io/bitnami/valkey:
-    license: Apache-2.0
+    license: BSD-3
     licenseLink: https://hub.docker.com/r/bitnami/valkey
   docker.io/bitnami/zookeeper:
     license: Apache-2.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the displayed license type for the Docker image `docker.io/bitnami/valkey` from Apache-2.0 to BSD-3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->