### PR TITLE
fix(base-cluster/monitoring): otherwise the metric will be duplicated if `suspend` is not set

### DIFF
--- a/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_kube-state-metrics-config.yaml
+++ b/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_kube-state-metrics-config.yaml
@@ -85,8 +85,7 @@ customResourceState:
                   "each" (dict
                     "type" "Gauge"
                     "gauge" (dict
-                      "path" (list "spec")
-                      "valueFrom" (list "suspend")
+                      "path" (list "spec" "suspend")
                       "nilIsZero" true
                     )
                   )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected the reconcile_suspended gauge to read directly from spec.suspend, ensuring accurate status reporting for suspended custom resources.
  - Resolves misreported values in monitoring, reducing false positives/negatives in dashboards and alerts.
  - Improves reliability of metrics consumed by kube-prometheus-stack visualizations and alerting rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->