### PR TITLE
feat(t8s-cluster): warn about PodSecurityStandard violations by default

### DIFF
--- a/charts/t8s-cluster/files/admission-control-config.yaml
+++ b/charts/t8s-cluster/files/admission-control-config.yaml
@@ -3,3 +3,13 @@ kind: AdmissionConfiguration
 plugins:
   - name: EventRateLimit
     path: event-rate-limit-config.yaml
+  - name: PodSecurity
+    configuration:
+      apiVersion: pod-security.admission.config.k8s.io/v1
+      kind: PodSecurityConfiguration
+      defaults:
+        audit: restricted
+        warn: restricted
+      exemptions:
+        namespaces:
+          - kube-system


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled PodSecurity admission control plugin with restricted security level enforcement.
  * Configured audit and warning mechanisms for security policy compliance.
  * Exempted system namespaces from admission restrictions to maintain cluster operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->