### PR TITLE
fix(base-cluster/monitoring): watching only the current version

### DIFF
--- a/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_kube-state-metrics-config.yaml
+++ b/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_kube-state-metrics-config.yaml
@@ -60,9 +60,9 @@ customResourceState:
         {{- $crd := lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" (printf "%s.%s" $crdPlural $group) -}}
         {{- if $crd -}}
           {{- $version := "" -}}
-          {{- range $version := $crd.spec.versions -}}
-            {{- if $version.storage -}}
-              {{- $version = $version.name -}}
+          {{- range $crdVersion := $crd.spec.versions -}}
+            {{- if $crdVersion.storage -}}
+              {{- $version = $crdVersion.name -}}
               {{- if eq $fluxKind "ImagePolicy" -}}
                 {{- $imagePolicyVersion = $version -}}
               {{- end -}}
@@ -72,7 +72,7 @@ customResourceState:
                 "groupVersionKind" (dict
                   "group" $group
                   "kind" $fluxKind
-                  "version" $version
+                  "version" ($version | required (printf "unable to determine version for %s.%s" $crdPlural $group))
                 )
                 "metricNamePrefix" "gotk"
                 "metrics" (list


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of Kubernetes monitoring configuration by adding stricter validation for custom resource versions; the system now more reliably detects the correct storage version or fails with a clear error when version information is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->