### PR TITLE
feat(base-cluster/monitoring)!: add alert for retention and automatically set retention based on size

### DIFF
--- a/charts/base-cluster/README.md.gotmpl
+++ b/charts/base-cluster/README.md.gotmpl
@@ -435,3 +435,6 @@ of `.monitoring.tracing.ingester.<field>`
 - This release disables the trivy-operator by default.
   To continue using the operator set `.monitoring.securityScanning.enabled` to `true`.
 {{ .Files.Get "values.md"  }}
+
+- This release remove the field `.monitoring.prometheus.retentionSize` as the retention is now automatically calculated
+  and set. If data retention is happening an alert is triggered.

--- a/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_prometheus_config.yaml
+++ b/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_prometheus_config.yaml
@@ -24,7 +24,8 @@ prometheusSpec:
   probeSelectorNilUsesHelmValues: false
   scrapeConfigSelectorNilUsesHelmValues: false
   retention: {{ .Values.monitoring.prometheus.retentionDuration }}
-  retentionSize: {{ .Values.monitoring.prometheus.retentionSize }}
+  {{ $size := .Values.monitoring.prometheus.persistence.size }}
+  retentionSize: {{ include "common.convert" (dict "value" (div (mul (include "common.convert" (dict "value" $size "to" "")) 9) 10) "to" "Gi") | replace "i" "B" }}
   storageSpec:
     volumeClaimTemplate:
       spec: {{- include "common.storage.class" (dict "persistence" .Values.monitoring.prometheus.persistence "global" $.Values.global) | nindent 8 }}

--- a/charts/base-cluster/templates/monitoring/kube-prometheus-stack/retention.yaml
+++ b/charts/base-cluster/templates/monitoring/kube-prometheus-stack/retention.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.monitoring.prometheus.enabled -}}
+{{- include "base-cluster.helm.resourceWithDependencies" (dict "name" "prometheus-retention" "resource" (include "base-cluster.prometheus.retentionRule" .) "render" false "dependencies" (dict "monitoring" "kube-prometheus-stack") "context" $ "additionalLabels" (dict "app.kubernetes.io/component" "prometheus" "app.kubernetes.io/part-of" "flux")) }}
+{{- end -}}
+
+{{- define "base-cluster.prometheus.retentionRule" -}}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: prometheus-retention-happened
+  namespace: monitoring
+  labels: {{- include "common.labels.standard" $ | nindent 4 }}
+    monitoring/provisioned-by: base-cluster
+    app.kubernetes.io/component: prometheus
+    app.kubernetes.io/part-of: monitoring
+spec:
+  groups:
+    - name: prometheus-retention
+      rules:
+        - alert: prometheusRetentionHappened
+          annotations:
+            description: Data retention happened on {{ `{{ $labels.pod }}` }} in namespace {{ `{{ $labels.namespace }}` }}!
+            summary: Data retention happened, you should increase storage!
+          expr: increase(prometheus_tsdb_size_retentions_total[5m]) > 0
+          for: 1m
+          labels:
+            severity: critical
+            period: WorkingHours
+{{- end }}

--- a/charts/base-cluster/values.schema.json
+++ b/charts/base-cluster/values.schema.json
@@ -538,10 +538,6 @@
               "type": "string",
               "pattern": "[0-9]+(ms|s|m|h|d|w|y)"
             },
-            "retentionSize": {
-              "type": "string",
-              "pattern": "[0-9]+(B|KB|MB|GB|TB|PB|EB)"
-            },
             "persistence": {
               "type": "object",
               "properties": {

--- a/charts/base-cluster/values.yaml
+++ b/charts/base-cluster/values.yaml
@@ -285,7 +285,6 @@ monitoring:
     enabled: true
     replicas: 2
     retentionDuration: 4w
-    retentionSize: 90GB
     persistence:
       storageClass: ""
       size: 100Gi


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated alerting for Prometheus storage retention events with critical-severity notifications, contextual summary/description, and working-hours scoping.

* **Chores**
  * Prometheus retention size now computed dynamically from configured storage capacity using a new unit-conversion helper (with validation), replacing the previous static value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->