### PR TITLE
chore(t8s-cluster): migrate config, ignore-volume-az is not enough

### DIFF
--- a/charts/t8s-cluster/templates/workload-cluster/cinder-csi-plugin/cinder-csi-plugin.yaml
+++ b/charts/t8s-cluster/templates/workload-cluster/cinder-csi-plugin/cinder-csi-plugin.yaml
@@ -52,6 +52,8 @@ spec:
           kubeletDir: /var/lib/k0s/kubelet
         {{- end }}
         controllerPlugin:
+          extraArgs:
+            - --with-topology=false
           tolerations:
             - effect: NoSchedule
               key: node-role.kubernetes.io/control-plane


### PR DESCRIPTION
Otherwise the PVs get a nodeSelector


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated storage controller plugin configuration to disable topology awareness for volumes.

* **Impact**
  * Volume provisioning no longer considers topology hints, leading to more uniform behavior across nodes and zones.
  * Improves compatibility on clusters lacking topology labels or mixed-zone setups.
  * If you relied on topology-aware scheduling for storage placement, review your workload and storage class configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->