### PR TITLE
chore(ckan): change to bitnami legacy

### DIFF
--- a/.github/image_licenses.yaml
+++ b/.github/image_licenses.yaml
@@ -14,22 +14,22 @@ licenses:
   docker.io/bitnami/grafana-tempo-vulture:
     license: Apache-2.0
     licenseLink: https://hub.docker.com/r/bitnami/grafana-tempo-vulture
-  docker.io/bitnami/kubectl:
+  docker.io/bitnamilegacy/kubectl:
     license: Apache-2.0
-    licenseLink: https://hub.docker.com/r/bitnami/kubectl
+    licenseLink: https://hub.docker.com/r/bitnamilegacy/kubectl
   docker.io/bitnami/memcached:
     license: Apache-2.0
     licenseLink: https://hub.docker.com/r/bitnami/memcached
   docker.io/bitnami/metrics-server:
     license: Apache-2.0
     licenseLink: https://hub.docker.com/r/bitnami/metrics-server
-  docker.io/bitnami/postgresql:
+  docker.io/bitnamilegacy/postgresql:
     license: PostgreSQL
     licenseLink: https://www.postgresql.org/about/licence/
-  docker.io/bitnami/valkey:
+  docker.io/bitnamilegacy/valkey:
     license: BSD-3
-    licenseLink: https://hub.docker.com/r/bitnami/valkey
-  docker.io/bitnami/zookeeper:
+    licenseLink: https://hub.docker.com/r/bitnamilegacy/valkey
+  docker.io/bitnamilegacy/zookeeper:
     license: Apache-2.0
     licenseLink: https://zookeeper.apache.org/
   docker.io/busybox:

--- a/.github/trusted_registries.yaml
+++ b/.github/trusted_registries.yaml
@@ -4,6 +4,7 @@ docker.io:
   bats:
     bats: ALL_TAGS
   bitnami: ALL_IMAGES
+  bitnamilegacy: ALL_IMAGES
   busybox: ALL_TAGS
   ckan:
     ckan-base-datapusher: ALL_TAGS

--- a/charts/ckan/Chart.yaml
+++ b/charts/ckan/Chart.yaml
@@ -35,13 +35,13 @@ version: 1.3.3
 annotations:
   artifacthub.io/image-licenses.docker.io/bitnami/valkey: Apache-2.0
   artifacthub.io/images: |-
-    - image: docker.io/bitnami/kubectl                                                                                             #  default/Job/ckan-ckan-post-install.yaml
-    - image: docker.io/bitnami/postgresql:16.4.0-debian-12-r14                                                                     #  default/StatefulSet/ckan-postgresql-primary.yaml
-    - image: docker.io/bitnami/postgresql:16.4.0-debian-12-r14                                                                     #  default/StatefulSet/ckan-postgresql-read.yaml
-    - image: docker.io/bitnami/postgresql:17                                                                                       #  default/Job/ckan-ckan-post-install.yaml
-    - image: docker.io/bitnami/valkey:8.1.2-debian-12-r0                                                                           #  default/StatefulSet/ckan-valkey-primary.yaml
-    - image: docker.io/bitnami/valkey:8.1.2-debian-12-r0                                                                           #  default/StatefulSet/ckan-valkey-replicas.yaml
-    - image: docker.io/bitnami/zookeeper:3.9.3-debian-12-r15                                                                       #  default/StatefulSet/ckan-zookeeper.yaml
+    - image: docker.io/bitnamilegacy/kubectl                                                                                             #  default/Job/ckan-ckan-post-install.yaml
+    - image: docker.io/bitnamilegacy/postgresql:16.4.0-debian-12-r14                                                                     #  default/StatefulSet/ckan-postgresql-primary.yaml
+    - image: docker.io/bitnamilegacy/postgresql:16.4.0-debian-12-r14                                                                     #  default/StatefulSet/ckan-postgresql-read.yaml
+    - image: docker.io/bitnamilegacy/postgresql:17                                                                                       #  default/Job/ckan-ckan-post-install.yaml
+    - image: docker.io/bitnamilegacy/valkey:8.1.2-debian-12-r0                                                                           #  default/StatefulSet/ckan-valkey-primary.yaml
+    - image: docker.io/bitnamilegacy/valkey:8.1.2-debian-12-r0                                                                           #  default/StatefulSet/ckan-valkey-replicas.yaml
+    - image: docker.io/bitnamilegacy/zookeeper:3.9.3-debian-12-r15                                                                       #  default/StatefulSet/ckan-zookeeper.yaml
     - image: docker.io/busybox:1.28                                                                                                #  default/Job/ckan-ckan-post-install.yaml
     - image: docker.io/ckan/ckan-base-datapusher:0.0.21@sha256:84d11924549f44bcc1419256811d156893d837f90885b24f81f1753733b9d6ef    #  default/Deployment/ckan-datapusher.yaml
     - image: ghcr.io/teutonet/oci-images/ckan:1.0.15@sha256:88cd3bd9ecb13d9b02f9f16def521b808f19063c716095119f7da83623a24ef9       #  default/Deployment/ckan-ckan.yaml

--- a/charts/ckan/templates/ckan/post-install.yaml
+++ b/charts/ckan/templates/ckan/post-install.yaml
@@ -18,7 +18,7 @@ spec:
       restartPolicy: Never
       initContainers:
         - name: wait-for-postgresql
-          image: docker.io/bitnami/postgresql:17
+          image: docker.io/bitnamilegacy/postgresql:17
           command: [ 'sh', '-c', 'until pg_isready -U $CKAN_DB_USER -d $CKAN_DB -h $POSTGRES_HOST -p 5432; do echo waiting for database; sleep 2; done;' ]
           env:
             {{- if .Values.postgresql.enabled }}
@@ -160,7 +160,7 @@ spec:
             - mountPath: /api-tokens
               name: api-tokens-volume
         - name: update-secret
-          image: docker.io/bitnami/kubectl
+          image: docker.io/bitnamilegacy/kubectl:1.31
           command:
             - "/bin/sh"
             - "-c"

--- a/charts/ckan/values.yaml
+++ b/charts/ckan/values.yaml
@@ -109,6 +109,15 @@ datapusher:
 
 postgresql:
   enabled: true
+  image:
+    repository: bitnamilegacy/postgresql
+  volumePermissions:
+    image:
+      repository: bitnamilegacy/os-shell
+  metrics:
+    image:
+      repository: bitnamilegacy/postgres-exporter
+
   global:
     postgresql:
       auth:
@@ -190,11 +199,20 @@ postgresql:
             key: datapusherDatabase
 valkey:
   enabled: true
+  image:
+    repository: bitnamilegacy/valkey
+    tag: 7.2.5-debian-12-r9
+  metrics:
+    image:
+      repository: bitnamilegacy/redis-exporter
   replica:
     replicaCount: 1
 
 solr:
   enabled: true
+  volumePermissions:
+    image:
+      repository: bitnamilegacy/os-shell
   image:
     registry: "ghcr.io"
     pullPolicy: IfNotPresent
@@ -215,3 +233,5 @@ solr:
   replicaCount: 2
   zookeeper:
     replicaCount: 3
+    image:
+      repository: bitnamilegacy/zookeeper


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated post-install job images to bitnamilegacy sources to ensure continued availability and alignment with upstream changes.
  * Added configurable image repositories for Valkey, its metrics exporter, and Solr Zookeeper, defaulting to bitnamilegacy images.
  * No configuration changes required; behavior remains the same.
  * Expected impact: smoother image pulls and improved reliability with no downtime or functional differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->