### PR TITLE
chore(t8s-cluster/management-cluster): remove `cloud-provider` flag >= 1.33.0

### DIFF
--- a/charts/t8s-cluster/templates/management-cluster/check-k8s-version.yaml
+++ b/charts/t8s-cluster/templates/management-cluster/check-k8s-version.yaml
@@ -2,7 +2,7 @@
 {{- $existingCluster := lookup $cluster.apiVersion $cluster.kind $cluster.metadata.namespace $cluster.metadata.name }}
 {{/* Should always pass, just doesn't work for local diffs 😥 */}}
 {{- if $existingCluster }}
-  {{- if semverCompare (printf "<%s" ($existingCluster.spec.version | trimPrefix "v")) (printf "%d.%d.%d" (.Values.version.major | int) (.Values.version.minor | int) (.Values.version.patch | int)) -}}
+  {{- if semverCompare (printf "<%s" ($existingCluster.spec.version | trimPrefix "v")) (include "t8s-cluster.k8s-version" .) -}}
     {{- fail "Cannot downgrade cluster version" -}}
   {{- end }}
 {{- end }}

--- a/charts/t8s-cluster/templates/management-cluster/clusterClass/_helpers.tpl
+++ b/charts/t8s-cluster/templates/management-cluster/clusterClass/_helpers.tpl
@@ -143,7 +143,10 @@ server = {{ printf "https://%s" .registry | quote }}
 {{- end }}
 
 {{- define "t8s-cluster.clusterClass.args.sharedController" -}}
-  {{- $args := dict "cloud-provider" "external" -}}
+  {{- $args := dict -}}
+  {{- if semverCompare "<1.33.0" (include "t8s-cluster.k8s-version" .context) -}}
+    {{- $args = set $args "cloud-provider" "external" -}}
+  {{- end -}}
   {{- toYaml $args -}}
 {{- end }}
 

--- a/charts/t8s-cluster/templates/management-cluster/clusterClass/patches/_kubelet.tpl
+++ b/charts/t8s-cluster/templates/management-cluster/clusterClass/patches/_kubelet.tpl
@@ -1,7 +1,7 @@
 {{- define "t8s-cluster.patches.kubelet.imagePulls" -}}
   {{- $_ := mustMerge . (pick .context "Values") -}}
   {{- $values := dict -}}
-  {{- if and (or (gt (.Values.version.major | int) 1) (ge (.Values.version.minor | int) 27)) (gt (int .Values.global.kubeletExtraConfig.maxParallelImagePulls) 1) -}}
+  {{- if and (semverCompare ">=1.27.0" (include "t8s-cluster.k8s-version" .context)) (gt (int .Values.global.kubeletExtraConfig.maxParallelImagePulls) 1) -}}
     {{- $values = mustMerge $values (dict "serializeImagePulls" false "maxParallelImagePulls" .Values.global.kubeletExtraConfig.maxParallelImagePulls) -}}
   {{- end -}}
   {{- toYaml $values -}}


### PR DESCRIPTION
See <https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.33.md#other-cleanup-or-flake-1>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version comparison logic to prevent usage of removed flags.
  * The "cloud-provider: external" argument is now only included for Kubernetes versions below 1.33.0.
  * Kubelet image pull concurrency patch now correctly applies only for Kubernetes versions 1.27.0 and above.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->