### PR TITLE
fix(t8s-cluster/management-cluster): prefix the autoscaler with `as-`

### DIFF
--- a/charts/t8s-cluster/templates/management-cluster/autoscaler.yaml
+++ b/charts/t8s-cluster/templates/management-cluster/autoscaler.yaml
@@ -20,6 +20,7 @@ spec:
   driftDetection:
     mode: enabled
   values:
+    fullnameOverride: {{ printf "as-%s-autoscaler" .Release.Name }}
     autoDiscovery:
       clusterName: {{ .Release.Name }}
     cloudProvider: clusterapi


### PR DESCRIPTION
Otherwise clusters starting with a number break the autoscaler service


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated autoscaler configuration in the cluster management template.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teutonet/teutonet-helm-charts/pull/2167)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->