### PR TITLE
chore(base-cluster/monitoring): remove deprecated plugin

### DIFF
--- a/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_grafana-config.yaml
+++ b/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_grafana-config.yaml
@@ -62,7 +62,6 @@ admin:
   userKey: username
   passwordKey: password
 plugins:
-  - grafana-piechart-panel
   {{- with .Values.monitoring.grafana.additionalPlugins }}
   {{- toYaml . | nindent 2 }}
   {{- end }}


### PR DESCRIPTION
this panel is already included anyways, see
<https://grafana.com/grafana/plugins/grafana-piechart-panel>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated Grafana configuration to only include plugins specified by user settings, removing the default inclusion of the "grafana-piechart-panel" plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->