### PR TITLE
chore(common): use upstream kubectl image instead of rancher

### DIFF
--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -1,4 +1,9 @@
 global:
+  kubectl:
+    image:
+      registry: registry.k8s.io
+      repository: kubectl
+      tag: 1.33.4@sha256:261a9ed843eb68e3d50da132245e2221d75ca19504130e47bd32788c0ff339a0
   telemetry:
     otlp:
       endpoint: auto


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added global settings to configure the kubectl image (registry, repository, tag), allowing stricter pinning and use of private or mirrored registries.
  - Expanded telemetry options with a new toggle for OTLP insecure mode (enabled by default), making it easier to connect to collectors that don’t use TLS, while the existing endpoint setting remains available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->