### PR TITLE
chore(teuto-portal-k8s-worker): change default loggingFormat to `json`

### DIFF
--- a/charts/teuto-portal-k8s-worker/values.schema.json
+++ b/charts/teuto-portal-k8s-worker/values.schema.json
@@ -195,7 +195,11 @@
               "type": "string"
             },
             "loggingFormat": {
-              "type": "string"
+              "type": "string",
+              "enum": [
+                "json",
+                "iso8601"
+              ]
             }
           },
           "additionalProperties": false

--- a/charts/teuto-portal-k8s-worker/values.yaml
+++ b/charts/teuto-portal-k8s-worker/values.yaml
@@ -19,6 +19,8 @@ global:
     fsGroupChangePolicy: OnRootMismatch
 
 worker:
+  config:
+    loggingFormat: json
   image:
     registry: registry-gitlab.teuto.net
     repository: 4teuto/dev/teuto-portal/teuto-portal-k8s-worker/teuto-portal-k8s-worker


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable logging format option for workers, allowing selection between "json" and "iso8601" formats.

* **Chores**
  * Improved validation for the logging format setting to only accept "json" or "iso8601".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->