### PR TITLE
feat(ckan/ingress): remove truncation for ingress tls secret name

### DIFF
--- a/charts/ckan/templates/ingress.yaml
+++ b/charts/ckan/templates/ingress.yaml
@@ -36,7 +36,7 @@ spec:
       {{- if .Values.ckan.ingress.existingSecret }}
       secretName: {{ .Values.ckan.ingress.existingSecret }}
       {{- else }}
-      secretName: {{ printf "%s-tls" (tpl .Values.ckan.ingress.hostname .) | trunc 63 | trimSuffix "-" }}
+      secretName: {{ printf "%s-tls" (tpl .Values.ckan.ingress.hostname .) }}
       {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
when the hostname has a certain length, it could generate an invalid secret name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated TLS secret naming for Ingress: secret names now use the full generated hostname (no truncation or trimming), which may change existing TLS secret names and affect certificate identification in your Kubernetes deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->