### PR TITLE
fix(base-cluster/monitoring): disable scrapeConfigSelector

### DIFF
--- a/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_prometheus_config.yaml
+++ b/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_prometheus_config.yaml
@@ -22,6 +22,7 @@ prometheusSpec:
   ruleSelectorNilUsesHelmValues: false
   podMonitorSelectorNilUsesHelmValues: false
   probeSelectorNilUsesHelmValues: false
+  scrapeConfigSelectorNilUsesHelmValues: false
   retention: {{ .Values.monitoring.prometheus.retentionDuration }}
   retentionSize: {{ .Values.monitoring.prometheus.retentionSize }}
   storageSpec:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an explicit Prometheus setting controlling Helm handling of nil scrapeConfig selectors (prometheusSpec.scrapeConfigSelectorNilUsesHelmValues: false), clarifying scrape config selection behavior and reducing ambiguity between Helm-provided and custom scrape configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->