### PR TITLE
feat(t8s-cluster/management-cluster): enable MutatingAdmissionPolicy

### DIFF
--- a/charts/t8s-cluster/templates/management-cluster/clusterClass/_helpers.tpl
+++ b/charts/t8s-cluster/templates/management-cluster/clusterClass/_helpers.tpl
@@ -80,8 +80,11 @@ server = {{ printf "https://%s" .registry | quote }}
 
 {{- define "t8s-cluster.featureGates" -}}
   {{- $featureGates := (dict "ImageVolume" (list "apiserver" "kubelet")) -}}
-  {{- if semverCompare ">=1.33.0" (include "t8s-cluster.k8s-version" .context) -}}
+  {{- if semverCompare ">=1.33.0 <1.35.0" (include "t8s-cluster.k8s-version" .context) -}}
     {{- $featureGates = set $featureGates "KubeletEnsureSecretPulledImages" (list "kubelet") -}}
+  {{- end -}}
+  {{- if semverCompare ">=1.32.0" (include "t8s-cluster.k8s-version" .context) -}}
+    {{- $featureGates = set $featureGates "MutatingAdmissionPolicy" (list "apiserver") -}}
   {{- end -}}
   {{- toYaml $featureGates -}}
 {{- end -}}
@@ -211,6 +214,9 @@ admission-control-config.yaml
   {{- $args = set $args "enable-admission-plugins" (include "t8s-cluster.clusterClass.apiServer.admissionPlugins" (dict "context" .context) | fromYamlArray | join ",") -}}
   {{- $args = set $args "event-ttl" "4h" -}}
   {{- $args = set $args "tls-cipher-suites" (include "t8s-cluster.clusterClass.tlsCipherSuites" (dict) | fromYamlArray | join ",") -}}
+  {{- if semverCompare ">=1.32.0" (include "t8s-cluster.k8s-version" .context) -}}
+    {{- $args = set $args "runtime-config" "admissionregistration.k8s.io/v1beta1=true" -}}
+  {{- end -}}
   {{- $featureFlags := list -}}
   {{- range $featureFlag, $enabled := include "t8s-cluster.featureGates.forComponent" (dict "component" "apiserver" "context" .context) | fromYaml -}}
     {{- $featureFlags = append $featureFlags (printf "%s=%t" $featureFlag $enabled) -}}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kubernetes feature gate compatibility requirements for cluster management templates
  * Refined version gating for `KubeletEnsureSecretPulledImages` (now 1.33.0 - 1.35.0)
  * Added support for `MutatingAdmissionPolicy` feature gate (Kubernetes 1.32.0+)
  * Enabled API server admissions registration runtime configuration (Kubernetes 1.32.0+)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->