### PR TITLE
fix(base-cluster/ingress): add missing `prometheus` block 🙄

### DIFF
--- a/charts/base-cluster/templates/ingress/traefik.yaml
+++ b/charts/base-cluster/templates/ingress/traefik.yaml
@@ -54,6 +54,8 @@ spec:
         loadBalancerIP: {{ .Values.ingress.IP | quote }}
         ipFamilyPolicy: PreferDualStack
       {{- end }}
+    ingressClass:
+      isDefaultClass: false
     gatewayClass:
       name: default
     gateway:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Traefik ingress controller configuration to specify non-default ingress class handling.
  * Reorganized metrics monitoring configuration structure for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->