### PR TITLE
feat(teuto-cnpg/credentials): allow adding roles during upgrades

### DIFF
--- a/charts/teuto-cnpg/templates/credentials.yaml
+++ b/charts/teuto-cnpg/templates/credentials.yaml
@@ -14,7 +14,7 @@ metadata:
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
     cnpg.io/reload: "true"
 data:
-  password: {{ include "common.secrets.passwords.manage" (dict "secret" $role.passwordSecret.name "length" 40 "strong" false "providedValues" (list) "key" "password" "context" $ ) }}
+  password: {{ include "common.secrets.passwords.manage" (dict "secret" $role.passwordSecret.name "length" 40 "strong" false "providedValues" (list) "failOnNew" false "key" "password" "context" $ ) }}
   username: {{ $role.name | b64enc }}
 ---
 {{- end }}


### PR DESCRIPTION
without "failOnNew" false, the function only works during install

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved password management in Kubernetes Secrets to prevent failures when new secrets are created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->