### PR TITLE
feat(teuto-cnpg)!: remodel to make use of the new way of creating barman backups

### DIFF
--- a/charts/teuto-cnpg/README.md.gotmpl
+++ b/charts/teuto-cnpg/README.md.gotmpl
@@ -25,4 +25,27 @@ Databases need to be migrated manually:
 - update helmchart
 - start cnpg-operator
 
+### 2.x.x -> 3.x.x
+
+Cloudnative-PG made the in-operator backup deprecated.
+
+Therefore a migration has to happen where the Backup block is moved
+into the Objectstore.
+
+In the values you need to remove .values.backup.barmanObjectStore block.
+Those values now need to be set under .values.backup.s3 like this:
+
+```
+values:
+  backup:
+    s3:
+      endpointURL: https://api.ffm3.teutostack.de:6780
+      path: s3://backup/
+      secret:
+        name: backup-credentials
+```
+
+accessKeyId and accessSecretKey are set to `ACCESS_KEY_ID` and `accessSecretKeyEY` by default
+but can be overwritten with .values.backup.s3.accessKeyId or .values.backup.s3.accessSecretKey.
+
 {{ .Files.Get "values.md"  }}

--- a/charts/teuto-cnpg/ci/backup-values.yaml
+++ b/charts/teuto-cnpg/ci/backup-values.yaml
@@ -1,11 +1,8 @@
 backup:
-  barmanObjectStore:
-    destinationPath: s3://test/
-    endpointURL: https://test.s3storage.com:6780
-    s3Credentials:
-      accessKeyId:
-        name: aws-creds
-        key: ACCESS_KEY_ID
-      secretAccessKey:
-        name: aws-creds
-        key: ACCESS_SECRET_KEY
+  s3:
+    path: "/test/path"
+    endpointURL: "endpointURL"
+    secret:
+      name: "MeinNameIstNichtGeheim"
+      accessKeyId: "dasjhiodsadas"
+      accessSecretKey: "jiopidasda"

--- a/charts/teuto-cnpg/ci/schedule-values.yaml
+++ b/charts/teuto-cnpg/ci/schedule-values.yaml
@@ -1,12 +1,9 @@
 backup:
   schedule: "0 0 0 * * *"
-  barmanObjectStore:
-    destinationPath: s3://test/
-    endpointURL: https://test.s3storage.com:6780
-    s3Credentials:
-      accessKeyId:
-        name: aws-creds
-        key: ACCESS_KEY_ID
-      secretAccessKey:
-        name: aws-creds
-        key: ACCESS_SECRET_KEY
+  s3:
+    path: "s3://backup"
+    endpointURL: "https://test.s3storage.com:6780"
+    secret:
+      name: "MeinNameIstNichtGeheim"
+      accessKeyId: "dasjhiodsadas"
+      accessSecretKey: "jiopidasda"

--- a/charts/teuto-cnpg/templates/cluster.yaml
+++ b/charts/teuto-cnpg/templates/cluster.yaml
@@ -19,8 +19,12 @@ spec:
   imageName: {{ include "common.images.image" (dict "imageRoot" .Values.databaseImage "global" .Values.global) }}
   instances: {{ .Values.instances }}
   logLevel: {{ .Values.logLevel }}
-  {{- with .Values.backup }}
-  backup: {{ omit . "schedule" | toYaml | nindent 4 }}
+  {{- if .Values.backup }}
+  plugins:
+  - name: barman-cloud.cloudnative-pg.io
+    isWALArchiver: true
+    parameters:
+      barmanObjectName: {{ .Release.Name }}
   {{- end }}
   managed:
     {{- $roles := dict -}}

--- a/charts/teuto-cnpg/templates/objectstore.yaml
+++ b/charts/teuto-cnpg/templates/objectstore.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.backup }}
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+spec:
+  configuration:
+    destinationPath: {{ .Values.backup.s3.path | quote }}
+    endpointURL: {{ .Values.backup.s3.endpointURL | quote }}
+    s3Credentials:
+      accessKeyId:
+        name: {{ .Values.backup.s3.secret.name }}
+        key: {{ .Values.backup.s3.secret.accessKeyId | default "ACCESS_KEY_ID" }}
+      secretAccessKey:
+        name: {{ .Values.backup.s3.secret.name }}
+        key: {{ .Values.backup.s3.secret.accessSecretKey | default "ACCESS_SECRET_KEY" }}
+    wal:
+      compression: gzip
+{{- end }}

--- a/charts/teuto-cnpg/templates/schedule.yaml
+++ b/charts/teuto-cnpg/templates/schedule.yaml
@@ -8,6 +8,9 @@ metadata:
 spec:
   schedule: {{ .Values.backup.schedule | quote }}
   backupOwnerReference: none
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io
   cluster:
     name: {{ printf "%s" .Release.Name }}
 {{- end -}}

--- a/charts/teuto-cnpg/values.schema.json
+++ b/charts/teuto-cnpg/values.schema.json
@@ -96,6 +96,9 @@
     },
     "backup": {
       "type": "object",
+      "required": [
+        "s3"
+      ],
       "description": "See: https://cloudnative-pg.io/documentation/1.16/backup_recovery/",
       "properties": {
         "schedule": {
@@ -104,9 +107,48 @@
           "examples": [
             "0 0 0 * * *"
           ]
+        },
+        "s3": {
+          "type": "object",
+          "required": [
+            "path",
+            "endpointURL"
+          ],
+          "description": "s3 related options",
+          "properties": {
+            "path": {
+              "type": "string",
+              "description": "s3 path to write files to"
+            },
+            "endpointURL": {
+              "type": "string",
+              "description": "url of the api endpoint"
+            },
+            "secret": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "accessKeyId": {
+                  "type": "string",
+                  "default": "ACCESS_KEY_ID"
+                },
+                "accessSecretKey": {
+                  "type": "string",
+                  "default": "ACCESS_SECRET_KEY"
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "name"
+              ]
+            }
+          },
+          "additionalProperties": false
         }
-      }
-
+      },
+      "additionalProperties": false
     },
     "databaseImage": {
       "type": "object",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - S3-backed backups via an ObjectStore resource and plugin-based WAL archiving; scheduled backups preserved.

- **Refactor**
  - Consolidated backup config under backup.s3 (path, endpointURL, secret); removed legacy barmanObjectStore keys.
  - Schema tightened: backup.s3 required, nested secret fields with defaults and stricter validation.

- **Documentation**
  - Added migration notes documenting deprecation of in-operator backups and how to move to the new format.

- **Chores**
  - Updated CI/example values to the new backup.s3 structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->