### PR TITLE
fix(base-cluster/kyverno): migrate to new `validationFailureAction` syntax

### DIFF
--- a/charts/base-cluster/templates/kyverno/policies/kyverno-base-policies/kyverno-policies.yaml
+++ b/charts/base-cluster/templates/kyverno/policies/kyverno-base-policies/kyverno-policies.yaml
@@ -25,7 +25,7 @@ spec:
     podSecuritySeverity: {{ .Values.kyverno.podSecuritySeverity | quote }}
     # Supported values- `audit`, `enforce`
     # For more info- https://kyverno.io/docs/writing-policies/validate/
-    validationFailureAction: {{ .Values.kyverno.validationFailureAction | quote }}
+    validationFailureAction: {{ .Values.kyverno.validationFailureAction | title | quote }}
     validationFailureActionOverride:
       all:
         - action: audit


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated formatting of the `validationFailureAction` field in Kyverno policy templates to ensure the value starts with an uppercase letter in generated YAML.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->