### PR TITLE
fix(base-cluster/loki): adjust retention settings for loki logs

### DIFF
--- a/charts/base-cluster/templates/monitoring/logs/loki.yaml
+++ b/charts/base-cluster/templates/monitoring/logs/loki.yaml
@@ -83,7 +83,7 @@ spec:
         retention_enabled: true
         delete_request_store: filesystem
         compaction_interval: 15m
-        retention_delete_delay: 1m
+        retention_delete_delay: 24h
         retention_delete_worker_count: 150
       ingester:
         chunk_block_size: 524288


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated log retention to 45 days.
  * Introduced compactor tuning: 15m compaction interval, 24h deletion delay, and 150 deletion workers.
  * Removed the legacy retention mechanism and consolidated retention/deletion configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->