### PR TITLE
chore(base-cluster): use upstream kubectl image instead of rancher

### DIFF
--- a/.github/image_licenses.yaml
+++ b/.github/image_licenses.yaml
@@ -77,9 +77,6 @@ licenses:
   docker.io/otel/opentelemetry-collector-contrib:
     license: Apache-2.0
     licenseLink: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/LICENSE
-  docker.io/rancher/kubectl:
-    license: Apache-2.0
-    licenseLink: https://raw.githubusercontent.com/kubernetes/kubernetes/refs/heads/master/LICENSE
   docker.io/stellio/stellio-api-gateway:
     license: Apache-2.0
     licenseLink: https://github.com/stellio-hub/stellio-context-broker/blob/develop/LICENSE.txt
@@ -200,6 +197,9 @@ licenses:
   registry.k8s.io/descheduler/descheduler:
     license: Apache-2.0
     licenseLink: https://github.com/kubernetes-sigs/descheduler/blob/master/LICENSE
+  registry.k8s.io/kubectl:
+    license: Apache-2.0
+    licenseLink: https://raw.githubusercontent.com/kubernetes/kubernetes/refs/heads/master/LICENSE
   registry.k8s.io/etcd:
     license: Apache-2.0
     licenseLink: https://github.com/kubernetes/kubernetes/blob/master/LICENSE

--- a/.github/trusted_registries.yaml
+++ b/.github/trusted_registries.yaml
@@ -22,8 +22,6 @@ docker.io:
   otel:
     opentelemetry-collector-contrib: ALL_TAGS
   postgres: ALL_TAGS
-  rancher:
-    kubectl: ALL_TAGS
   stellio: ALL_IMAGES
   traefik: ALL_TAGS
   velero: ALL_IMAGES
@@ -59,6 +57,7 @@ registry.k8s.io:
     external-dns: ALL_TAGS
   ingress-nginx: ALL_IMAGES
   kube-state-metrics: ALL_IMAGES
+  kubectl: ALL_TAGS
   metrics-server:
     metrics-server: ALL_TAGS
   provider-os: ALL_IMAGES

--- a/charts/base-cluster/templates/backup/velero/velero.yaml
+++ b/charts/base-cluster/templates/backup/velero/velero.yaml
@@ -26,7 +26,7 @@ spec:
       repository: {{ printf "%s/velero/velero" ($.Values.global.imageRegistry | default (include "base-cluster.defaultRegistry" (dict))) }}
     kubectl:
       image:
-        repository: {{ printf "%s/rancher/kubectl" ($.Values.global.imageRegistry | default (include "base-cluster.defaultRegistry" (dict))) }}
+        repository: {{ printf "%s/kubectl" ($.Values.global.imageRegistry | default .Values.global.kubectl.image.registry) }}
         tag: {{ .Capabilities.KubeVersion.Version }}
     upgradeCRDs: false
     cleanUpCRDs: true

--- a/charts/base-cluster/templates/kyverno/kyverno.yaml
+++ b/charts/base-cluster/templates/kyverno/kyverno.yaml
@@ -32,15 +32,11 @@ spec:
     test:
       image:
         registry: {{ include "base-cluster.defaultRegistry" (dict) }}
-    cleanupJobs:
-      admissionReports: &defaultImage
-        image:
-          registry: {{ include "base-cluster.defaultRegistry" (dict) }}
-      updateRequests: *defaultImage
-      ephemeralReports: *defaultImage
-      clusterEphemeralReports: *defaultImage
-      clusterAdmissionReports: *defaultImage
-    policyReportsCleanup: *defaultImage
+    policyReportsCleanup:
+      image:
+        registry: {{ .Values.global.imageRegistry | default .Values.global.kubectl.image.registry }}
+        repository: {{ .Values.global.kubectl.image.repository }}
+        tag: {{ .Values.global.kubectl.image.tag }}
     crds:
       migration:
         image:
@@ -51,12 +47,10 @@ spec:
       enabled: false
     webhooksCleanup:
       enable: true
-      {{- if not .Values.global.imageRegistry }}
       image:
         registry: {{ .Values.global.imageRegistry | default .Values.global.kubectl.image.registry }}
         repository: {{ .Values.global.kubectl.image.repository }}
         tag: {{ .Values.global.kubectl.image.tag }}
-      {{- end }}
     features:
       policyExceptions:
         enabled: true

--- a/charts/base-cluster/values.yaml
+++ b/charts/base-cluster/values.yaml
@@ -63,9 +63,9 @@ global:
   storageClass: ""
   kubectl:
     image:
-      registry: docker.io
-      repository: rancher/kubectl
-      tag: 1.33.3@sha256:26d09fcee6eb9a14b81c95e52dd90964a0a24263abb075f58651d2ac62651b59
+      registry: registry.k8s.io
+      repository: kubectl
+      tag: 1.33.4@sha256:261a9ed843eb68e3d50da132245e2221d75ca19504130e47bd32788c0ff339a0
   flux:
     image:
       registry: docker.io


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated kubectl container image source to registry.k8s.io/kubectl, replacing docker.io/rancher/kubectl
  * Upgraded kubectl to version 1.33.4
  * Updated image registry configurations and trusted registries list to reflect new image source
  * Refactored policy cleanup configurations for improved clarity
<!-- end of auto-generated comment: release notes by coderabbit.ai -->