### PR TITLE
fix(base-cluster/ingress-nginx): set a couple of timeouts in the loadbalancer to the maximum value

### DIFF
--- a/charts/base-cluster/templates/ingress/nginx.yaml
+++ b/charts/base-cluster/templates/ingress/nginx.yaml
@@ -51,6 +51,10 @@ spec:
         {{- end }}
       service:
         annotations:
+          loadbalancer.openstack.org/timeout-client-data: "2073600000"
+          loadbalancer.openstack.org/timeout-member-connect: "2073600000"
+          loadbalancer.openstack.org/timeout-member-data: "2073600000"
+          loadbalancer.openstack.org/timeout-tcp-inspect: "2073600000"
           loadbalancer.openstack.org/proxy-protocol: "true"
           load-balancer.hetzner.cloud/uses-proxyprotocol: "true"
           load-balancer.hetzner.cloud/disable-private-ingress: "true"


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new timeout configuration options for OpenStack load balancers, allowing for extended timeout values on client data, member connect, member data, and TCP inspect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->