### PR TITLE
chore(base-cluster): migrate kubectl image away from bitnami

### DIFF
--- a/.github/image_licenses.yaml
+++ b/.github/image_licenses.yaml
@@ -77,6 +77,9 @@ licenses:
   docker.io/otel/opentelemetry-collector-contrib:
     license: Apache-2.0
     licenseLink: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/LICENSE
+  docker.io/rancher/kubectl:
+    license: Apache-2.0
+    licenseLink: https://raw.githubusercontent.com/kubernetes/kubernetes/refs/heads/master/LICENSE
   docker.io/stellio/stellio-api-gateway:
     license: Apache-2.0
     licenseLink: https://github.com/stellio-hub/stellio-context-broker/blob/develop/LICENSE.txt

--- a/.github/trusted_registries.yaml
+++ b/.github/trusted_registries.yaml
@@ -21,6 +21,8 @@ docker.io:
   otel:
     opentelemetry-collector-contrib: ALL_TAGS
   postgres: ALL_TAGS
+  rancher:
+    kubectl: ALL_TAGS
   stellio: ALL_IMAGES
   traefik: ALL_TAGS
   velero: ALL_IMAGES

--- a/charts/base-cluster/values.yaml
+++ b/charts/base-cluster/values.yaml
@@ -67,8 +67,8 @@ global:
   kubectl:
     image:
       registry: docker.io
-      repository: bitnami/kubectl
-      tag: 1.33.3-debian-12-r1@sha256:cd354d5b25562b195b277125439c23e4046902d7f1abc0dc3c75aad04d298c17
+      repository: rancher/kubectl
+      tag: 1.33.3@sha256:26d09fcee6eb9a14b81c95e52dd90964a0a24263abb075f58651d2ac62651b59
   flux:
     image:
       registry: docker.io


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the kubectl container image repository and tag used in global settings.
  * Added licensing information for the kubectl image.
  * Expanded trusted registries to include the rancher/kubectl image with all tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->