### PR TITLE
chore(base-cluster/monitoring): migrate metrics-server away from bitnami

### DIFF
--- a/.github/trusted_registries.yaml
+++ b/.github/trusted_registries.yaml
@@ -52,6 +52,8 @@ registry.k8s.io:
   etcd: ALL_TAGS
   ingress-nginx: ALL_IMAGES
   kube-state-metrics: ALL_IMAGES
+  metrics-server:
+    metrics-server: ALL_TAGS
   provider-os: ALL_IMAGES
   sig-storage:
     csi-attacher: ALL_TAGS

--- a/charts/base-cluster/templates/monitoring/metrics-server/metrics-server.yaml
+++ b/charts/base-cluster/templates/monitoring/metrics-server/metrics-server.yaml
@@ -9,23 +9,35 @@ metadata:
     app.kubernetes.io/part-of: monitoring
 spec:
   chart:
-    spec: {{- include "base-cluster.helm.chartSpec" (dict "repo" "bitnami" "chart" "metrics-server" "context" $) | nindent 6 }}
+    spec: {{- include "base-cluster.helm.chartSpec" (dict "repo" "metrics-server" "chart" "metrics-server" "context" $) | nindent 6 }}
   interval: 1h
   driftDetection:
     mode: enabled
   values:
     apiService:
       create: true
-    {{- if .Values.global.imageRegistry }}
-    global:
-      imageRegistry: {{ $.Values.global.imageRegistry }}
-    {{- end }}
+    image:
+      repository: {{ printf "%s/metrics-server/metrics-server" ($.Values.global.imageRegistry | default "registry.k8s.io") }}
     replicas: 2
     priorityClassName: cluster-components
+    podSecurityContext:
+      fsGroup: 1000
+      fsGroupChangePolicy: Always
+      supplementalGroups: []
+      sysctls: []
+    securityContext:
+      privileged: false
+      runAsGroup: 1000
+      seLinuxOptions: {}
     podDisruptionBudget:
       enabled: true
       minAvailable: 1
-    extraArgs:
+    tls:
+      type: cert-manager
+    defaultArgs:
+      - --cert-dir=/tmp
       - --kubelet-preferred-address-types=InternalIP
-      - --kubelet-insecure-tls=true
+      - --kubelet-insecure-tls
+      - --kubelet-use-node-status-port
+      - --metric-resolution=15s
   {{- end -}}

--- a/charts/base-cluster/values.yaml
+++ b/charts/base-cluster/values.yaml
@@ -114,14 +114,17 @@ global:
     bitnami:
       url: oci://docker.io/bitnamicharts
       charts:
-        metrics-server: 7.4.10
         external-dns: 8.9.2
-        grafana-tempo: 4.0.13
     oauth2-proxy:
       url: https://oauth2-proxy.github.io/manifests
       charts:
         oauth2-proxy: 7.14.1
       condition: '{{ and .Values.global.authentication.config .Values.monitoring.prometheus.enabled }}'
+    metrics-server:
+      url: https://kubernetes-sigs.github.io/metrics-server
+      charts:
+        metrics-server: 3.12.2
+      condition: "{{ .Values.monitoring.metricsServer.enabled }}"
     descheduler:
       url: https://kubernetes-sigs.github.io/descheduler
       charts:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the metrics-server component to use the official Kubernetes SIGs Helm chart repository instead of Bitnami.
  * Enhanced security settings for metrics-server pods and containers.
  * Updated metrics-server command-line arguments for improved operation.
  * Metrics-server deployment is now conditionally enabled via monitoring settings.
  * Added new trusted container registries and reorganized existing entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->