### PR TITLE
feat(base-cluster)!: remove unnecessary enabled field for deadMansSwitch

### DIFF
--- a/charts/base-cluster/README.md.gotmpl
+++ b/charts/base-cluster/README.md.gotmpl
@@ -417,17 +417,19 @@ of `.monitoring.tracing.ingester.<field>`
 
 ### 11.x.x -> 12.0.0
 
-`kube-janitor` is replaced by `ttl-controller` ([k8s-ttl-controller](https://github.com/TwiN/k8s-ttl-controller)).
+- `kube-janitor` is replaced by `ttl-controller` ([k8s-ttl-controller](https://github.com/TwiN/k8s-ttl-controller)).
 
-If you had `kube-janitor.enabled: true`, change it to:
+  If you had `kube-janitor.enabled: true`, change it to:
 
-```yaml
-ttl-controller:
-  enabled: true
-```
+  ```yaml
+  ttl-controller:
+    enabled: true
+  ```
 
-Resources annotated with `janitor/ttl` must be re-annotated to `k8s-ttl-controller.twin.sh/ttl`.
-Duration values (e.g. `1h`, `7d`) transfer as-is. However, `janitor/expires` absolute timestamps and
-the `forever` value are not supported by `k8s-ttl-controller` and must be removed or replaced.
+  Resources annotated with `janitor/ttl` must be re-annotated to `k8s-ttl-controller.twin.sh/ttl`.
+  Duration values (e.g. `1h`, `7d`) transfer as-is. However, `janitor/expires` absolute timestamps and
+  the `forever` value are not supported by `k8s-ttl-controller` and must be removed or replaced.
+
+- This release also removes the `monitoring.deadMansSwitch.enabled` field, it is just active when the `monitoring.deadMansSwitch` block is set.
 
 {{ .Files.Get "values.md"  }}

--- a/charts/base-cluster/ci/artifacthub-values.yaml
+++ b/charts/base-cluster/ci/artifacthub-values.yaml
@@ -32,7 +32,6 @@ monitoring:
   tracing:
     enabled: true
   deadMansSwitch:
-    enabled: true
     pingKey: PING_KEY
     apiKey: API_KEY
   prometheus:

--- a/charts/base-cluster/ci/deadmansswitch-values.yaml
+++ b/charts/base-cluster/ci/deadmansswitch-values.yaml
@@ -1,6 +1,5 @@
 monitoring:
   deadMansSwitch:
-    enabled: true
     pingKey: PING_KEY
     apiKey: API_KEY
 global:

--- a/charts/base-cluster/templates/monitoring/deadMansSwitch/cronjob.yaml
+++ b/charts/base-cluster/templates/monitoring/deadMansSwitch/cronjob.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.monitoring.deadMansSwitch.enabled }}
+{{- if .Values.monitoring.deadMansSwitch }}
 {{- if false }}
 apiVersion: batch/v1
 {{- else }}

--- a/charts/base-cluster/templates/monitoring/deadMansSwitch/hook-secret.yaml
+++ b/charts/base-cluster/templates/monitoring/deadMansSwitch/hook-secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.monitoring.deadMansSwitch.enabled -}}
+{{- if .Values.monitoring.deadMansSwitch -}}
   {{- $secret := include (print .Template.BasePath "/monitoring/deadMansSwitch/secret.yaml") . | fromYaml -}}
   {{- $secret = mustMerge (dict
       "metadata" (dict

--- a/charts/base-cluster/templates/monitoring/deadMansSwitch/registration.yaml
+++ b/charts/base-cluster/templates/monitoring/deadMansSwitch/registration.yaml
@@ -2,7 +2,7 @@
   {{- printf "k8s-cluster-%s-%s" (.Values.global.baseDomain | replace "." "-") .Values.global.clusterName }}
 {{- end -}}
 
-{{- if .Values.monitoring.deadMansSwitch.enabled }}
+{{- if .Values.monitoring.deadMansSwitch }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/base-cluster/templates/monitoring/deadMansSwitch/secret.yaml
+++ b/charts/base-cluster/templates/monitoring/deadMansSwitch/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.monitoring.deadMansSwitch.enabled -}}
+{{- if .Values.monitoring.deadMansSwitch -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/base-cluster/templates/monitoring/deadMansSwitch/validation.tpl
+++ b/charts/base-cluster/templates/monitoring/deadMansSwitch/validation.tpl
@@ -1,4 +1,4 @@
-{{- if .Values.monitoring.deadMansSwitch.enabled -}}
+{{- if .Values.monitoring.deadMansSwitch -}}
   {{- if not .Values.global.baseDomain -}}
     {{- fail "You need to provide a `.Values.global.baseDomain` when enabling the dead mans switch" -}}
   {{- end -}}

--- a/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_alertmanager-config.yaml
+++ b/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_alertmanager-config.yaml
@@ -39,7 +39,7 @@ alertmanagerSpec:
             storage: {{ .Values.monitoring.prometheus.alertmanager.persistence.size }}
 config:
   {{- $receivers := dict "null" (dict) -}}
-  {{- if and .Values.monitoring.deadMansSwitch.enabled .Values.global.baseDomain .Values.global.clusterName -}}
+  {{- if and .Values.monitoring.deadMansSwitch .Values.global.baseDomain .Values.global.clusterName -}}
     {{- $receivers = set $receivers "healthchecks.io" (dict
           "webhook_configs" (list
             (dict

--- a/charts/base-cluster/values.schema.json
+++ b/charts/base-cluster/values.schema.json
@@ -504,9 +504,6 @@
           "type": "object",
           "description": "This needs `.global.clusterName` to be set up as an integration in healthchecks.io. Also, `.global.baseDomain` has to be set.",
           "properties": {
-            "enabled": {
-              "type": "boolean"
-            },
             "apiKey": {
               "type": "string",
               "description": "Used for registration and unregistration"
@@ -515,6 +512,10 @@
               "type": "string"
             }
           },
+          "required": [
+            "apiKey",
+            "pingKey"
+          ],
           "additionalProperties": false
         },
         "prometheus": {

--- a/charts/base-cluster/values.yaml
+++ b/charts/base-cluster/values.yaml
@@ -281,10 +281,6 @@ monitoring:
     storageClassMapping:
       teutostack-hdd: 0.002
       teutostack-ssd: 0.0067
-  deadMansSwitch:
-    enabled: false
-    apiKey: ""
-    pingKey: ""
   prometheus:
     enabled: true
     replicas: 2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Dead Man's Switch no longer requires an explicit "enabled" flag; providing the deadMansSwitch configuration (with keys) enables the feature.

* **Bug Fixes**
  * Validation tightened to require apiKey and pingKey when Dead Man's Switch is present.

* **Chores**
  * Schema and configuration docs updated to reflect the new, simpler configuration shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->