### PR TITLE
fix(base-cluster/monitoring): only watch and create metrics for latest apiVersion

### DIFF
--- a/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_kube-state-metrics-config.yaml
+++ b/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_kube-state-metrics-config.yaml
@@ -53,50 +53,62 @@ customResourceState:
       -}}
 
       {{- $resources := list -}}
-      {{- range $kind, $group := $types -}}
-        {{- $resources = append $resources (dict
-              "groupVersionKind" (dict
-                "group" (printf "%s.toolkit.fluxcd.io" $group)
-                "kind" $kind
-              )
-              "metricNamePrefix" "gotk"
-              "metrics" (list
-                (dict
-                  "name" "reconcile_condition_gauge"
-                  "help" (printf "The current conditions of a Flux %s resource." $kind)
-                  "each" (dict
-                    "type" "Gauge"
-                    "gauge" (dict
-                      "path" (list "status" "conditions")
-                      "labelsFromPath" (dict
-                        "type" (list "type")
+      {{- range $fluxKind, $fluxGroup := $types -}}
+        {{- $crdPlural := regexReplaceAll "$" (regexReplaceAll "y$" ($fluxKind | lower) "ie") "s" -}}
+        {{- $group := printf "%s.toolkit.fluxcd.io" $fluxGroup -}}
+        {{- $crd := lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" (printf "%s.%s" $crdPlural $group) -}}
+        {{- if $crd -}}
+          {{- $version := "" -}}
+          {{- range $version := $crd.spec.versions -}}
+            {{- if $version.storage -}}
+              {{- $version = $version.name -}}
+            {{- end -}}
+          {{- end -}}
+          {{- $resources = append $resources (dict
+                "groupVersionKind" (dict
+                  "group" $group
+                  "kind" $fluxKind
+                  "version" $version
+                )
+                "metricNamePrefix" "gotk"
+                "metrics" (list
+                  (dict
+                    "name" "reconcile_condition_gauge"
+                    "help" (printf "The current conditions of a Flux %s resource." $fluxKind)
+                    "each" (dict
+                      "type" "Gauge"
+                      "gauge" (dict
+                        "path" (list "status" "conditions")
+                        "labelsFromPath" (dict
+                          "type" (list "type")
+                        )
+                        "valueFrom" (list "status")
                       )
-                      "valueFrom" (list "status")
+                    )
+                    "labelsFromPath" (dict
+                      "customresource_namespace" (list "metadata" "namespace")
+                      "customresource_name" (list "metadata" "name")
                     )
                   )
-                  "labelsFromPath" (dict
-                    "customresource_namespace" (list "metadata" "namespace")
-                    "customresource_name" (list "metadata" "name")
-                  )
-                )
-                (dict
-                  "name" "reconcile_suspended_gauge"
-                  "help" (printf "The reconciliation suspended status of a Flux %s resource." $kind)
-                  "each" (dict
-                    "type" "Gauge"
-                    "gauge" (dict
-                      "path" (list "spec" "suspend")
-                      "nilIsZero" true
+                  (dict
+                    "name" "reconcile_suspended_gauge"
+                    "help" (printf "The reconciliation suspended status of a Flux %s resource." $fluxKind)
+                    "each" (dict
+                      "type" "Gauge"
+                      "gauge" (dict
+                        "path" (list "spec" "suspend")
+                        "nilIsZero" true
+                      )
                     )
-                  )
-                  "labelsFromPath" (dict
-                    "customresource_namespace" (list "metadata" "namespace")
-                    "customresource_name" (list "metadata" "name")
+                    "labelsFromPath" (dict
+                      "customresource_namespace" (list "metadata" "namespace")
+                      "customresource_name" (list "metadata" "name")
+                    )
                   )
                 )
               )
-            )
-        -}}
+          -}}
+        {{- end -}}
       {{- end -}}
 
       {{- $resources = append $resources (dict

--- a/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_kube-state-metrics-config.yaml
+++ b/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_kube-state-metrics-config.yaml
@@ -38,6 +38,7 @@ customResourceState:
   enabled: true
   config:
     spec:
+      {{- $imagePolicyVersion := "" -}}
       {{- $types := dict
         "Bucket" "source"
         "GitRepository" "source"
@@ -62,6 +63,9 @@ customResourceState:
           {{- range $version := $crd.spec.versions -}}
             {{- if $version.storage -}}
               {{- $version = $version.name -}}
+              {{- if eq $fluxKind "ImagePolicy" -}}
+                {{- $imagePolicyVersion = $version -}}
+              {{- end -}}
             {{- end -}}
           {{- end -}}
           {{- $resources = append $resources (dict
@@ -115,6 +119,7 @@ customResourceState:
             "groupVersionKind" (dict
               "group" "image.toolkit.fluxcd.io"
               "kind" "ImagePolicy"
+              "version" $imagePolicyVersion
             )
             "metricNamePrefix" "image_policy"
             "metrics" (list


### PR DESCRIPTION
That way there are also no deprecatedAPIAlerts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced Prometheus monitoring configuration for Flux custom resources. The kube-state-metrics setup now dynamically discovers custom resource definitions and resolves API versions from live cluster data instead of using static hardcoded configurations, providing more accurate and comprehensive metrics collection across all Flux resource types deployed in the cluster.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->