### PR TITLE
feat(base-cluster/monitoring): set code_challenge_method for oauth2-proxy

### DIFF
--- a/charts/base-cluster/templates/monitoring/kube-prometheus-stack/oauth-proxy.yaml
+++ b/charts/base-cluster/templates/monitoring/kube-prometheus-stack/oauth-proxy.yaml
@@ -65,6 +65,7 @@ spec:
         {{- else }}
         email_domains = "*"
         {{- end }}
+        code_challenge_method = "S256"
         upstreams = [ {{ printf "http://%s:%d" $targetServiceName $port | quote }} ]
     podAnnotations:
       # This might change on every `template` call, this can be ignored


### PR DESCRIPTION
This prevents token interceptions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated monitoring configuration to explicitly set the OAuth2 code challenge method to "S256" for improved OIDC provider compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->