### PR TITLE
chore(ci): all jobs must be successful for 15 seconds

### DIFF
--- a/.github/workflows/wait-for-checks.yaml
+++ b/.github/workflows/wait-for-checks.yaml
@@ -28,8 +28,12 @@ jobs:
           set -e
           set -o pipefail
 
-          while unfinished_jobs="$(gh api --paginate "/repos/${GITHUB_REPOSITORY}/commits/${CHANGE_SHA}/check-runs" | jq --arg ignored "$IGNORED_JOBS,$CURRENT_JOB" -e '.check_runs | map(select(([.conclusion] | inside(["success","skipped","cancelled"]) | not) and ([.name] | inside($ignored | split(",")) | not))) | map("\(.name) (\(.conclusion // .status))") | if length == 0 then halt_error(1) end')"; do
-            echo "The following jobs are not (successfully) finished yet:" >&2
-            echo "$unfinished_jobs" >&2
+          # must work three times, (sometimes) the github API drops jobs that are currently restarting
+          tries=3; while (( --tries >= 0 )); do
+            while unfinished_jobs="$(gh api --paginate "/repos/${GITHUB_REPOSITORY}/commits/${CHANGE_SHA}/check-runs" | jq --arg ignored "$IGNORED_JOBS,$CURRENT_JOB" -e '.check_runs | map(select(([.conclusion] | inside(["success","skipped","cancelled"]) | not) and ([.name] | inside($ignored | split(",")) | not))) | map("\(.name) (\(.conclusion // .status))") | if length == 0 then halt_error(1) end')"; do
+              echo "The following jobs are not (successfully) finished yet:" >&2
+              echo "$unfinished_jobs" >&2
+              sleep 5
+            done
             sleep 5
           done


### PR DESCRIPTION
Otherwise some jobs might slip through the cracks (thanks github)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the reliability of GitHub workflow checks by adding a retry mechanism to handle intermittent API issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->