### PR TITLE
fix(t8s-cluster/workload-cluster): adjust cilium healthChecks

### DIFF
--- a/charts/t8s-cluster/templates/workload-cluster/cloud-controller-manager.yaml
+++ b/charts/t8s-cluster/templates/workload-cluster/cloud-controller-manager.yaml
@@ -57,6 +57,9 @@ spec:
                 value: Deployment
               - op: remove
                 path: /spec/template/spec/nodeSelector
+              - op: move
+                from: /spec/updateStrategy
+                path: /spec/strategy
   {{- end }}
   values:
     priorityClassName: system-cluster-critical

--- a/charts/t8s-cluster/templates/workload-cluster/cni-cilium.yaml
+++ b/charts/t8s-cluster/templates/workload-cluster/cni-cilium.yaml
@@ -14,6 +14,16 @@ spec:
   kubeConfig:
     secretRef:
       name: {{ .Release.Name }}-kubeconfig
+  healthCheckExprs:
+    - apiVersion: apps/v1
+      kind: DaemonSet
+      current: status.numberAvailable == status.desiredNumberScheduled
+      inProgress: status.numberAvailable < status.desiredNumberScheduled
+    - apiVersion: apps/v1
+      kind: Deployment
+      # ignore deployments other than cilium-operator, as they are not critical
+      current: metadata.name != "cilium-operator" || (has(status.conditions) && status.conditions.exists(c, c.type == "Available" && c.status == "True"))
+      inProgress: metadata.name == "cilium-operator" && (!has(status.conditions) || !status.conditions.exists(c, c.type == "Available" && c.status == "True"))
   install:
     remediation:
       retries: -1


### PR DESCRIPTION
That way the hubble deployments don't block the rollout

chore(t8s-cluster/workload-cluster): move the updateStrategy -> strategy field in the ccm Deployment


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced health monitoring for Cilium CNI components to provide more accurate, automated health evaluations and clearer status during upgrades and rollouts.
  * Optimized cloud controller manager configuration within the hosted control plane to improve deployment stability and alignment with cluster rollout strategies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->