### PR TITLE
feat(ci/renovate): up PR limits

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,6 +10,8 @@
   "additionalBranchPrefix": "{{parentDir}}-",
   "separateMinorPatch": true,
   "automerge": true,
+  "prHourlyLimit": 50,
+  "prConcurrentLimit": 20,
   "labels": [
     "dependencies"
   ],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Renovate configuration to limit the number of pull requests opened per hour and concurrently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->