### PR TITLE
feat(t8s-cluster/rbac): use Users instead of the whole Group

### DIFF
--- a/charts/t8s-cluster/templates/workload-cluster/rbac/teuto-clusterrolebinding.yaml
+++ b/charts/t8s-cluster/templates/workload-cluster/rbac/teuto-clusterrolebinding.yaml
@@ -6,8 +6,12 @@ kind: ClusterRoleBinding
 metadata:
   name: teuto-staff
 subjects:
-  - kind: Group
-    name: teuto.net:staff
+  - kind: User
+    name: cwr@teuto.net
+  - kind: User
+    name: mw@teuto.net
+  - kind: User
+    name: st@teuto.net
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated cluster authorization and role-based access control configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->