### PR TITLE
chore(base-cluster): change descheduler syntax

### DIFF
--- a/charts/base-cluster/templates/descheduler/descheduler.yaml
+++ b/charts/base-cluster/templates/descheduler/descheduler.yaml
@@ -1,12 +1,6 @@
 {{- if .Values.descheduler.enabled -}}
-{{- $kubeMinorVersion := .Capabilities.KubeVersion.Minor -}}
-{{- $versionMatrix := dict -}}
-{{- $latestVersion := "" -}}
-{{- with .Values.global.helmRepositories.descheduler.charts -}}
-  {{- $versionMatrix = dict 27 .descheduler_27 28 .descheduler_28 29 .descheduler_29 -}}
-  {{- $latestVersion = .descheduler -}}
-{{- end -}}
-{{- $selectedVersion := (hasKey $versionMatrix $kubeMinorVersion) | ternary (index $versionMatrix $kubeMinorVersion) $latestVersion -}}
+  {{- $repoCharts := (index .Values.global.helmRepositories "descheduler").charts -}}
+  {{- $selectedVersion := default (index $repoCharts "descheduler") (index $repoCharts (printf "descheduler 0.%d.x" ($.Capabilities.KubeVersion.Minor | int))) -}}
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -14,9 +8,6 @@ metadata:
   namespace: kube-system
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
     app.kubernetes.io/component: descheduler
-    {{- if ne $selectedVersion $latestVersion }}
-    helmrelease-metrics/ignore: "true"
-    {{- end }}
 spec:
   chart:
     spec:
@@ -25,7 +16,7 @@ spec:
         kind: HelmRepository
         name: descheduler
         namespace: {{ .Release.Namespace }}
-      version: {{ $selectedVersion }}
+      version: {{ $selectedVersion | quote }}
   interval: 1h
   driftDetection:
     mode: enabled

--- a/charts/base-cluster/values.yaml
+++ b/charts/base-cluster/values.yaml
@@ -120,10 +120,10 @@ global:
     descheduler:
       url: https://kubernetes-sigs.github.io/descheduler
       charts:
-        descheduler_27: 0.29.0
-        descheduler_28: 0.30.2
-        descheduler_29: 0.31.2
         descheduler: 0.32.2
+        descheduler 0.29.x: 0.31.2
+        descheduler 0.28.x: 0.30.2
+        descheduler 0.27.x: 0.29.0
       condition: "{{ .Values.descheduler.enabled }}"
     jetstack:
       url: https://charts.jetstack.io


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved the logic for selecting the descheduler chart version, making it more dynamic and flexible based on the Kubernetes minor version.
  - Updated version mappings to use semantic versioning patterns for easier maintenance and clarity in configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->