### PR TITLE
chore(base-cluster/traces): delete tempo volumes on deletion

### DIFF
--- a/charts/base-cluster/templates/monitoring/tracing/grafana-tempo.yaml
+++ b/charts/base-cluster/templates/monitoring/tracing/grafana-tempo.yaml
@@ -23,6 +23,10 @@ spec:
         registry: {{ $.Values.global.imageRegistry }}
     {{- end }}
     ingester: {{- include "common.resourcesWithPreset" .Values.monitoring.tracing.ingester | nindent 6 }}
+      persistentVolumeClaimRetentionPolicy:
+        enabled: true
+        whenDeleted: Delete
+        whenScaled: Retain
       replicas: &replicas 1
       config:
         replication_factor: *replicas

--- a/charts/base-cluster/values.yaml
+++ b/charts/base-cluster/values.yaml
@@ -111,7 +111,7 @@ global:
       charts:
         loki: 6.33.0
         alloy: 1.2.0
-        tempo-distributed: 1.46.0
+        tempo-distributed: 1.48.0
       condition: "{{ and .Values.monitoring.prometheus.enabled (or .Values.monitoring.loki.enabled .Values.monitoring.tracing.enabled) }}"
     external-dns:
       url: https://kubernetes-sigs.github.io/external-dns


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added PVC retention policy for Grafana Tempo ingester to retain data during scaling and clean up on deletion, improving data durability and lifecycle management.

- Chores
  - Upgraded Grafana Tempo Distributed chart to v1.48.0 for the monitoring stack.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->