### PR TITLE
fix(base-cluster/monitoring): also create metrics for resources without suspend field

### DIFF
--- a/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_kube-state-metrics-config.yaml
+++ b/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_kube-state-metrics-config.yaml
@@ -87,6 +87,7 @@ customResourceState:
                     "gauge" (dict
                       "path" (list "spec")
                       "valueFrom" (list "suspend")
+                      "nilIsZero" true
                     )
                   )
                   "labelsFromPath" (dict


### PR DESCRIPTION
Otherwise there are no metrics which creates an alert for missing metrics


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated monitoring configuration to treat missing values for the "reconcile_suspended_gauge" metric as zero, improving metric accuracy and consistency in dashboards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->