### PR TITLE
feat(teuto-cnpg): add ability to use encrypted backups

### DIFF
--- a/charts/teuto-cnpg/README.md
+++ b/charts/teuto-cnpg/README.md
@@ -47,6 +47,15 @@ values:
 accessKeyId and accessSecretKey are set to `ACCESS_KEY_ID` and `accessSecretKeyEY` by default
 but can be overwritten with .values.backup.s3.accessKeyId or .values.backup.s3.accessSecretKey.
 
+## Migration from barman to pgbackrest
+
+- comment out the `.values.backup`-block
+- after rollout, remove barman CRDs
+- re-add backup section with `encrypted: true` and `bucketname`
+- path should look like `/backup`
+- the target bucket needs to be empty. Make sure to create it as
+  pgbackrest wont create the bucket.
+
 # cnpg-wrapper configuration
 
 **Title:** cnpg-wrapper configuration
@@ -522,4 +531,3 @@ cloudnative-pg/postgresql
 | **Type** | `string` |
 
 ----------------------------------------------------------------------------------------------------------------------------
-

--- a/charts/teuto-cnpg/ci/encrypted-backup-values.yaml
+++ b/charts/teuto-cnpg/ci/encrypted-backup-values.yaml
@@ -1,0 +1,17 @@
+backup:
+  encrypted: true
+  retention:
+    full: 7
+    diff: 14
+    archive: 2
+    history: 30
+
+  s3:
+    path: "/test/path"
+    endpointURL: "endpointURL"
+    bucketName: "test"
+    secret:
+      name: "MeinNameIstNichtGeheim"
+      accessKeyId: "dasjhiodsadas"
+      accessSecretKey: "jiopidasda"
+      encryptionPass: "ENCRYPTIONPASS"

--- a/charts/teuto-cnpg/templates/cluster.yaml
+++ b/charts/teuto-cnpg/templates/cluster.yaml
@@ -19,12 +19,31 @@ spec:
   imageName: {{ include "common.images.image" (dict "imageRoot" .Values.databaseImage "global" .Values.global) }}
   instances: {{ .Values.instances }}
   logLevel: {{ .Values.logLevel }}
-  {{- if .Values.backup }}
+  {{- if and (not (.Values.backup).encrypted) .Values.backup }}
   plugins:
   - name: barman-cloud.cloudnative-pg.io
     isWALArchiver: true
     parameters:
       barmanObjectName: {{ .Release.Name }}
+  {{- end }}
+  {{- if and  (.Values.backup).encrypted .Values.backup.recovery }}
+  plugins:
+    - name: pgbackrest.dalibo.com
+      enabled: true
+      isWALArchiver: true
+      parameters:
+        stanzaRef: {{ .Release.Name }}
+  {{- end }}
+  {{- if and (.Values.backup).encrypted .Values.backup.recovery }}
+  bootstrap:
+    recovery:
+      source: {{ .Values.backup.recoveryName }}
+  externalClusters:
+    - name: {{ .Values.backup.recoveryName }}
+      plugin:
+        name: pgbackrest.dalibo.com
+        parameters:
+          stanzaRef: {{ .Release.Name }}
   {{- end }}
   managed:
     {{- $roles := dict -}}

--- a/charts/teuto-cnpg/templates/objectstore.yaml
+++ b/charts/teuto-cnpg/templates/objectstore.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.backup }}
+{{- if and (not (.Values.backup).encrypted) .Values.backup }}
 apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore
 metadata:

--- a/charts/teuto-cnpg/templates/stanza.yaml
+++ b/charts/teuto-cnpg/templates/stanza.yaml
@@ -1,0 +1,38 @@
+{{- if (.Values.backup).encrypted }}
+apiVersion: pgbackrest.dalibo.com/v1
+kind: Stanza
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+spec:
+  stanzaConfiguration:
+    name: main
+    s3Repositories:
+      - bucket: {{ .Values.backup.s3.bucketName | quote }}
+        endpoint: {{ .Values.backup.s3.endpointURL | quote }}
+        repoPath: {{ .Values.backup.s3.path | quote }}
+        region: Region1
+        uriStyle: path
+        verifyTLS: true
+        {{- if .Values.backup.retention }}
+        retentionPolicy:
+          full: {{ .Values.backup.retention.full }}
+          fullType: count
+          diff: {{ .Values.backup.retention.diff }}
+          archive: {{ .Values.backup.retention.archive }}
+          archiveType: full
+          history: {{ .Values.backup.retention.history }}
+        {{- end }}
+        cipherConfig:
+          encryptionPass:
+            name: {{ .Values.backup.s3.secret.name }}
+            key: {{ .Values.backup.s3.secret.encryptionPass | default "ENCRYPTION_PASS" }}
+        secretRef:
+          accessKeyId:
+            name: {{ .Values.backup.s3.secret.name }}
+            key: {{ .Values.backup.s3.secret.accessKeyId | default "ACCESS_KEY_ID" }}
+          secretAccessKey:
+            name: {{ .Values.backup.s3.secret.name }}
+            key: {{ .Values.backup.s3.secret.accessSecretKey | default "ACCESS_SECRET_KEY" }}
+{{- end }}

--- a/charts/teuto-cnpg/templates/validation.yaml
+++ b/charts/teuto-cnpg/templates/validation.yaml
@@ -1,0 +1,5 @@
+{{- if (.Values.backup).encrypted }}
+  {{- if not .Values.backup.s3.bucketName }}
+    {{ fail "bucketName must be set when encryption is activated"}}
+  {{- end }}
+{{- end }}

--- a/charts/teuto-cnpg/values.schema.json
+++ b/charts/teuto-cnpg/values.schema.json
@@ -170,12 +170,43 @@
       ],
       "description": "See: https://cloudnative-pg.io/documentation/1.16/backup_recovery/",
       "properties": {
+        "retention": {
+          "type": "object",
+          "required": [
+            "full",
+            "diff",
+            "archive",
+            "history"
+          ],
+          "properties": {
+            "full": {
+              "type": "integer",
+              "description": "Number of full backups in days"
+            },
+            "diff": {
+              "type": "integer",
+              "description": "Number of differential backups"
+            },
+            "archive": {
+              "type": "integer",
+              "description": "Number of backups worth of continuous WAL to retain."
+            },
+            "history": {
+              "type": "integer",
+              "description": "Days of backup history manifests to retain."
+            }
+          }
+        },
         "schedule": {
           "type": "string",
           "description": "cron syntax",
           "examples": [
             "0 0 0 * * *"
           ]
+        },
+        "encrypted": {
+          "type": "boolean",
+          "default": false
         },
         "s3": {
           "type": "object",
@@ -193,6 +224,10 @@
               "type": "string",
               "description": "url of the api endpoint"
             },
+            "bucketName": {
+              "type": "string",
+              "description": "name of the bucket"
+            },
             "secret": {
               "type": "object",
               "properties": {
@@ -206,6 +241,10 @@
                 "accessSecretKey": {
                   "type": "string",
                   "default": "ACCESS_SECRET_KEY"
+                },
+                "encryptionPass": {
+                  "type": "string",
+                  "default": "ENCRYPTION_PASS"
                 }
               },
               "additionalProperties": false,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standalone encrypted-backup profile for S3-based backups.
  * Adds pgBackRest stanza support for encrypted backups and conditional plugin selection for encrypted vs non-encrypted setups.

* **Configuration**
  * Configurable encrypted backup retention (full, differential, archive, history) and S3 repository settings.
  * Secret-backed encryption and credential references.

* **Validation**
  * Deployment checks require an S3 bucket when encryption is enabled.

* **Documentation**
  * Migration guidance and updated configuration docs for backup migration and wrapper properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->