### PR TITLE
fix(ci): also check licenses during linting

### DIFF
--- a/.github/scripts/check-licenses.sh
+++ b/.github/scripts/check-licenses.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+[[ "$RUNNER_DEBUG" == 1 ]] && set -x
+[[ -o xtrace ]] && export RUNNER_DEBUG=1
+
+set -eu
+set -o pipefail
+
+function checkLicenses() {
+  local chart="${1?}"
+
+  # shellcheck disable=SC2016
+  if missingImages="$(yq -r -e -c --argjson usedImages "$(yq -r '.annotations["artifacthub.io/images"]' "${chart?}/Chart.yaml" | yq -r -c 'map(.image | split(":")[0]) | unique')" '$usedImages - (.licenses | keys) | if length == 0 then false else . end' .github/image_licenses.yaml)"; then
+    echo "The following images of '$(basename "$chart")' have no license, please review:"
+    echo "$missingImages" | yq -r 'map("  - " + .)[]'
+    exit 1
+  fi
+}
+
+if [[ "$#" == 1 && -d "$1" ]]; then
+  checkLicenses "$1"
+else
+  result=0
+  for chart in charts/*; do
+    [[ -d "$chart" ]] || continue
+
+    if ! checkLicenses "$chart"; then
+      result=1
+    fi
+  done
+  exit "$result"
+fi

--- a/.github/workflows/check-licenses.yaml
+++ b/.github/workflows/check-licenses.yaml
@@ -43,20 +43,11 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     needs: getChangedChart
+    env:
+      CHART: ${{ needs.getChangedChart.outputs.chart }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - run: pip install yq
-      - env:
-          chart: ${{ needs.getChangedChart.outputs.chart }}
-        run: |
-          [[ "$RUNNER_DEBUG" == 1 ]] && set -x
-          set -e
-          set -o pipefail
-          # shellcheck disable=SC2016
-          if missingImages="$(yq -r -e -c --argjson usedImages "$(yq -r '.annotations["artifacthub.io/images"]' "charts/${chart?}/Chart.yaml" | yq -r -c 'map(.image | split(":")[0]) | unique')" '$usedImages - (.licenses | keys) | if length == 0 then false else . end' .github/image_licenses.yaml)"; then
-            echo "The following images have no license, please review:"
-            echo "$missingImages" | yq -r 'map("  - " + .)[]'
-            exit 1
-          fi
+      - run: ./.github/scripts/check-licenses.sh "charts/$CHART"

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -83,6 +83,8 @@ jobs:
         if: ${{ steps.templateChart.outputs.skipped == 'false' }}
       - run: ./.github/scripts/enforce-trusted-registries.sh "charts/$CHART"
         if: ${{ steps.templateChart.outputs.skipped == 'false' }}
+      - run: ./.github/scripts/check-licenses.sh "charts/$CHART"
+        if: ${{ steps.templateChart.outputs.skipped == 'false' }}
       - name: Download Pluto
         uses: FairwindsOps/pluto/github-action@92afdefd3cb579090dc1e5d55e7f7b89e9fc1dfa # v5.22.0
         if: ${{ steps.templateChart.outputs.skipped == 'false' }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced an automated license verification script to ensure all container images in Helm charts have corresponding license entries.
  * Updated CI workflows to use the new license checking script, streamlining the license validation process during chart linting and checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->