### PR TITLE
fix(base-cluster/cert-manager): add new line to fix breaking yaml file

### DIFF
--- a/charts/base-cluster/templates/cert-manager/clusterissuer.yaml
+++ b/charts/base-cluster/templates/cert-manager/clusterissuer.yaml
@@ -1,7 +1,7 @@
 {{- if and .Values.certManager.email (ne .Values.ingress.provider "none") }}
-{{- include "base-cluster.helm.resourceWithDependencies" (dict "name" "clusterissuer-letsencrypt-production" "resource" (include "base-cluster.cert-manager.clusterIssuer" (dict "name" "production" "url" "https://acme-v02.api.letsencrypt.org/directory" "context" $)) "dependencies" (dict "cert-manager" "cert-manager") "context" $ "additionalLabels" (dict "app.kubernetes.io/component" "cert-manager")) }}
+{{- include "base-cluster.helm.resourceWithDependencies" (dict "name" "clusterissuer-letsencrypt-production" "resource" (include "base-cluster.cert-manager.clusterIssuer" (dict "name" "production" "url" "https://acme-v02.api.letsencrypt.org/directory" "context" $)) "dependencies" (dict "cert-manager" "cert-manager") "context" $ "additionalLabels" (dict "app.kubernetes.io/component" "cert-manager")) | nindent 0 }}
 ---
-{{- include "base-cluster.helm.resourceWithDependencies" (dict "name" "clusterissuer-letsencrypt-staging" "resource" (include "base-cluster.cert-manager.clusterIssuer" (dict "name" "staging" "url" "https://acme-staging-v02.api.letsencrypt.org/directory" "context" $)) "dependencies" (dict "cert-manager" "cert-manager") "context" $ "additionalLabels" (dict "app.kubernetes.io/component" "cert-manager")) }}
+{{- include "base-cluster.helm.resourceWithDependencies" (dict "name" "clusterissuer-letsencrypt-staging" "resource" (include "base-cluster.cert-manager.clusterIssuer" (dict "name" "staging" "url" "https://acme-staging-v02.api.letsencrypt.org/directory" "context" $)) "dependencies" (dict "cert-manager" "cert-manager") "context" $ "additionalLabels" (dict "app.kubernetes.io/component" "cert-manager")) | nindent 0 }}
 {{- end -}}
 
 {{- define "base-cluster.cert-manager.clusterIssuer" -}}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted indentation in cert-manager ClusterIssuer templates for production and staging to improve YAML formatting and consistency in rendered manifests. These changes only affect output formatting and do not alter names, URLs, contexts, or runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->