### PR TITLE
fix(t8s-cluster/management-cluster): filter network by name

### DIFF
--- a/charts/t8s-cluster/templates/management-cluster/clusterClass/openStackClusterTemplate/_openStackClusterTemplateSpec.yaml
+++ b/charts/t8s-cluster/templates/management-cluster/clusterClass/openStackClusterTemplate/_openStackClusterTemplateSpec.yaml
@@ -144,4 +144,7 @@ managedSecurityGroups:
   allowAllInClusterTraffic: {{ $allowNativeRouting }}
 managedSubnets:
   - cidr: 10.6.0.0/24
+externalNetwork:
+  filter:
+    name: extern
 {{- end -}}


### PR DESCRIPTION
The default CAPO logic filters by a property, which might be duplicate


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added external network configuration support to OpenStack cluster templates. Clusters can now automatically identify and bind to external network resources through managed subnet configuration, enhancing network accessibility for deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->