### PR TITLE
fix(base-cluster/velero): remove last reference to bitnami images

### DIFF
--- a/charts/base-cluster/templates/backup/velero.yaml
+++ b/charts/base-cluster/templates/backup/velero.yaml
@@ -26,7 +26,8 @@ spec:
       repository: {{ printf "%s/velero/velero" ($.Values.global.imageRegistry | default (include "base-cluster.defaultRegistry" (dict))) }}
     kubectl:
       image:
-        repository: {{ printf "%s/bitnami/kubectl" ($.Values.global.imageRegistry | default (include "base-cluster.defaultRegistry" (dict))) }}
+        repository: {{ printf "%s/rancher/kubectl" ($.Values.global.imageRegistry | default (include "base-cluster.defaultRegistry" (dict))) }}
+        tag: {{ .Capabilities.KubeVersion.Version }}
     upgradeCRDs: false
     cleanUpCRDs: true
     initContainers:

--- a/charts/base-cluster/values.schema.json
+++ b/charts/base-cluster/values.schema.json
@@ -1733,7 +1733,7 @@
           "type": "string",
           "description": "The image path in the registry",
           "examples": [
-            "bitnami/kubectl"
+            "rancher/kubectl"
           ]
         },
         "tag": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatically aligns the kubectl image tag with the cluster’s Kubernetes version for improved compatibility in backups.
- Bug Fixes
  - Reduced risk of version mismatches in backup operations by updating the kubectl image source.
- Chores
  - Updated configuration examples to reference the new kubectl image repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->