### PR TITLE
feat(base-cluster/traefik): Changed ipFamilyPolicy to DualStack

### DIFF
--- a/charts/base-cluster/templates/ingress/traefik.yaml
+++ b/charts/base-cluster/templates/ingress/traefik.yaml
@@ -52,6 +52,7 @@ spec:
       {{- if .Values.ingress.IP }}
       spec:
         loadBalancerIP: {{ .Values.ingress.IP | quote }}
+        ipFamilyPolicy: PreferDualStack
       {{- end }}
     gatewayClass:
       name: default


### PR DESCRIPTION
ipFamilyPolicy for ipv6 Dual-Stack Ingress
https://github.com/traefik/traefik-helm-chart/blob/master/traefik/values.yaml#L825C5-L825C19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Traefik ingress will prefer dual‑stack networking (IPv4/IPv6) when a static external IP is configured, improving compatibility in mixed IP environments.
  * No changes for deployments that don't set a static load‑balancer IP.

* **Refactor**
  * Ingress configuration now explicitly prefers dual‑stack when a static IP is present, yielding more predictable networking behavior across clusters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->