### PR TITLE
chore(base-cluster): add loki retention value

### DIFF
--- a/charts/base-cluster/templates/monitoring/logs/loki.yaml
+++ b/charts/base-cluster/templates/monitoring/logs/loki.yaml
@@ -78,7 +78,7 @@ spec:
       commonConfig:
         replication_factor: 1
       limits_config:
-        retention_period: 45d
+        retention_period: {{ .Values.monitoring.loki.retention_period }}
       compactor:
         retention_enabled: true
         delete_request_store: filesystem

--- a/charts/base-cluster/values.schema.json
+++ b/charts/base-cluster/values.schema.json
@@ -921,6 +921,12 @@
             "enabled": {
               "type": "boolean"
             },
+            "retention_period": {
+              "type": "string",
+              "pattern": "[0-9]+(ms|s|m|h|d|w|y)",
+              "description": "Loki log retention period (e.g., 45d, 7d, 24h)",
+              "examples": ["45d", "7d", "24h"]
+            },
             "persistence": {
               "type": "object",
               "properties": {

--- a/charts/base-cluster/values.yaml
+++ b/charts/base-cluster/values.yaml
@@ -312,6 +312,7 @@ monitoring:
         size: 1Gi
   loki:
     enabled: true
+    retention_period: 45d
     persistence:
       storageClass: ""
       size: 10Gi


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Loki log retention period is now configurable via chart values; default remains 45 days.
* **Validation**
  * Added schema validation for the retention setting (pattern and examples) to ensure valid duration formats (e.g., 45d, 7d, 24h).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->