### PR TITLE
feat(base-cluster/trivy): add the option to add labels to all trivy reports

### DIFF
--- a/charts/base-cluster/templates/monitoring/security/trivy.yaml
+++ b/charts/base-cluster/templates/monitoring/security/trivy.yaml
@@ -69,6 +69,9 @@ spec:
       scanJobCompressLogs: false
       scanJobPodTemplateContainerSecurityContext: *securityContext
       scanJobPodTemplatePodSecurityContext: *podSecurityContext
+      {{- with .Values.monitoring.securityScanning.reportLabels }}
+      additionalReportLabels: {{ toYaml . | nindent 8 }}
+      {{- end }}
     excludeNamespaces: ""
     serviceMonitor:
       enabled: {{ .Values.monitoring.prometheus.enabled }}

--- a/charts/base-cluster/values.schema.json
+++ b/charts/base-cluster/values.schema.json
@@ -967,6 +967,12 @@
                   }
                 }
               }
+            },
+            "reportLabels": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           },
           "additionalProperties": false


### PR DESCRIPTION
This is for example needed if you want to exclude trivy reports from a velero backup.

see `https://github.com/aquasecurity/trivy-operator/blob/main/deploy/helm/README.md?plain=1#L195C3-L195C16`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for specifying additional report labels for Trivy operator reports through an optional configuration parameter. This allows users to customize report labeling in security scanning settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->