### PR TITLE
fix(base-cluster/external-dns): correctly check if provider is set

### DIFF
--- a/charts/base-cluster/values.yaml
+++ b/charts/base-cluster/values.yaml
@@ -117,7 +117,7 @@ global:
       url: https://kubernetes-sigs.github.io/external-dns
       charts:
         external-dns: 1.18.0
-      condition: '{{ .Values.dns.provider }}'
+      condition: '{{ ne .Values.dns.provider nil }}'
     oauth2-proxy:
       url: https://oauth2-proxy.github.io/manifests
       charts:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted external DNS enablement logic: the chart now enables external DNS when a DNS provider is defined, and disables it when unset. This prevents unexpected disabling caused by falsy values (e.g., empty strings) and ensures consistent behavior across configurations. If you want external DNS enabled, set dns.provider to any value; to disable it, leave dns.provider unset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->