### PR TITLE
chore(ci): pluto doesn't have a tag for `v5`, changed to newest release

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -84,7 +84,7 @@ jobs:
       - run: ./.github/scripts/enforce-trusted-registries.sh "charts/$CHART"
         if: ${{ steps.templateChart.outputs.skipped == 'false' }}
       - name: Download Pluto
-        uses: FairwindsOps/pluto/github-action@282bddb2e5a1e8a9398da41a896367995cee97ff # v5
+        uses: FairwindsOps/pluto/github-action@92afdefd3cb579090dc1e5d55e7f7b89e9fc1dfa # v5.22.0
         if: ${{ steps.templateChart.outputs.skipped == 'false' }}
       - run: pluto detect-files -d /tmp/templated -o custom --columns 'FILEPATH,NAME,KIND,VERSION,REPLACEMENT,REMOVED,DEPRECATED,REPL AVAIL'
         if: ${{ steps.templateChart.outputs.skipped == 'false' }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the linting workflow to use a newer version of the Pluto tool for detecting deprecated Kubernetes APIs in Helm charts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->