### PR TITLE
fix(ci): use the bot for labelling PRs

### DIFF
--- a/.github/workflows/label-pullrequest.yaml
+++ b/.github/workflows/label-pullrequest.yaml
@@ -28,7 +28,7 @@ jobs:
     needs: getChangedCharts
     steps:
       - env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.number }}
           CHANGED_CHARTS: ${{ needs.getChangedCharts.outputs.charts }}
         run: |


### PR DESCRIPTION
Otherwise "outsiders" won't get their PRs labelled


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the authentication method used for labeling pull requests in the workflow configuration. No changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->