### PR TITLE
fix(base-cluster/descheduler): don't remove pods with too many restarts

### DIFF
--- a/charts/base-cluster/values.yaml
+++ b/charts/base-cluster/values.yaml
@@ -361,9 +361,6 @@ descheduler:
           evictLocalStoragePods: true
           nodeFit: true
       - name: RemoveDuplicates
-      - name: RemovePodsHavingTooManyRestarts
-        args:
-          podRestartThreshold: 10
       - name: RemovePodsViolatingNodeAffinity
         args:
           nodeAffinityType:


### PR DESCRIPTION
Otherwise the prometheus alerts don't fire, as they never get too old.
Combined with pods that take a little while to crash and are ready
before that, not even KubeDeploymentReplicasMismatch triggers.
This effectively hides that error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the RemovePodsHavingTooManyRestarts policy from the base cluster descheduler configuration, including its associated pod restart threshold parameters and all related plugin list entries. This configuration change updates how the cluster manages pod eviction and rescheduling, specifically modifying the handling of pods that experience frequent restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->