### PR TITLE
fix(base-cluster): add missing license info

### DIFF
--- a/.github/image_licenses.yaml
+++ b/.github/image_licenses.yaml
@@ -119,6 +119,9 @@ licenses:
   ghcr.io/teutonet/oci-images/solr-ckan:
     license: MIT
     licenseLink: https://github.com/teutonet/oci-images/blob/main/LICENSE
+  ghcr.io/k8up-io/k8up:
+    license: Apache-2.0
+    licenseLink: https://raw.githubusercontent.com/k8up-io/k8up/refs/heads/master/LICENSE
   mirror.gcr.io/aquasec/trivy-operator:
     license: Apache-2.0
     licenseLink: https://github.com/aquasecurity/trivy-operator/blob/main/LICENSE

--- a/.github/trusted_registries.yaml
+++ b/.github/trusted_registries.yaml
@@ -36,6 +36,8 @@ ghcr.io:
   kyverno:
     kyverno-cli: ALL_TAGS
   teutonet: ALL_IMAGES
+  k8up-io:
+    k8up: ALL_TAGS
 mirror.gcr.io:
   aquasec: ALL_IMAGES
 quay.io:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new container image registry to the trusted registries configuration with support for all tags.
  * Documented licensing information for the newly added registry entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->