### PR TITLE
feat(base-cluster/monitoring): don't automount the ServiceAccountToken

### DIFF
--- a/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_grafana-config.yaml
+++ b/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_grafana-config.yaml
@@ -31,6 +31,7 @@ auth.generic_oauth:
 {{- define "base-cluster.prometheus-stack.grafana.config" -}}
 imageRenderer:
   enabled: true
+  automountServiceAccountToken: false
   securityContext:
     seccompProfile:
       type: RuntimeDefault

--- a/charts/base-cluster/templates/monitoring/kube-prometheus-stack/prometheus-operator.yaml
+++ b/charts/base-cluster/templates/monitoring/kube-prometheus-stack/prometheus-operator.yaml
@@ -19,15 +19,5 @@ spec:
   upgrade:
     timeout: 20m0s
     crds: CreateReplace
-  postRenderers:
-    - kustomize:
-        patches:
-          - target:
-              kind: Deployment
-              name: kube-prometheus-stack-grafana-image-renderer
-            patch: |-
-              - op: add
-                path: /spec/template/spec/automountServiceAccountToken
-                value: false
   values: {{- include "base-cluster.prometheus.config" . | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
This flag is now supported by the chart, no need for a postRenderer


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Grafana imageRenderer configuration to disable automatic mounting of the service account token.
  * Removed a patch related to service account token mounting from the monitoring stack deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->