### PR TITLE
fix(base-cluster): migrate promtail leftovers to alloy

### DIFF
--- a/charts/base-cluster/templates/monitoring/alloy.yaml
+++ b/charts/base-cluster/templates/monitoring/alloy.yaml
@@ -31,7 +31,7 @@ spec:
     {{- end }}
     alloy:
       enableReporting: false
-      resources: {{- include "common.resources" .Values.monitoring.loki.promtail | nindent 8 }}
+      resources: {{- include "common.resources" .Values.monitoring.alloy | nindent 8 }}
       {{- if .Values.monitoring.loki.enabled }}
       mounts:
         varlog: true

--- a/charts/base-cluster/values.schema.json
+++ b/charts/base-cluster/values.schema.json
@@ -947,18 +947,18 @@
             },
             "resources": {
               "$ref": "#/$defs/resourceRequirements"
+            }
+          },
+          "additionalProperties": false
+        },
+        "alloy": {
+          "type": "object",
+          "properties": {
+            "resourcesPreset": {
+              "$ref": "#/$defs/resourcesPreset"
             },
-            "promtail": {
-              "type": "object",
-              "properties": {
-                "resourcesPreset": {
-                  "$ref": "#/$defs/resourcesPreset"
-                },
-                "resources": {
-                  "$ref": "#/$defs/resourceRequirements"
-                }
-              },
-              "additionalProperties": false
+            "resources": {
+              "$ref": "#/$defs/resourceRequirements"
             }
           },
           "additionalProperties": false

--- a/charts/base-cluster/values.yaml
+++ b/charts/base-cluster/values.yaml
@@ -328,15 +328,15 @@ monitoring:
       limits:
         cpu: 1
         memory: 1Gi
-    promtail:
-      resourcesPreset: nano
-      resources:
-        requests:
-          cpu: 50m
-          memory: 64Mi
-        limits:
-          cpu: 1
-          memory: 128Mi
+  alloy:
+    resourcesPreset: nano
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 1
+        memory: 128Mi
   metricsServer:
     enabled: true
   securityScanning:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved monitoring configuration from promtail to alloy, consolidating resource configuration under monitoring.alloy and updating templates to reference alloy resources.

* **Chores**
  * Removed promtail-specific configuration from values and schema; alloy now exposes resourcesPreset and resources fields.
  * Preserved existing default resource requests/limits to maintain current runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->