### PR TITLE
ci(CVE-Reports): create issue if report creation fails

### DIFF
--- a/.github/issue-template.md
+++ b/.github/issue-template.md
@@ -1,0 +1,6 @@
+---
+title: CVE-Scan-Error
+assignees: k8s
+labels: bug
+---
+CVE-Scan failed

--- a/.github/workflows/scan-for-cves.yaml
+++ b/.github/workflows/scan-for-cves.yaml
@@ -44,9 +44,12 @@ jobs:
 
   createIssue:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     name: Create Issue
-    if: steps.generateSarifReports.conclusion == 'failure'
+    needs: generateSarifReports
+    if: needs.generateSarifReports.result == 'failure'
     steps:
       - uses: JasonEtco/create-an-issue@v2
         env:
-          GITHUB_TOKEN: ${{GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/scan-for-cves.yaml
+++ b/.github/workflows/scan-for-cves.yaml
@@ -50,6 +50,9 @@ jobs:
     needs: generateSarifReports
     if: needs.generateSarifReports.result == 'failure'
     steps:
+      - uses: actions/checkout@v3
       - uses: JasonEtco/create-an-issue@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          filename: .github/issue-template.md

--- a/.github/workflows/scan-for-cves.yaml
+++ b/.github/workflows/scan-for-cves.yaml
@@ -41,3 +41,12 @@ jobs:
         with:
           sarif_file: reports
           # TODO: github dependency tree?
+
+  createIssue:
+    runs-on: ubuntu-latest
+    name: Create Issue
+    if: steps.generateSarifReports.conclusion == 'failure'
+    steps:
+      - uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{GITHUB_TOKEN}}

--- a/.github/workflows/scan-for-cves.yaml
+++ b/.github/workflows/scan-for-cves.yaml
@@ -50,7 +50,7 @@ jobs:
     needs: generateSarifReports
     if: needs.generateSarifReports.result == 'failure'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: JasonEtco/create-an-issue@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Create an issue if the scan-for-cve jobs failed

Project of the github action: https://github.com/JasonEtco/create-an-issue

GH-Workflow steps documentation: https://docs.github.com/en/actions/reference/accessing-contextual-information-about-workflow-runs#steps-context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automated creation of a GitHub issue when a security scan fails, improving visibility of potential vulnerabilities.
  * Added a template for automatically generated issues related to scan failures, streamlining issue reporting and assignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->