### PR TITLE
fix(base-cluster/dns): only deploy external-dns HelmRepository if needed

### DIFF
--- a/charts/base-cluster/values.yaml
+++ b/charts/base-cluster/values.yaml
@@ -120,6 +120,7 @@ global:
       url: https://kubernetes-sigs.github.io/external-dns
       charts:
         external-dns: 1.18.0
+      condition: '{{ .Values.dns.provider }}'
     oauth2-proxy:
       url: https://oauth2-proxy.github.io/manifests
       charts:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a conditional check for enabling the external-dns Helm repository based on the DNS provider value in configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->