### PR TITLE
feat(t8s-cluster/management-cluster): enable etcd backups

### DIFF
--- a/charts/t8s-cluster/templates/_etcd-backup.yaml
+++ b/charts/t8s-cluster/templates/_etcd-backup.yaml
@@ -1,0 +1,158 @@
+{{- define "t8s-cluster.etcd-backup" -}}
+  {{- $_ := mustMerge . (pick .context "Values" "Release" "Chart") -}}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: kube-etcd-backup
+  namespace: kube-system
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 5
+  successfulJobsHistoryLimit: 1
+  schedule: "@daily"
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        spec:
+          automountServiceAccountToken: false
+          initContainers:
+            - name: etcd-snapshot
+              image: {{ include "common.images.image" (dict "imageRoot" .Values.global.etcd.image "global" .Values.global) }}
+              imagePullPolicy: {{ include "common.images.pullPolicy" .Values.global.etcd.image }}
+              command:
+                - etcdctl
+                - snapshot
+                - save
+                - /snapshot/snapshot.db
+              env:
+                - name: ETCDCTL_API
+                  value: "3"
+                - name: ETCDCTL_ENDPOINTS
+                  value: localhost:2379
+                - name: ETCDCTL_CACERT
+                  value: /etc/kubernetes/pki/etcd/ca.crt
+                - name: ETCDCTL_CERT
+                  value: /etc/kubernetes/pki/etcd/peer.crt
+                - name: ETCDCTL_KEY
+                  value: /etc/kubernetes/pki/etcd/peer.key
+              securityContext:
+                runAsGroup: 1000
+                runAsUser: 0 # needed for peer.key
+                runAsNonRoot: false
+                privileged: false
+                allowPrivilegeEscalation: false
+                seccompProfile:
+                  type: RuntimeDefault
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+              volumeMounts:
+                - mountPath: /etc/kubernetes/pki/etcd
+                  name: etcd-certs
+                  readOnly: true
+                - mountPath: /snapshot
+                  name: snapshot
+            - name: fix-snapshot-permissions
+              image: {{ include "common.images.image" (dict "imageRoot" .Values.global.s3.image "global" .Values.global) }}
+              imagePullPolicy: {{ include "common.images.pullPolicy" .Values.global.s3.image }}
+              command:
+                - chmod
+                - u=rw,g=r,o=
+                - /snapshot/snapshot.db
+              securityContext:
+                runAsUser: 0
+                runAsGroup: 1000
+                runAsNonRoot: false
+                privileged: false
+                allowPrivilegeEscalation: false
+                seccompProfile:
+                  type: RuntimeDefault
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+              volumeMounts:
+                - mountPath: /snapshot
+                  name: snapshot
+          containers:
+            - name: upload
+              image: {{ include "common.images.image" (dict "imageRoot" .Values.global.s3.image "global" .Values.global) }}
+              imagePullPolicy: {{ include "common.images.pullPolicy" .Values.global.s3.image }}
+              command:
+                - bash
+                - -exc
+                - mc cp /snapshot/snapshot.db "backup/{{ printf "${S3_BUCKET}/%s/%s" .Release.Namespace .Release.Name }}/$(date --iso-8601=seconds).etcd"
+              env:
+                - name: MC_CONFIG_DIR
+                  value: /tmp
+                - name: AWS_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: etcd-backup
+                      key: accessKeyID
+                - name: AWS_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: etcd-backup
+                      key: secretAccessKey
+                - name: AWS_DEFAULT_REGION
+                  valueFrom:
+                    secretKeyRef:
+                      name: etcd-backup
+                      key: region
+                      optional: true
+                - name: S3_ENDPOINT
+                  valueFrom:
+                    secretKeyRef:
+                      name: etcd-backup
+                      key: host
+                - name: S3_BUCKET
+                  valueFrom:
+                    secretKeyRef:
+                      name: etcd-backup
+                      key: bucket
+                - name: MC_HOST_backup
+                  value: https://$(AWS_ACCESS_KEY_ID):$(AWS_SECRET_ACCESS_KEY)@$(S3_ENDPOINT)
+              securityContext:
+                runAsUser: 1000
+                runAsGroup: 1000
+                runAsNonRoot: true
+                privileged: false
+                allowPrivilegeEscalation: false
+                seccompProfile:
+                  type: RuntimeDefault
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+              volumeMounts:
+                - mountPath: /snapshot
+                  name: snapshot
+                  readOnly: true
+                - mountPath: /tmp
+                  name: tmp
+          dnsPolicy: ClusterFirstWithHostNet
+          hostNetwork: true
+          nodeSelector:
+            node-role.kubernetes.io/control-plane: ""
+          tolerations:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/control-plane
+              operator: Exists
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/master
+              operator: Exists
+          restartPolicy: OnFailure
+          volumes:
+            - name: etcd-certs
+              hostPath:
+                path: /etc/kubernetes/pki/etcd
+                type: Directory
+            - name: snapshot
+              emptyDir: {}
+            - name: tmp
+              emptyDir: {}
+{{- end -}}

--- a/charts/t8s-cluster/templates/management-cluster/clusterClass/hostedControlPlaneTemplate/_hostedControlPlaneTemplateSpec.yaml
+++ b/charts/t8s-cluster/templates/management-cluster/clusterClass/hostedControlPlaneTemplate/_hostedControlPlaneTemplateSpec.yaml
@@ -34,6 +34,15 @@ deployment:
     args: {{- include "t8s-cluster.clusterClass.args.scheduler" (dict) | nindent 6 }}
     resources: {{- include "common.resources" .Values.controlPlane | nindent 6 }}
     replicas: 1
+  {{- $backupSecret := lookup "v1" "Secret" "capi-hosted-control-plane-system" "etcd-backup" -}}
+  {{- if $backupSecret }}
+etcd:
+  backup:
+    schedule: "@daily"
+    secret:
+      name: etcd-backup
+      namespace: capi-hosted-control-plane-system
+  {{- end }}
 kubeProxy:
   disabled: {{ .Values.controlPlane.hosted }}
 gateway:

--- a/charts/t8s-cluster/templates/workload-cluster/etcd-backup.yaml
+++ b/charts/t8s-cluster/templates/workload-cluster/etcd-backup.yaml
@@ -1,0 +1,3 @@
+{{- if and (not .Values.controlPlane.hosted) .Values.controlPlane.etcdBackup -}}
+  {{- include "t8s-cluster.helm.resourceIntoCluster" (dict "name" "etcd-backup" "resource" (include "t8s-cluster.etcd-backup" (dict "context" $)) "context" $ "additionalLabels" (dict "app.kubernetes.io/component" "etcd")) | nindent 0 -}}
+{{- end -}}

--- a/charts/t8s-cluster/values.schema.json
+++ b/charts/t8s-cluster/values.schema.json
@@ -28,6 +28,16 @@
           },
           "additionalProperties": false
         },
+        "s3": {
+          "type": "object",
+          "description": "Image with an S3 client (mc) for etcd backup uploads",
+          "properties": {
+            "image": {
+              "$ref": "#/$defs/image"
+            }
+          },
+          "additionalProperties": false
+        },
         "injectedCertificateAuthorities": {
           "type": "string"
         },
@@ -160,6 +170,10 @@
         },
         "resources": {
           "$ref": "#/$defs/resourceRequirements"
+        },
+        "etcdBackup": {
+          "type": "boolean",
+          "description": "Enable daily etcd backups for KCP (non-hosted) clusters. Credentials are read from secret 'etcd-backup' in kube-system of the workload cluster. The secret must contain: accessKeyID (required), secretAccessKey (required), host (required), region (optional). Backups are stored at $cloud/$namespace/$name. For hosted clusters, backup is always enabled via the HCP controller using secret 'etcd-backup' in capi-hosted-control-plane-system."
         }
       },
       "additionalProperties": false

--- a/charts/t8s-cluster/values.yaml
+++ b/charts/t8s-cluster/values.yaml
@@ -40,6 +40,11 @@ global:
       registry: docker.io
       repository: bitnami/kubectl
       tag: 1.31.4-debian-12-r1@sha256:64614ef8290f3fb27fed5164b338debeeb79a1e5e26c93eb920770b71abd7c48
+  s3:
+    image:
+      registry: docker.io
+      repository: minio/mc
+      tag: RELEASE.2024-11-21T17-21-54Z@sha256:771f5ad7925a6b5e069786d8e847a292de320f1e3e3203647e29f47ec9b3d93b
   injectedCertificateAuthorities: ""
   kubeletExtraConfig:
     # This is only used when using 1.27 or later
@@ -63,6 +68,7 @@ controlPlane:
       memory: 2Gi
     limits:
       memory: 4Gi
+  etcdBackup: false
 
 quotas: {}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated etcd backup support with S3-compatible storage and a scheduled daily backup job.
  * Hosted clusters: backup orchestration delegated to the hosted control-plane flow; workload clusters: optional in-cluster CronJob when enabled.

* **Chores**
  * Added a chart-level toggle (disabled by default) to enable control-plane etcd backups.
  * Added configurable S3 client image settings and secret-based credential retrieval for uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->