### PR TITLE
chore(ckan): change sorl auth in preperation for service metrics

### DIFF
--- a/charts/ckan/templates/ckan/deployment.yaml
+++ b/charts/ckan/templates/ckan/deployment.yaml
@@ -137,10 +137,7 @@ spec:
               value: "http://{{ printf "%s-%s" (include "ckan.solr.fullname" . ) "headless" }}:{{ include "ckan.solr.service.port" $ }}/solr/ckan"
             {{- if .Values.solr.auth.enabled }}
             - name: CKAN_SOLR_USER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ printf "%s-config" (include "ckan.solr.fullname" . ) }}
-                  key: solrUsername
+              value: {{ .Values.solr.auth.adminUsername | quote }}
             - name: CKAN_SOLR_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/ckan/templates/ckan/post-install.yaml
+++ b/charts/ckan/templates/ckan/post-install.yaml
@@ -113,10 +113,7 @@ spec:
               value: "http://{{ printf "%s-%s" (include "ckan.solr.fullname" . ) "headless" }}:{{ include "ckan.solr.service.port" $ }}/solr/ckan"
             {{- if .Values.solr.auth.enabled }}
             - name: CKAN_SOLR_USER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ printf "%s-config" (include "ckan.solr.fullname" . ) }}
-                  key: solrUsername
+              value: {{ .Values.solr.auth.adminUsername | quote }}
             - name: CKAN_SOLR_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/ckan/templates/solr/secret.yaml
+++ b/charts/ckan/templates/solr/secret.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/component: {{ $name }}
   namespace: {{ .Release.Namespace | quote }}
 stringData:
-  solrUsername: {{ .Values.solr.auth.adminUsername | default "admin" | quote}}
   {{- if .Values.solr.auth.enabled }}
   solrPassword: {{ $solrPassword }}
   {{- end }}

--- a/charts/ckan/values.yaml
+++ b/charts/ckan/values.yaml
@@ -202,19 +202,13 @@ solr:
     repository: teutonet/oci-images/solr-ckan
     tag: 1.0.27@sha256:cb0d2e59e5394dc861848bbf4c830a86a4bfc8b841370e9efd8c6199fb871fd9
     digest: ""
-  extraEnvVars:
-    - name: SOLR_ADMIN_USERNAME
-      valueFrom:
-        secretKeyRef:
-          name: '{{ printf "%s-config" (include "common.names.fullname" .) }}'
-          key: solrUsername
   coreNames:
     - ckan
   collection: ckan
   auth:
     enabled: true
     adminPassword: ""
-    adminUsername: ""
+    adminUsername: "admin"
     existingSecret: '{{ printf "%s-config" (include "common.names.fullname" .) }}'
     existingSecretPasswordKey: solrPassword
   collectionReplicas: 2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated configuration to set the Solr admin username directly from chart values instead of using a Kubernetes secret.
	- Removed the Solr username from Kubernetes secrets and related environment variable references.
	- The Solr admin username is now set to "admin" by default in the configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->