### PR TITLE
feat(common): add statefulset recreate job

### DIFF
--- a/charts/common/templates/_statefulset_recreate_hook.yaml
+++ b/charts/common/templates/_statefulset_recreate_hook.yaml
@@ -1,0 +1,156 @@
+{{- define "common.statefulset.recreateOnSizeChangeHook" -}}
+  {{- $_ := mustMerge . (pick .context "Values" "Capabilities" "Release") -}}
+  {{- $renderedStatefulSets := list -}}
+  {{- range $renderedStatefulSet := include (print .context.Template.BasePath .pathToStatefulsetTemplate) .context | splitList "---" -}}
+    {{- with $renderedStatefulSet | fromYaml -}}
+      {{- $renderedStatefulSets = append $renderedStatefulSets . -}}
+    {{- end }}
+  {{- end -}}
+  {{- if $renderedStatefulSets }}
+    {{- range $newStatefulSet := $renderedStatefulSets -}}
+      {{- if $newStatefulSet.spec.volumeClaimTemplates }}
+        {{- $resourceNamespace := default $.Release.Namespace $newStatefulSet.metadata.namespace -}}
+        {{- $currentStatefulset := lookup $newStatefulSet.apiVersion $newStatefulSet.kind $resourceNamespace $newStatefulSet.metadata.name -}}
+        {{- $needsRecreation := false -}}
+        {{- $templates := dict -}}
+        {{- if $currentStatefulset -}}
+          {{- if ne (len $newStatefulSet.spec.volumeClaimTemplates) (len $currentStatefulset.spec.volumeClaimTemplates) -}}
+            {{- $needsRecreation = true -}}
+          {{- end -}}
+          {{- range $index, $newVolumeClaimTemplate := $newStatefulSet.spec.volumeClaimTemplates -}}
+            {{- $currentVolumeClaimTemplateSpec := dict -}}
+            {{- range $oldVolumeClaimTemplate := $currentStatefulset.spec.volumeClaimTemplates -}}
+              {{- if eq $oldVolumeClaimTemplate.metadata.name $newVolumeClaimTemplate.metadata.name -}}
+                {{- $currentVolumeClaimTemplateSpec = $oldVolumeClaimTemplate.spec -}}
+              {{- end -}}
+            {{- end }}
+            {{- $newVolumeClaimTemplateStorageSize := $newVolumeClaimTemplate.spec.resources.requests.storage -}}
+            {{- if not $currentVolumeClaimTemplateSpec -}}
+              {{- $needsRecreation = true -}}
+            {{- else -}}
+              {{- if ne $newVolumeClaimTemplateStorageSize $currentVolumeClaimTemplateSpec.resources.requests.storage -}}
+                {{- $needsRecreation = true -}}
+                {{- $templates = set $templates $newVolumeClaimTemplate.metadata.name $newVolumeClaimTemplateStorageSize -}}
+              {{- end -}}
+            {{- end -}}
+          {{- end -}}
+        {{- end -}}
+        {{- if $needsRecreation }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $newStatefulSet.metadata.name }}-recreate
+  namespace: {{ $resourceNamespace }}
+  labels:
+    {{- $newStatefulSet.metadata.labels | toYaml | nindent 4 }}
+    app.kubernetes.io/component: statefulset-recreate-job
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      name: {{ $newStatefulSet.metadata.name }}-recreate
+      labels:
+        {{- $newStatefulSet.metadata.labels | toYaml | nindent 8 }}
+    spec:
+      serviceAccountName: {{ $newStatefulSet.metadata.name }}-recreate
+      restartPolicy: OnFailure
+      containers:
+        - name: recreate
+          image: {{ include "common.images.image" (dict "imageRoot" (mustMerge (dict "tag" $.Capabilities.KubeVersion.Version) $.Values.global.kubectl.image) "global" $.Values.global) -}}
+          command:
+            - kubectl
+            - delete
+            - statefulset
+            - --cascade=orphan
+            - {{ $newStatefulSet.metadata.name }}
+        {{- range $index := until (int (default 1 $newStatefulSet.spec.replicas)) }}
+          {{- range $template, $size := $templates }}
+        - name: patch-pvc-{{ $template }}-{{ $index }}
+          image: {{ include "loki.baseImage" (dict "service" (dict "registry" "docker.io" "repository" "rancher/kubectl" "tag" ($.Capabilities.KubeVersion.Version | default "v1.33.0")) "global" $.Values.global.image) }}
+          command:
+            - kubectl
+            - patch
+            - pvc
+            - {{ printf "%s-%s-%d" $template $newStatefulSet.metadata.name $index }}
+            - --type='json'
+            - '-p=[{"op": "replace", "path": "/spec/resources/requests/storage", "value": "{{ $size }}"}]'
+          {{- end }}
+        {{- end }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $newStatefulSet.metadata.name }}-recreate
+  namespace: {{ $resourceNamespace }}
+  labels:
+    {{- $newStatefulSet.metadata.labels | toYaml | nindent 4 }}
+    app.kubernetes.io/component: statefulset-recreate-job
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $newStatefulSet.metadata.name }}-recreate
+  namespace: {{ $resourceNamespace }}
+  labels:
+    {{- $newStatefulSet.metadata.labels | toYaml | nindent 4 }}
+    app.kubernetes.io/component: statefulset-recreate-job
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    resourceNames:
+      - {{ $newStatefulSet.metadata.name }}
+    verbs:
+      - delete
+  - apiGroups:
+      - v1
+    resources:
+      - persistentvolumeclaims
+    resourceNames:
+    {{- range $index := until (int $newStatefulSet.spec.replicas) }}
+      {{- range $template := $templates | keys }}
+      - {{ printf "%s-%s-%d" $template $newStatefulSet.metadata.name $index }}
+      {{- end }}
+    {{- end }}
+    verbs:
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $newStatefulSet.metadata.name }}-recreate
+  namespace: {{ $resourceNamespace }}
+  labels:
+    {{- $newStatefulSet.metadata.labels | toYaml | nindent 4 }}
+    app.kubernetes.io/component: statefulset-recreate-job
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+subjects:
+  - kind: ServiceAccount
+    name: {{ $newStatefulSet.metadata.name }}-recreate
+    namespace: {{ $resourceNamespace }}
+roleRef:
+  kind: Role
+  name: {{ $newStatefulSet.metadata.name }}-recreate
+  apiGroup: rbac.authorization.k8s.io
+---
+        {{- end }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+{{- end -}}

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -1,4 +1,9 @@
 global:
+  kubectl:
+    image:
+      registry: registry.k8s.io
+      repository: kubectl
+      tag: 1.33.4@sha256:261a9ed843eb68e3d50da132245e2221d75ca19504130e47bd32788c0ff339a0
   telemetry:
     otlp:
       endpoint: auto


### PR DESCRIPTION
including this automatically adds a `pre-upgrade` hook that deletes the
referenced statefulset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically recreates StatefulSets during upgrades when PVC counts or requested storage sizes change, running controlled pre-upgrade steps to apply storage updates safely across replicas.
  * Added chart values to configure the kubectl image (registry, repository, tag) for clearer image control and provenance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->