### PR TITLE
fix(base-cluster/certificates): certificate for `baseDomain` is not used

### DIFF
--- a/charts/base-cluster/values.yaml
+++ b/charts/base-cluster/values.yaml
@@ -57,12 +57,9 @@ global:
   certificates:
     cluster-wildcard:
       dnsNames: |-
-        - {{ include "base-cluster.domain" $ | quote }}
-        {{- if .Values.dns.provider }}
         - {{ printf "*.%s" (include "base-cluster.domain" $) | quote }}
-        {{- end }}
       targetNamespaces: ALL
-      condition: "{{ not (empty .Values.global.baseDomain) }}"
+      condition: "{{ and (not (empty .Values.global.baseDomain)) .Values.dns.provider }}"
   storageClass: ""
   kubectl:
     image:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated certificate configuration to include only the wildcard DNS name.
  * Certificate activation now requires both a base domain and a DNS provider to be set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->