### PR TITLE
feat(base-cluster/rbac): adjust rbac stuff for OIDC accounts

### DIFF
--- a/charts/base-cluster/ci/rbac-emails-values.yaml
+++ b/charts/base-cluster/ci/rbac-emails-values.yaml
@@ -31,7 +31,7 @@ rbac:
           - update
           - patch
   accounts:
-    test:
+    test@example.com:
       roles:
         edit:
           - my-fav-ns

--- a/charts/base-cluster/templates/NOTES.txt
+++ b/charts/base-cluster/templates/NOTES.txt
@@ -43,7 +43,7 @@ Password: $ kubectl -n monitoring get secret {{ $secretName | quote }} -o json |
 {{- if .Values.rbac.accounts }}
 
 ===
-Use the following commands to create a kubeconfig for an account;
+Use the following commands to create a kubeconfig for an account if it's not a user with an email, for that you use OIDC as per your hoster;
 
 function generateKubeconfig() {
   local user="${1?Missing user parameter}"
@@ -71,5 +71,6 @@ users:
 EOF
 }
 
+# example usage:
 $ generateKubeconfig {{ .Values.rbac.accounts | keys | first }}
 {{- end -}}

--- a/charts/base-cluster/templates/rbac/accounts.yaml
+++ b/charts/base-cluster/templates/rbac/accounts.yaml
@@ -1,5 +1,6 @@
 {{- range $name := .Values.rbac.accounts | keys -}}
   {{- $fullName := printf "%s-%s" (include "common.names.fullname" $) $name -}}
+  {{- if not (contains "@" $name) -}}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -19,4 +20,5 @@ metadata:
   annotations:
     kubernetes.io/service-account.name: {{ $fullName }}
 type: kubernetes.io/service-account-token
-{{ end -}}
+  {{ end -}}
+{{- end -}}

--- a/charts/base-cluster/templates/rbac/roleBindings.yaml
+++ b/charts/base-cluster/templates/rbac/roleBindings.yaml
@@ -1,6 +1,19 @@
 {{- $roles := include "base-cluster.rbac.roles" (dict "accounts" .Values.rbac.accounts "roles" (.Values.rbac.roles | keys) "namespaces" (include "base-cluster.enabled-namespaces" . | fromYaml | keys)) | fromYaml -}}
 {{- $definedRoles := .Values.rbac.roles | keys -}}
 
+{{- define "base-cluster.rbac.subjects" -}}
+  {{- $_ := mustMerge . (pick .context "Release") -}}
+  {{- $subjects := list -}}
+  {{- range $account := .accounts -}}
+    {{- if contains "@" $account -}}
+      {{- $subjects = append $subjects (dict "kind" "User" "name" $account) -}}
+    {{- else -}}
+      {{- $subjects = append $subjects (dict "kind" "ServiceAccount" "namespace" $.Release.Namespace "name" (printf "%s-%s" (include "common.names.fullname" $.context) $account)) -}}
+    {{- end -}}
+  {{- end }}
+  {{- toYaml $subjects -}}
+{{- end -}}
+
 {{- range $roleName, $roleMapping := $roles -}}
   {{- $clusterMapping := dig "clusterMapping" (dict) $roleMapping -}}
   {{- $namespaceMapping := dig "namespaceMapping" (dict) $roleMapping -}}
@@ -15,12 +28,7 @@ metadata:
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
     app.kubernetes.io/component: rbac
   namespace: {{ $namespace }}
-subjects:
-    {{- range $account := $accounts }}
-  - kind: ServiceAccount
-    namespace: {{ $.Release.Namespace }}
-    name: {{ printf "%s-%s" (include "common.names.fullname" $) $account }}
-    {{- end }}
+subjects: {{- include "base-cluster.rbac.subjects" (dict "accounts" $accounts "context" $) | nindent 2 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -34,12 +42,7 @@ metadata:
   name: {{ $roleBindingFullName }}
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
     app.kubernetes.io/component: rbac
-subjects:
-    {{- range $account := $clusterMapping }}
-  - kind: ServiceAccount
-    namespace: {{ $.Release.Namespace }}
-    name: {{ printf "%s-%s" (include "common.names.fullname" $) $account }}
-    {{- end }}
+subjects: {{- include "base-cluster.rbac.subjects" (dict "accounts" $clusterMapping "context" $) | nindent 2 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced configuration for mapping email-based user accounts to RBAC roles and permissions within Kubernetes clusters.
- **Bug Fixes**
  - Updated instructions to clarify kubeconfig creation steps for email-based users versus service accounts.
- **Refactor**
  - Centralized and improved logic for generating RBAC subjects, now distinguishing between user and service accounts.
- **Chores**
  - Removed unused global and monitoring configuration options from cluster settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->