### PR TITLE
fix(base-cluster/monitoring): oauth-proxy serviceMonitor labels

### DIFF
--- a/charts/base-cluster/templates/monitoring/kube-prometheus-stack/oauth-proxy.yaml
+++ b/charts/base-cluster/templates/monitoring/kube-prometheus-stack/oauth-proxy.yaml
@@ -69,7 +69,8 @@ spec:
     metrics:
       serviceMonitor:
         enabled: {{ $.Values.monitoring.prometheus.enabled }}
-        additionalLabels: {{- include "common.tplvalues.render" (dict "value" $.Values.monitoring.labels "context" .) | nindent 10 }}
+        additionalLabels:
+          monitoring/provisioned-by: base-cluster
     config:
       existingSecret: {{ include "common.secrets.name" (dict "defaultNameSuffix" "oauth-proxy" "context" $) }}
       configFile: |-


### PR DESCRIPTION
See <https://github.com/teutonet/teutonet-helm-charts/pull/1429>
