### PR TITLE
chore(base-cluster/external-dns): migrate domainFilters syntax

### DIFF
--- a/charts/base-cluster/templates/dns/external-dns.yaml
+++ b/charts/base-cluster/templates/dns/external-dns.yaml
@@ -40,6 +40,12 @@ spec:
     {{- with .Values.dns.domains }}
     domainFilters: {{- toYaml . | nindent 6 }}
     {{- end }}
+    {{- with .Values.dns.zones }}
+    extraArgs:
+      {{- range $zone := . }}
+      - --zone-name-filter={{ $zone }}
+      {{- end }}
+    {{- end }}
     sources:
       - ingress
       - gateway-httproute

--- a/charts/base-cluster/values.schema.json
+++ b/charts/base-cluster/values.schema.json
@@ -1150,6 +1150,14 @@
           ]
         },
         "domains": {
+          "description": "This field is also used for zone filtering if `zones` is not provided, be careful",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "zones": {
           "type": "array",
           "uniqueItems": true,
           "items": {


### PR DESCRIPTION
Until a few versions ago the domain filter was only used for domains,
now it's also used for zones if there is no zone filter given, which
makes it misleading.
