### PR TITLE
fix(base-cluster): conditions must the `true`, not just truthy

### DIFF
--- a/charts/base-cluster/values.schema.json
+++ b/charts/base-cluster/values.schema.json
@@ -1758,7 +1758,7 @@
     },
     "condition": {
       "type": "string",
-      "description": "A condition with which to decide to include the resource. This will be templated. Must return a truthy value",
+      "description": "A condition with which to decide to include the resource. This will be templated. Must return the literal `true`, truthy values don't work.",
       "examples": [
         "{{ true }}",
         "{{ eq .Values.global.baseDomain \"teuto.net\" }}"

--- a/charts/base-cluster/values.yaml
+++ b/charts/base-cluster/values.yaml
@@ -59,7 +59,7 @@ global:
       dnsNames: |-
         - {{ printf "*.%s" (include "base-cluster.domain" $) | quote }}
       targetNamespaces: ALL
-      condition: "{{ and (not (empty .Values.global.baseDomain)) .Values.dns.provider }}"
+      condition: "{{ and (not (empty .Values.global.baseDomain)) (not (empty .Values.dns.provider)) }}"
   storageClass: ""
   kubectl:
     image:
@@ -117,12 +117,12 @@ global:
       url: https://kubernetes-sigs.github.io/external-dns
       charts:
         external-dns: 1.18.0
-      condition: '{{ ne .Values.dns.provider nil }}'
+      condition: '{{ not (empty .Values.dns.provider) }}'
     oauth2-proxy:
       url: https://oauth2-proxy.github.io/manifests
       charts:
         oauth2-proxy: 7.14.1
-      condition: '{{ and .Values.global.authentication.config .Values.monitoring.prometheus.enabled }}'
+      condition: '{{ and (not (empty .Values.global.authentication.config)) .Values.monitoring.prometheus.enabled }}'
     metrics-server:
       url: https://kubernetes-sigs.github.io/metrics-server
       charts:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened conditional checks to require explicit, non-empty values.
  * Certificates now deploy only when both a base domain and a DNS provider are set.
  * External DNS repository now enables only when a DNS provider is defined.
  * OAuth2 Proxy repository now enables only when Prometheus is enabled and authentication config is non-empty.

* **Documentation**
  * Clarified schema description: conditions must evaluate to the literal true; general truthy values are not accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->