### PR TITLE
fix: handle null rules in grype sarif jq filter

### DIFF
--- a/.github/scripts/generate-sarif-reports.sh
+++ b/.github/scripts/generate-sarif-reports.sh
@@ -49,7 +49,7 @@ function generateSarifReport() {
   chartsJson="$(yq --arg image "$image" -r '.annotations["artifacthub.io/images"] | split("\n")[] | select(contains($image))' "$chart/Chart.yaml" |
     awk '{print $NF}' |
     jq -r -c -Rn '[inputs]')"
-if GRYPE_DB_AUTO_UPDATE=false grype "$image" -o sarif --by-cve --only-fixed | jq -r --arg category "$chart/${GITHUB_JOB:-local}" --argjson subCharts "$chartsJson" --arg chart "$chartName" '.runs |= map( . as $run | .tool.driver.rules |= map(select(((.properties["security-severity"]) | tonumber) >= 9)) | (.tool.driver.rules | map(.id)) as $ruleIds | .results |= map(select(.ruleId | IN($ruleIds[]))) | .automationDetails = {id: $category} | .properties = {chart: $chart, subCharts: $subCharts})' >"$tmpFile"; then
+  if GRYPE_DB_AUTO_UPDATE=false grype "$image" -o sarif --by-cve --only-fixed | jq -r --arg category "$chart/${GITHUB_JOB:-local}" --argjson subCharts "$chartsJson" --arg chart "$chartName" '.runs |= map( . as $run | .tool.driver.rules |= ((. // []) | map(select(((.properties["security-severity"] // "0") | tonumber) >= 9))) | ((.tool.driver.rules // []) | map(.id)) as $ruleIds | .results |= ((. // []) | map(select(.ruleId | IN($ruleIds[])))) | .automationDetails = {id: $category} | .properties = {chart: $chart, subCharts: $subCharts})' >"$tmpFile"; then
     mv "${tmpFile}" "${outFile}"
   else
     rm "$tmpFile"


### PR DESCRIPTION

When grype finds no vulnerabilities, .tool.driver.rules is null
instead of an empty array, causing jq iteration to fail. Default
to [] with // operator for both the rules filter and ruleIds
extraction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved robustness of SARIF report post-processing so reports gracefully handle missing rule metadata or optional fields, preventing failures and ensuring consistent output.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teutonet/teutonet-helm-charts/pull/2124)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #2121 