### PR TITLE
fix(t8s-cluster): correctly set flags for MutatingAdmissionPolicy

### DIFF
--- a/charts/t8s-cluster/templates/management-cluster/clusterClass/_helpers.tpl
+++ b/charts/t8s-cluster/templates/management-cluster/clusterClass/_helpers.tpl
@@ -83,7 +83,7 @@ server = {{ printf "https://%s" .registry | quote }}
   {{- if semverCompare ">=1.33.0 <1.35.0" (include "t8s-cluster.k8s-version" .context) -}}
     {{- $featureGates = set $featureGates "KubeletEnsureSecretPulledImages" (list "kubelet") -}}
   {{- end -}}
-  {{- if semverCompare ">=1.32.0" (include "t8s-cluster.k8s-version" .context) -}}
+  {{- if semverCompare ">=1.34.0 <1.36.0" (include "t8s-cluster.k8s-version" .context) -}}
     {{- $featureGates = set $featureGates "MutatingAdmissionPolicy" (list "apiserver") -}}
   {{- end -}}
   {{- toYaml $featureGates -}}
@@ -216,7 +216,7 @@ admission-control-config.yaml
   {{- $args = set $args "enable-admission-plugins" (include "t8s-cluster.clusterClass.apiServer.admissionPlugins" (dict "context" .context) | fromYamlArray | join ",") -}}
   {{- $args = set $args "event-ttl" "4h" -}}
   {{- $args = set $args "tls-cipher-suites" (include "t8s-cluster.clusterClass.tlsCipherSuites" (dict) | fromYamlArray | join ",") -}}
-  {{- if semverCompare ">=1.32.0" (include "t8s-cluster.k8s-version" .context) -}}
+  {{- if semverCompare ">=1.34.0 <1.36.0" (include "t8s-cluster.k8s-version" .context) -}}
     {{- $args = set $args "runtime-config" "admissionregistration.k8s.io/v1beta1=true" -}}
   {{- end -}}
   {{- $featureFlags := list -}}


### PR DESCRIPTION
This shouldn't rotate, as our customers are already on 1.35


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kubernetes version compatibility constraints for MutatingAdmissionPolicy feature gate and admission API server runtime configuration. Support is now restricted to Kubernetes 1.34.x versions instead of 1.32+.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->