### PR TITLE
feat(base-cluster/backup): make k8up a bit more configurable

### DIFF
--- a/charts/base-cluster/templates/backup/k8up/k8up.yaml
+++ b/charts/base-cluster/templates/backup/k8up/k8up.yaml
@@ -43,7 +43,7 @@ spec:
     resources: {{- include "common.resources" .Values.backup | nindent 6 }}
     k8up:
       globalResources: {{- include "common.resources" .Values.backup.runners | nindent 8 }}
-      skipWithoutAnnotation: true
+      skipWithoutAnnotation: {{ .Values.backup.provider.k8up.skipWithoutAnnotation | default false }}
     priorityClassName: system-cluster-critical
     {{- if .Values.monitoring.prometheus.enabled }}
     metrics:

--- a/charts/base-cluster/values.schema.json
+++ b/charts/base-cluster/values.schema.json
@@ -1692,6 +1692,11 @@
               "properties": {
                 "k8up": {
                   "type": "object",
+                  "properties": {
+                    "skipWithoutAnnotation": {
+                      "type": "boolean"
+                    }
+                  },
                   "additionalProperties": false
                 }
               },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * k8up backup behavior is now configurable via values: the skip-without-annotation setting can be enabled or disabled (defaults to false).
  * Configuration schema updated to add and validate a boolean skipWithoutAnnotation setting for k8up, ensuring deployments can declare and be validated for this option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->