### PR TITLE
fix(t8s-cluster): missing rbac

### DIFF
--- a/charts/t8s-cluster/templates/management-cluster/autoscaler.yaml
+++ b/charts/t8s-cluster/templates/management-cluster/autoscaler.yaml
@@ -30,7 +30,21 @@ spec:
     extraArgs:
       scale-down-utilization-threshold: 0.8
       skip-nodes-with-local-storage: false
+    podDisruptionBudget: false
     serviceMonitor:
       enabled: true
       namespace: {{ .Release.Namespace }}
+    rbac:
+      # needed until https://github.com/kubernetes/autoscaler/issues/6490#issuecomment-4590829570
+      # has been addressed
+      clusterScoped: true
+      additionalRules:
+        - apiGroups:
+            - infrastructure.cluster.x-k8s.io
+          resources:
+            - openstackmachinetemplates
+          verbs:
+            - get
+            - list
+            - watch
 {{- end -}}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled service monitoring for the autoscaler in the release namespace
  * Added cluster-scoped RBAC permissions to query OpenStack machine templates

* **Bug Fixes**
  * Disabled pod disruption budget to improve autoscaler stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->