### PR TITLE
feat(t8s-cluster): implement autoscaling

### DIFF
--- a/charts/t8s-cluster/templates/management-cluster/cluster.yaml
+++ b/charts/t8s-cluster/templates/management-cluster/cluster.yaml
@@ -33,7 +33,17 @@ spec:
       availabilityZone: {{ $machineDeploymentClass.availabilityZone | quote }}
       {{- end }}
       flavor: {{ $machineDeploymentClass.flavor | quote }}
-      replicas: {{ $machineDeploymentClass.replicas }}
+      {{- with $machineDeploymentClass.replicas }}
+        {{- if typeIs "map" . }}
+          {{- if gt .min .max }}
+            {{- fail (printf "nodePools.%s.replicas.min must not be greater than nodePools.%s.replicas.max" $name $name) -}}
+          {{- end }}
+      minReplicas: {{ .min }}
+      maxReplicas: {{ .max }}
+        {{- else }}
+      replicas: {{ . }}
+        {{- end }}
+      {{- end }}
   {{- end }}
   bastion:
     enabled: false

--- a/charts/t8s-cluster/values.schema.json
+++ b/charts/t8s-cluster/values.schema.json
@@ -216,8 +216,30 @@
         "type": "object",
         "properties": {
           "replicas": {
-            "type": "integer",
-            "minimum": 0
+            "oneOf": [
+              {
+                "type": "integer",
+                "minimum": 0
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "min": {
+                    "type": "integer",
+                    "minimum": 1
+                  },
+                  "max": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                },
+                "required": [
+                  "min",
+                  "max"
+                ],
+                "additionalProperties": false
+              }
+            ]
           },
           "availabilityZone": {
             "type": "string"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Node pool replicas can be specified as a single number or as a min/max range; rendering outputs either replicas or minReplicas/maxReplicas and emits nothing when replicas is absent.
  * Schema accepts both formats, with integer form allowing 0 and range form requiring min and max.

* **Bug Fixes / Validation**
  * Adds validation to fail if min > max and enforces minimums for range fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->