### PR TITLE
feat(base-cluster/monitoring): also read secrets for datasources

### DIFF
--- a/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_grafana-config.yaml
+++ b/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_grafana-config.yaml
@@ -94,7 +94,7 @@ sidecar:
     searchNamespace: ALL
   datasources:
     enabled: true
-    resource: configmap
+    resource: both
     searchNamespace: ALL
   resources: {{- include "common.resources" .Values.monitoring.grafana.sidecar | nindent 4 }}
   securityContext: {{- include "base-cluster.prometheus-stack.containerSecurityContext" (dict) | nindent 4 }}


### PR DESCRIPTION
see <https://github.com/kiwigrid/k8s-sidecar#:~:text=string-,RESOURCE,-Resource%20type%2C%20which>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Grafana configuration to allow the sidecar to manage datasources from both ConfigMaps and Secrets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->