### PR TITLE
chore(base-cluster/logs): only delete volumes on deletion

### DIFF
--- a/charts/base-cluster/templates/monitoring/logs/loki.yaml
+++ b/charts/base-cluster/templates/monitoring/logs/loki.yaml
@@ -56,6 +56,8 @@ spec:
         capabilities:
           drop:
             - ALL
+      podSecurityContext:
+        fsGroupChangePolicy: OnRootMismatch
       auth_enabled: false
       storage:
         type: filesystem
@@ -94,6 +96,8 @@ spec:
       replicas: 1
       persistence: {{- include "common.storage.class" (dict "persistence" .Values.monitoring.loki.persistence "global" $.Values.global) | nindent 8 }}
         enabled: true
+        whenScaled: Retain
+        whenDeleted: Delete
         size: {{ .Values.monitoring.loki.persistence.size }}
       resources: {{- include "common.resources" .Values.monitoring.loki | nindent 8 }}
     monitoring:

--- a/charts/base-cluster/values.yaml
+++ b/charts/base-cluster/values.yaml
@@ -109,7 +109,7 @@ global:
     grafana:
       url: https://grafana.github.io/helm-charts
       charts:
-        loki: 6.33.0
+        loki: 6.42.0
         alloy: 1.2.0
         tempo-distributed: 1.46.0
       condition: "{{ and .Values.monitoring.prometheus.enabled (or .Values.monitoring.loki.enabled .Values.monitoring.tracing.enabled) }}"


### PR DESCRIPTION
chore(base-cluster/logs): optimize volume chown; this speeds up startup


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced filesystem group security policy for Loki pods to improve default security posture.
  - Added persistence lifecycle controls for Loki storage: retain data on scale events and delete on resource removal for clearer data management.
- Chores
  - Upgraded Loki chart dependency to 6.42.0 for the latest stability and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->