### PR TITLE
chore(t8s-cluster): pin versions

### DIFF
--- a/.github/trusted_registries.yaml
+++ b/.github/trusted_registries.yaml
@@ -48,8 +48,12 @@ registry.k8s.io:
   kube-state-metrics: ALL_IMAGES
   sig-storage:
     nfs-provisioner: ALL_TAGS
+    csi-attacher: ALL_TAGS
+    csi-node-driver-registrar: ALL_TAGS
+    csi-provisioner: ALL_TAGS
+    csi-resizer: ALL_TAGS
+    csi-snapshotter: ALL_TAGS
+    livenessprobe: ALL_TAGS
   etcd: ALL_TAGS
   provider-os: ALL_IMAGES
-k8s.gcr.io:
-  sig-storage: ALL_IMAGES
 registry-gitlab.teuto.net: ALL_IMAGES

--- a/charts/t8s-cluster/templates/workload-cluster/cinder-csi-plugin/cinder-csi-plugin.yaml
+++ b/charts/t8s-cluster/templates/workload-cluster/cinder-csi-plugin/cinder-csi-plugin.yaml
@@ -1,3 +1,5 @@
+{{- $repoCharts := (index .Values.global.helmRepositories "cloud-provider-openstack").charts -}}
+{{- $selectedVersion := default (index $repoCharts "openstack-cinder-csi") (index $repoCharts (printf "openstack-cinder-csi 2.%d.x" ($.Values.version.minor | int))) -}}
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -13,7 +15,7 @@ spec:
         kind: HelmRepository
         name: {{ printf "%s-cloud-provider-openstack" .Release.Name }}
         namespace: {{ .Release.Namespace }}
-      version: {{ printf "2.%d.x" (.Values.version.minor | int) }}
+      version: {{ $selectedVersion | quote }}
   interval: 1h
   driftDetection:
     mode: enabled

--- a/charts/t8s-cluster/templates/workload-cluster/cloud-controller-manager.yaml
+++ b/charts/t8s-cluster/templates/workload-cluster/cloud-controller-manager.yaml
@@ -1,3 +1,5 @@
+{{- $repoCharts := (index .Values.global.helmRepositories "cloud-provider-openstack").charts -}}
+{{- $selectedVersion := default (index $repoCharts "openstack-cloud-controller-manager") (index $repoCharts (printf "openstack-cloud-controller-manager 2.%d.x" ($.Values.version.minor | int))) -}}
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -12,7 +14,7 @@ spec:
         kind: HelmRepository
         name: {{ printf "%s-cloud-provider-openstack" .Release.Name }}
         namespace: {{ .Release.Namespace }}
-      version: {{ printf "2.%d.x" (.Values.version.minor | int) }}
+      version: {{ $selectedVersion | quote }}
   interval: 1h
   driftDetection:
     mode: enabled

--- a/charts/t8s-cluster/values.yaml
+++ b/charts/t8s-cluster/values.yaml
@@ -4,15 +4,28 @@ global:
     cilium:
       url: https://helm.cilium.io
       charts:
-        cilium: 1.x.x
+        cilium: 1.17.4
       condition: '{{ eq (include "t8s-cluster.cni" .) "cilium" }}'
     nvidia:
       url: https://helm.ngc.nvidia.com/nvidia
       charts:
-        gpu-operator: 24.x
+        gpu-operator: 24.9.2
       condition: '{{ include "t8s-cluster.hasGPUNodes" (dict "context" $) }}'
     cloud-provider-openstack:
       url: https://kubernetes.github.io/cloud-provider-openstack
+      charts:
+        openstack-cloud-controller-manager: 2.32.0
+        openstack-cloud-controller-manager 2.31.x: 2.31.3
+        openstack-cloud-controller-manager 2.30.x: 2.30.5
+        openstack-cloud-controller-manager 2.29.x: 2.29.3
+        openstack-cloud-controller-manager 2.28.x: 2.28.5
+        openstack-cloud-controller-manager 2.27.x: 2.27.6
+        openstack-cinder-csi: 2.32.0
+        openstack-cinder-csi 2.31.x: 2.31.7
+        openstack-cinder-csi 2.30.x: 2.30.3
+        openstack-cinder-csi 2.29.x: 2.29.2
+        openstack-cinder-csi 2.28.x: 2.28.3
+        openstack-cinder-csi 2.27.x: 2.27.3
     cetic:
       url: https://cetic.github.io/helm-charts
   etcd:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Improved version selection logic for OpenStack Cinder CSI and Cloud Controller Manager components, enabling more flexible and context-aware deployment based on available chart versions.

- **Chores**
  - Updated Helm chart dependencies to use specific, pinned versions for Cilium, NVIDIA GPU operator, and multiple OpenStack-related charts for enhanced consistency and reproducibility.
  - Added new trusted image entries for CSI-related components under the Kubernetes storage SIG registry and removed the k8s.gcr.io registry entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->