### PR TITLE
fix(base-cluster): add missing value to template

### DIFF
--- a/charts/base-cluster/values.yaml
+++ b/charts/base-cluster/values.yaml
@@ -192,7 +192,7 @@ global:
       url: https://vmware-tanzu.github.io/helm-charts
       charts:
         velero: 7.2.2
-      condition: "{{ not (empty .Values.backup.backupStorageLocations) }}"
+      condition: '{{ ne (.Values.backup.provider).velero nil }}'
     kube-janitor:
       url: https://codeberg.org/hjacobs/kube-janitor
       charts:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Changed deployment gating for the VMware chart to rely on the Velero provider being set rather than the presence of backup storage locations, preventing incorrect skips or deployments during Helm releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->