### PR TITLE
chore(base-cluster/trivy)!: set trivy disabled by default

### DIFF
--- a/charts/base-cluster/README.md.gotmpl
+++ b/charts/base-cluster/README.md.gotmpl
@@ -432,4 +432,6 @@ of `.monitoring.tracing.ingester.<field>`
 
 - This release also removes the `monitoring.deadMansSwitch.enabled` field, it is just active when the `monitoring.deadMansSwitch` block is set.
 
+- This release disables the trivy-operator by default.
+  To continue using the operator set `.monitoring.securityScanning.enabled` to `true`.
 {{ .Files.Get "values.md"  }}

--- a/charts/base-cluster/values.yaml
+++ b/charts/base-cluster/values.yaml
@@ -365,7 +365,7 @@ monitoring:
   metricsServer:
     enabled: true
   securityScanning:
-    enabled: true
+    enabled: false
     nodeCollector:
       tolerations:
         - key: node-role.kubernetes.io/control-plane


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Security scanning in cluster monitoring is now disabled by default for base cluster deployments.

* **Documentation**
  * Migration guidance updated: instructions added showing how to re-enable security scanning by setting .monitoring.securityScanning.enabled: true in your deployment values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->