### PR TITLE
feat(base-cluster/monitoring): non-critical alerts aren't routed to on-call

### DIFF
--- a/charts/base-cluster/templates/backup/velero.yaml
+++ b/charts/base-cluster/templates/backup/velero.yaml
@@ -102,5 +102,7 @@ spec:
             expr: velero_backup_last_status{schedule!=""} != 1
             for: 15m
             labels:
-              severity: warning
+              severity: critical
+              period: WorkingHours
+
 {{- end }}

--- a/charts/base-cluster/templates/cert-manager/rules/certificate-expiration.yaml
+++ b/charts/base-cluster/templates/cert-manager/rules/certificate-expiration.yaml
@@ -24,7 +24,8 @@ spec:
             certmanager_certificate_expiration_timestamp_seconds and (certmanager_certificate_expiration_timestamp_seconds - time() <= (60 * 60 * 24 * 14))
           for: 5m
           labels:
-            severity: warning
+            severity: critical
+            period: WorkingHours
         - alert: CertificateExpiringSoon
           annotations:
             description: {{ "Certificate {{ $labels.exported_namespace }}/{{ $labels.name }} will expire in less than 1 week. The certificate will expire at {{ humanizeTimestamp $value }}" | quote }}
@@ -34,4 +35,5 @@ spec:
           for: 5m
           labels:
             severity: critical
+            period: WorkingHours
   {{- end -}}

--- a/charts/base-cluster/templates/flux/rules/flux-status.yaml
+++ b/charts/base-cluster/templates/flux/rules/flux-status.yaml
@@ -24,7 +24,8 @@ spec:
             gotk_reconcile_condition_info{type="Ready",status="False"} == 1
           for: 10m
           labels:
-            severity: warning
+            severity: critical
+            period: WorkingHours
         - alert: MetricsMissing
           annotations:
             description: The flux metrics are missing
@@ -34,4 +35,5 @@ spec:
           for: 5m
           labels:
             severity: critical
+            period: WorkingHours
   {{- end }}

--- a/charts/base-cluster/templates/monitoring/kdave/rules/releases-with-deprecation.yaml
+++ b/charts/base-cluster/templates/monitoring/kdave/rules/releases-with-deprecation.yaml
@@ -24,7 +24,8 @@ spec:
             wf_k8s_deployed_releases_with_deprecated_api_version > 0
           for: 5m
           labels:
-            severity: warning
+            severity: critical
+            period: WorkingHours
         - alert: ReleasesHaveRemovedAPIs
           annotations:
             description: {{ "{{ $value }} releases have removed APIs." | quote }}
@@ -34,4 +35,5 @@ spec:
           for: 5m
           labels:
             severity: critical
+            period: WorkingHours
   {{- end -}}

--- a/charts/base-cluster/templates/nfs-server-provisioner/rules/storage-size.yaml
+++ b/charts/base-cluster/templates/nfs-server-provisioner/rules/storage-size.yaml
@@ -25,5 +25,6 @@ spec:
               sum(kube_persistentvolumeclaim_resource_requests_storage_bytes{namespace="nfs-server-provisioner",persistentvolumeclaim="data-nfs-server-provisioner-0"})) > 0
           for: 1m
           labels:
-            severity: warning
+            severity: critical
+            period: WorkingHours
 {{- end }}


### PR DESCRIPTION
Period WorkingHours prevents this from waking someone up, but it will
still be sent out during the day.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated several monitoring alerts to use a higher severity level ("critical" instead of "warning") for improved visibility.
  - Added a new "period: WorkingHours" label to multiple alerts to indicate active monitoring during business hours.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->