### PR TITLE
feat(base-cluster/cert-manager): enableCertificateOwnerRef

### DIFF
--- a/charts/base-cluster/templates/cert-manager/cert-manager.yaml
+++ b/charts/base-cluster/templates/cert-manager/cert-manager.yaml
@@ -48,6 +48,7 @@ spec:
     {{- end }}
     resources: {{- include "common.resources" $.Values.certManager | nindent 6 }}
     replicaCount: 1
+    enableCertificateOwnerRef: true
     securityContext: &securityContext
       runAsNonRoot: true
       runAsUser: 1001


### PR DESCRIPTION
That way secrets are automatically cleaned up when the corresponding Certificate is deleted


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled certificate owner references in cert-manager deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->