### PR TITLE
feat(base-cluster): add support for podSecurityStandards

### DIFF
--- a/charts/base-cluster/ci/namespace-pss-values.yaml
+++ b/charts/base-cluster/ci/namespace-pss-values.yaml
@@ -1,0 +1,8 @@
+global:
+  namespaces:
+    main0:
+      podSecurityStandards:
+        enforce: restricted
+    main1:
+      podSecurityStandards:
+        audit: none

--- a/charts/base-cluster/templates/global/_namespaces.tpl
+++ b/charts/base-cluster/templates/global/_namespaces.tpl
@@ -1,17 +1,36 @@
 {{- define "base-cluster.enabled-namespaces" -}}
-{{- $blackList := list "default" "kube-system" "kube-public" "kube-node-lease" -}}
-{{- $namespaces := dict -}}
-{{- range $name, $namespace := .Values.global.namespaces -}}
-  {{- if has $name $blackList -}}
-    {{- fail (printf "Using namespace '%s' is not allowed" $name) -}}
+  {{- $_ := mustMerge . (pick .context "Values") -}}
+  {{- $context := .context -}}
+  {{- $blackList := list "default" "kube-system" "kube-public" "kube-node-lease" -}}
+  {{- $namespaces := dict -}}
+  {{- range $name, $namespace := .Values.global.namespaces -}}
+    {{- if has $name $blackList -}}
+      {{- fail (printf "Using namespace '%s' is not allowed" $name) -}}
+    {{- end -}}
+    {{- $create := true -}}
+    {{- if $namespace.condition -}}
+      {{- $create = eq (include "common.tplvalues.render" (dict "value" $namespace.condition "context" (deepCopy $context))) "true" -}}
+    {{- end -}}
+    {{- if $create -}}
+      {{- $namespaces = set $namespaces $name (omit $namespace "condition") -}}
+    {{- end -}}
   {{- end -}}
-  {{- $create := true -}}
-  {{- if $namespace.condition -}}
-    {{- $create = eq (include "common.tplvalues.render" (dict "value" $namespace.condition "context" (deepCopy $))) "true" -}}
-  {{- end -}}
-  {{- if $create -}}
-    {{- $namespaces := set $namespaces $name (omit $namespace "condition") -}}
-  {{- end -}}
+  {{- toYaml $namespaces -}}
 {{- end -}}
-{{- toYaml $namespaces -}}
+
+{{- define "base-cluster.namespace.podSecurityStandardsLabels" -}}
+  {{- $prefix := "pod-security.kubernetes.io" -}}
+  {{- $labels := dict -}}
+  {{- $podSecurityStandards := dig "podSecurityStandards" (dict) .namespace -}}
+  {{- $levels := dict
+      "enforce" (dig "enforce" "none" $podSecurityStandards)
+      "warn" (dig "warn" "restricted" $podSecurityStandards)
+      "audit" (dig "audit" "restricted" $podSecurityStandards)
+  -}}
+  {{- range $level, $value := $levels -}}
+    {{- if ne $value "none" -}}
+      {{- $labels = set $labels (printf "%s/%s" $prefix $level) $value -}}
+    {{- end -}}
+  {{- end -}}
+  {{- toYaml $labels -}}
 {{- end -}}

--- a/charts/base-cluster/templates/global/namespaces.yaml
+++ b/charts/base-cluster/templates/global/namespaces.yaml
@@ -1,10 +1,12 @@
-{{- range $name, $namespace := include "base-cluster.enabled-namespaces" . | fromYaml -}}
+{{- range $name, $namespace := include "base-cluster.enabled-namespaces" (dict "context" .) | fromYaml -}}
 apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ $name }}
-  labels: {{- include "common.labels.standard" $ | nindent 4 -}}
-    {{- with $namespace.additionalLabels -}}{{- toYaml . | nindent 4 -}}{{- end }}
+  {{- $labels := include "common.labels.standard" $ | fromYaml -}}
+  {{- $labels = mustMergeOverwrite $labels (include "base-cluster.namespace.podSecurityStandardsLabels" (dict "namespace" $namespace) | fromYaml) -}}
+  {{- $labels = mustMergeOverwrite $labels ($namespace.additionalLabels | default (dict)) }}
+  labels: {{- toYaml $labels | nindent 4 }}
 ---
 apiVersion: v1
 kind: LimitRange

--- a/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_prometheus_config.yaml
+++ b/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_prometheus_config.yaml
@@ -37,7 +37,7 @@ prometheusSpec:
   additionalAlertRelabelConfigs:
     {{- if not .Values.monitoring.monitorAllNamespaces }}
       {{- $namespaces := list .Release.Namespace "kube-node-lease" "kube-public" "kube-system" -}}
-      {{- range $name := include "base-cluster.enabled-namespaces" . | fromYaml | keys -}}
+      {{- range $name := include "base-cluster.enabled-namespaces" (dict "context" .) | fromYaml | keys -}}
         {{- $namespaces = append $namespaces $name -}}
       {{- end }}
     - # TODO: Needs alternative

--- a/charts/base-cluster/templates/rbac/roleBindings.yaml
+++ b/charts/base-cluster/templates/rbac/roleBindings.yaml
@@ -1,4 +1,4 @@
-{{- $roles := include "base-cluster.rbac.roles" (dict "accounts" .Values.rbac.accounts "roles" (.Values.rbac.roles | keys) "namespaces" (include "base-cluster.enabled-namespaces" . | fromYaml | keys)) | fromYaml -}}
+{{- $roles := include "base-cluster.rbac.roles" (dict "accounts" .Values.rbac.accounts "roles" (.Values.rbac.roles | keys) "namespaces" (include "base-cluster.enabled-namespaces" (dict "context" .) | fromYaml | keys)) | fromYaml -}}
 {{- $definedRoles := .Values.rbac.roles | keys -}}
 
 {{- define "base-cluster.rbac.subjects" -}}

--- a/charts/base-cluster/templates/rbac/roles.yaml
+++ b/charts/base-cluster/templates/rbac/roles.yaml
@@ -1,5 +1,5 @@
 {{- $preExistingRoles := include "base-cluster.rbac.preexistingRoles" (dict) | fromYamlArray -}}
-{{- $usedRoles := include "base-cluster.rbac.roles" (dict "accounts" .Values.rbac.accounts "roles" (.Values.rbac.roles | keys) "namespaces" (include "base-cluster.enabled-namespaces" . | fromYaml | keys)) | fromYaml -}}
+{{- $usedRoles := include "base-cluster.rbac.roles" (dict "accounts" .Values.rbac.accounts "roles" (.Values.rbac.roles | keys) "namespaces" (include "base-cluster.enabled-namespaces" (dict "context" .) | fromYaml | keys)) | fromYaml -}}
 
 {{- range $name, $spec := .Values.rbac.roles -}}
   {{- if not (hasKey $usedRoles $name) -}}

--- a/charts/base-cluster/values.schema.json
+++ b/charts/base-cluster/values.schema.json
@@ -234,6 +234,23 @@
                   "type": "string"
                 }
               },
+              "podSecurityStandards": {
+                "type": "object",
+                "properties": {
+                  "enforce": {
+                    "$ref": "#/$defs/podSecurityStandardPolicy"
+                  },
+                  "warn": {
+                    "$ref": "#/$defs/podSecurityStandardPolicy",
+                    "default": "restricted"
+                  },
+                  "audit": {
+                    "$ref": "#/$defs/podSecurityStandardPolicy",
+                    "default": "restricted"
+                  }
+                },
+                "additionalProperties": false
+              },
               "condition": {
                 "$ref": "#/$defs/condition"
               },
@@ -1760,6 +1777,15 @@
       },
       "required": [
         "url"
+      ]
+    },
+    "podSecurityStandardPolicy": {
+      "type": "string",
+      "enum": [
+        "none",
+        "privileged",
+        "baseline",
+        "restricted"
       ]
     }
   }

--- a/charts/base-cluster/values.yaml
+++ b/charts/base-cluster/values.yaml
@@ -8,9 +8,13 @@ global:
   namespaces:
     ingress:
       condition: '{{ or (not (empty .Values.dns.provider)) (eq .Values.ingress.provider "traefik") }}'
+      podSecurityStandards:
+        enforce: restricted
       additionalLabels:
         app.kubernetes.io/component: ingress
     cert-manager:
+      podSecurityStandards:
+        enforce: restricted
       additionalLabels:
         app.kubernetes.io/component: cert-manager
       resources:
@@ -26,6 +30,8 @@ global:
           limits.memory: 2Gi
     ingress-nginx:
       condition: '{{ eq .Values.ingress.provider "nginx" }}'
+      podSecurityStandards:
+        enforce: restricted
       additionalLabels:
         app.kubernetes.io/component: ingress
     kyverno:
@@ -34,6 +40,8 @@ global:
         app.kubernetes.io/component: kyverno
     monitoring:
       condition: "{{ or .Values.monitoring.prometheus.enabled .Values.monitoring.metricsServer.enabled }}"
+      podSecurityStandards:
+        enforce: privileged
       additionalLabels:
         app.kubernetes.io/component: monitoring
       resources:
@@ -43,15 +51,21 @@ global:
             memory: 100Mi
     trivy:
       condition: "{{ .Values.monitoring.securityScanning.enabled }}"
+      podSecurityStandards:
+        enforce: privileged
       additionalLabels:
         app.kubernetes.io/component: security
     nfs-server-provisioner:
       condition: "{{ .Values.storage.readWriteMany.enabled }}"
+      podSecurityStandards:
+        enforce: privileged
       additionalLabels:
         app.kubernetes.io/component: storage
         app.kubernetes.io/part-of: nfs-server-provisioner
     backup:
       condition: "{{ not (empty .Values.backup.provider) }}"
+      podSecurityStandards:
+        enforce: privileged
       additionalLabels:
         app.kubernetes.io/component: backup
   certificates:


### PR DESCRIPTION
Also add settings for own namespaces


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced per-namespace Pod Security Standards (enforce/warn/audit) with validated allowed values.
  * Namespace manifests now emit pod-security.kubernetes.io labels for applicable PSS settings.
* **Changes**
  * Several built-in namespaces now have enforced PSS levels by default (e.g., ingress, cert-manager, monitoring, trivy, etc.).
  * Namespace label generation now produces a single merged labels map including PSS labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->