### PR TITLE
fix(base-cluster/rbac): *RoleBindings should always be prefixed to avoid collision

### DIFF
--- a/charts/base-cluster/templates/rbac/roleBindings.yaml
+++ b/charts/base-cluster/templates/rbac/roleBindings.yaml
@@ -4,13 +4,14 @@
 {{- range $roleName, $roleMapping := $roles -}}
   {{- $clusterMapping := dig "clusterMapping" (dict) $roleMapping -}}
   {{- $namespaceMapping := dig "namespaceMapping" (dict) $roleMapping -}}
+  {{- $roleBindingFullName := printf "%s-%s" (include "common.names.fullname" $) $roleName -}}
   {{- $roleFullName := has $roleName $definedRoles | ternary (printf "%s-%s" (include "common.names.fullname" $) $roleName) $roleName -}}
   {{- range $namespace, $accounts := $namespaceMapping }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ $roleFullName }}
+  name: {{ $roleBindingFullName }}
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
     app.kubernetes.io/component: rbac
   namespace: {{ $namespace }}
@@ -30,7 +31,7 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ $roleFullName }}
+  name: {{ $roleBindingFullName }}
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
     app.kubernetes.io/component: rbac
 subjects:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated naming conventions for RoleBinding and ClusterRoleBinding resources to ensure consistent and clear separation between binding names and referenced role names. No changes to user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->