### PR TITLE
feat(base-cluster/alertmanager): add telegram receiver

### DIFF
--- a/charts/base-cluster/ci/telegram-values.yaml
+++ b/charts/base-cluster/ci/telegram-values.yaml
@@ -1,0 +1,10 @@
+monitoring:
+  prometheus:
+    alertmanager:
+      receivers:
+        telegram:
+          botToken: botToken
+          chatid: 123456789
+        telegram zwei:
+          botToken: botToken2
+          chatid: 987654321

--- a/charts/base-cluster/templates/_helpers.tpl
+++ b/charts/base-cluster/templates/_helpers.tpl
@@ -11,3 +11,14 @@
 {{- define "base-cluster.helm.chartSpec" -}}
   {{- include "common.helm.chartSpec" (dict "context" .context "repo" .repo "chart" .chart "prependReleaseName" false "reconcileStrategy" .reconcileStrategy) -}}
 {{- end -}}
+
+{{- define "base-cluster.monitoring.alertmanager.receiver.splitName" -}}
+  {{- $name := .name -}}
+  {{- $type := $name -}}
+  {{- $splitted := splitList " " $name -}}
+  {{- if eq (len $splitted) 2 -}}
+    {{- $type = index $splitted 0 -}}
+    {{- $name = index $splitted 1 -}}
+  {{- end -}}
+  {{- dict "type" $type "name" $name | toYaml -}}
+{{- end -}}

--- a/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_alertmanager-config.yaml
+++ b/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_alertmanager-config.yaml
@@ -14,6 +14,7 @@
 {{- end -}}
 
 {{- define "base-cluster.prometheus-stack.alertmanager.config" -}}
+{{- $credentialPath := "/var/run/secrets/alertmanager" -}}
 {{- if include "base-cluster.prometheus-stack.alertmanager.enabled" . -}}
 enabled: true
 podDisruptionBudget:
@@ -29,6 +30,14 @@ alertmanagerSpec:
   {{- end }}
   retention: {{ .Values.monitoring.prometheus.alertmanager.retentionDuration }}
   priorityClassName: monitoring-components
+  volumes:
+    - name: alertmanager-receiver-credentials
+      secret:
+        secretName: alertmanager-receiver-credentials
+  volumeMounts:
+    - name: alertmanager-receiver-credentials
+      mountPath: {{ printf "%s" $credentialPath }}
+      readOnly: true
   storageSpec:
     volumeClaimTemplate:
       spec: {{- include "common.storage.class" (dict "persistence" .Values.monitoring.prometheus.alertmanager.persistence "global" $.Values.global) | nindent 8 }}
@@ -43,7 +52,7 @@ config:
     {{- $receivers = set $receivers "healthchecks.io" (dict
           "webhook_configs" (list
             (dict
-              "url" (printf "https://hc-ping.com/%s/%s-monitoring" .Values.monitoring.deadMansSwitch.pingKey (include "base-cluster.deadMansSwitch.checkName" .))
+              "url_file" (printf "%s/%s" $credentialPath "healthchecks.io")
               "send_resolved" false
             )
           )
@@ -51,17 +60,17 @@ config:
     -}}
   {{- end -}}
   {{- range $name, $config := .Values.monitoring.prometheus.alertmanager.receivers -}}
-    {{- $type := $name -}}
-    {{- $splitted := splitList " " $name -}}
-    {{- if eq (len $splitted) 2 -}}
-      {{- $type = index $splitted 0 -}}
-      {{- $name = index $splitted 1 -}}
+    {{- $receiverInfo := include "base-cluster.monitoring.alertmanager.receiver.splitName" (dict "name" $name) | fromYaml -}}
+    {{- $type := $receiverInfo.type -}}
+    {{- $name = $receiverInfo.name -}}
+    {{- if hasKey $receivers $name -}}
+      {{- fail (printf "Duplicate: %s" $name) -}}
     {{- end -}}
     {{- if eq $type "pagerduty" -}}
-      {{- $receivers = set $receivers "pagerduty" (dict
+      {{- $receivers = set $receivers $name (dict
             "pagerduty_configs" (list
               (dict
-                "routing_key" $config.integrationKey
+                "routing_key_file" (printf "%s/%s" $credentialPath $name)
                 "url" ($config.url | default "https://events.pagerduty.com/v2/enqueue")
                 "send_resolved" true
                 "http_config" (dict "follow_redirects" true)
@@ -78,13 +87,25 @@ config:
                 "smarthost" (printf "%s:%d" $config.host (int64 $config.port))
                 "send_resolved" (dig "sendResolved" false $config)
                 "auth_username" $config.username
-                "auth_password" $config.password
+                "auth_password_file" (printf "%s/%s" $credentialPath $name)
+              )
+            )
+        )
+      -}}
+    {{- else if eq $type "telegram" -}}
+      {{- $receivers = set $receivers $name (dict
+            "telegram_configs" (list
+              (dict
+                "bot_token_file" (printf "%s/%s" $credentialPath $name)
+                "chat_id" $config.chatid
+                "send_resolved" (dig "sendResolved" true $config)
               )
             )
         )
       -}}
     {{- end -}}
   {{- end -}}
+
   {{- $receiversList := list -}}
   {{- range $name, $receiver := $receivers -}}
     {{- $receiversList = append $receiversList (mustMerge (dict "name" $name) $receiver) -}}

--- a/charts/base-cluster/templates/monitoring/kube-prometheus-stack/receiver-secret.yaml
+++ b/charts/base-cluster/templates/monitoring/kube-prometheus-stack/receiver-secret.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.monitoring.prometheus.alertmanager.receivers }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: alertmanager-receiver-credentials
+  namespace: monitoring
+  labels: {{- include "common.labels.standard" $ | nindent 4 }}
+    app.kubernetes.io/component: grafana
+    app.kubernetes.io/part-of: monitoring
+type: Opaque
+{{- $list := dict -}}
+{{- if (.Values.monitoring.deadMansSwitch).pingKey -}}
+  {{- $list = set $list "healthchecks.io" (printf "https://hc-ping.com/%s/%s-monitoring" .Values.monitoring.deadMansSwitch.pingKey (include "base-cluster.deadMansSwitch.checkName" .)) -}}
+{{- end -}}
+{{- $keys := list "botToken" "password" "integrationKey" -}}
+{{- range $name, $receiver := .Values.monitoring.prometheus.alertmanager.receivers -}}
+  {{- range $key := $keys -}}
+    {{- if hasKey $receiver $key -}}
+      {{- $value := index $receiver $key -}}
+      {{- $splitted := include "base-cluster.monitoring.alertmanager.receiver.splitName" (dict "name" $name) | fromYaml -}}
+      {{- $list = set $list $splitted.name $value -}}
+    {{- end -}}
+  {{- end -}}
+{{- end }}
+stringData: {{- toYaml $list | nindent 2 }}
+{{- end }}

--- a/charts/base-cluster/values.schema.json
+++ b/charts/base-cluster/values.schema.json
@@ -612,8 +612,8 @@
                 },
                 "receivers": {
                   "type": "object",
-                  "properties": {
-                    "pagerduty": {
+                  "patternProperties": {
+                    "^pagerduty( \\S+)?$": {
                       "type": "object",
                       "properties": {
                         "url": {
@@ -630,10 +630,9 @@
                         "integrationKey"
                       ],
                       "additionalProperties": false
-                    }
-                  },
-                  "patternProperties": {
-                    "^email($| \\S+$)": {
+                    },
+                    "^email( \\S+)?$": {
+                      "type": "object",
                       "description": "Sets up an email receiver, if suffixed with ` $name` `$name` will be used as the name of the receiver, otherwise it's `email`",
                       "properties": {
                         "from": {
@@ -669,7 +668,28 @@
                         "password"
                       ],
                       "additionalProperties": false
-                    }
+                    },
+                    "^telegram( \\S+)?$": {
+                      "type": "object",
+                      "description": "Sets up a telegram receiver, if suffixed with ` $name` `$name` will be used as the name of the receiver, otherwise it's `telegram`",
+                      "properties": {
+                        "botToken": {
+                          "type": "string"
+                        },
+                        "chatid": {
+                          "type": "integer"
+                        },
+                        "sendResolved": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "chatid",
+                        "botToken"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "additionalProperties": false
                   }
                 },
                 "routes": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Telegram receiver support for Alertmanager: configure bot token, chat ID, and sendResolved per receiver via Kubernetes secrets.
  * Secrets-backed receivers: Alertmanager now reads credentials (PagerDuty, email, Telegram, healthchecks) from mounted secret files.

* **Bug Fixes / Validation**
  * Healthchecks dead-man-switch URL switched to file-based secret.
  * Receiver name parsing/validation improved; duplicate receiver names are rejected.
* **Schema**
  * Receiver schema updated to pattern-based keys to support typed receiver names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->