### PR TITLE
fix(base-cluster/docs): there is no 9.0.0 release for now...

### DIFF
--- a/charts/base-cluster/README.md
+++ b/charts/base-cluster/README.md
@@ -354,7 +354,7 @@ This also replaces `promtail` and the `otel-collector` with `alloy`, using
 <https://github.com/teutonet/teutonet-helm-charts/blob/main/charts/common/templates/_telemetry.tpl>
 makes this a drop-in change.
 
-### 8.x.x -> 9.0.0
+---
 
 This release adds another option for ingress, [traefik](https://traefik.io)! 🎉
 

--- a/charts/base-cluster/README.md.gotmpl
+++ b/charts/base-cluster/README.md.gotmpl
@@ -344,7 +344,7 @@ This also replaces `promtail` and the `otel-collector` with `alloy`, using
 <https://github.com/teutonet/teutonet-helm-charts/blob/main/charts/common/templates/_telemetry.tpl>
 makes this a drop-in change.
 
-### 8.x.x -> 9.0.0
+---
 
 This release adds another option for ingress, [traefik](https://traefik.io)! 🎉
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the migration section formatting in the README to use a horizontal rule instead of a heading for the 8.x.x to 9.0.0 upgrade. No content changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->