### PR TITLE
ci(generate-sarif-reports): reduce number of parallel jobs

### DIFF
--- a/.github/scripts/generate-sarif-reports.sh
+++ b/.github/scripts/generate-sarif-reports.sh
@@ -17,7 +17,7 @@ function createSarifReports() {
   # shellcheck disable=SC2046
   yq -r '.annotations["artifacthub.io/images"]' "$chart/Chart.yaml" |
     yq -r '.[] | .image' |
-    parallel ${GITHUB_JOB+--bar} --retries 10 -P 0 -k generateSarifReport "$chart" "{}" "reports/$chartName-{#}.json"
+    parallel ${GITHUB_JOB+--bar} --retries 10 -P 4 -k generateSarifReport "$chart" "{}" "reports/$chartName-{#}.json"
 
   # return with 1 (false) if a file has been found
   if find reports -type f -name "$chartName-*" -exec false {} + -quit; then


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Adjusted parallel execution level for generating SARIF reports in CI, resulting in more predictable performance and resource usage.
  - Expected impact: faster and more consistent report generation during pipeline runs, with no changes to application behavior.
  - No user-facing functionality affected; this change only influences internal build/reporting processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->