### PR TITLE
feat(t8s-cluster): add rbac for teuto staff

### DIFF
--- a/charts/t8s-cluster/templates/management-cluster/clusterClass/_authenticationConfig.yaml
+++ b/charts/t8s-cluster/templates/management-cluster/clusterClass/_authenticationConfig.yaml
@@ -9,6 +9,8 @@ jwt:
     claimMappings:
       username:
         expression: claims.email
+      groups:
+        expression: dyn(claims.groups).map(g, "teuto.net:" + g)
     claimValidationRules:
       - expression: (has(claims.email_verified) && claims.email_verified) || !has(claims.email_verified)
         message: email must be verified

--- a/charts/t8s-cluster/templates/workload-cluster/rbac/teuto-clusterrolebinding.yaml
+++ b/charts/t8s-cluster/templates/workload-cluster/rbac/teuto-clusterrolebinding.yaml
@@ -1,0 +1,15 @@
+{{- include "t8s-cluster.helm.resourceIntoCluster" (dict "name" "teuto-rbac" "resource" (include "t8s-cluster.rbac.teuto" (dict)) "context" $ "additionalLabels" (dict "app.kubernetes.io/component" "rbac")) | nindent 0 -}}
+
+{{- define "t8s-cluster.rbac.teuto" -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: teuto-staff
+subjects:
+  - kind: Group
+    name: teuto.net:staff
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+{{- end -}}


### PR DESCRIPTION
This allows the staff users to use OIDC kubeconfigs instead of the admin-conf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added automatic mapping of JWT "groups" claims with a "teuto.net:" prefix for improved authentication integration.
	- Introduced a new RBAC configuration that grants cluster-admin privileges to the "teuto.net:staff" group.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->