### PR TITLE
fix(base-cluster/monitoring): remove versions from datasources so they always take precedence

### DIFF
--- a/charts/base-cluster/templates/monitoring/logs/grafana-loki.yaml
+++ b/charts/base-cluster/templates/monitoring/logs/grafana-loki.yaml
@@ -16,7 +16,6 @@ data:
         type: loki
         access: proxy
         url: "http://loki:3100"
-        version: 1
         isDefault: false
         uid: loki
 {{- end -}}

--- a/charts/base-cluster/templates/monitoring/tracing/grafana-tempo.yaml
+++ b/charts/base-cluster/templates/monitoring/tracing/grafana-tempo.yaml
@@ -69,7 +69,6 @@ data:
         access: proxy
         uid: tempo
         url: "http://grafana-tempo-query-frontend.monitoring:3200"
-        version: 1
         isDefault: false
         jsonData:
           tracesToLogsV2:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Grafana Loki and Tempo datasource configurations by removing the explicit version field from their setup. No changes to functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->