### PR TITLE
feat(t8s-cluster/management-cluster): exluce selfsubjectaccessreviews from audit

### DIFF
--- a/charts/t8s-cluster/templates/management-cluster/clusterClass/_helpers.tpl
+++ b/charts/t8s-cluster/templates/management-cluster/clusterClass/_helpers.tpl
@@ -287,6 +287,9 @@ rules:
       - group: ""
         resources:
           - events
+      - group: authorization.k8s.io
+        resources:
+          - selfsubjectaccessreviews
   - level: Metadata
     verbs: [] # All verbs
     resources:


### PR DESCRIPTION
This happens all the time during normal usage and is not relevant


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded cluster audit policy to include RBAC metadata checks (including self-access review events) at the minimal-audit level, improving visibility of permission-evaluation activity in audit trails without changing existing audit structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->