### PR TITLE
feat(base-cluster/ingress): add nginx compatibility option for traefik

### DIFF
--- a/charts/base-cluster/templates/ingress/traefik.yaml
+++ b/charts/base-cluster/templates/ingress/traefik.yaml
@@ -91,6 +91,11 @@ spec:
       kubernetesGateway:
         enabled: true
         experimentalChannel: true
+      {{- if .Values.ingress.useTraefikNginxCompatibility }}
+      kubernetesIngressNGINX:
+        enabled: true
+        watchIngressWithoutClass: true # required, because uninstalling nginx also removes the ingress class and it is recommended to not use an IngressClass anyways.
+      {{- end }}
     logs:
       general:
         format: json

--- a/charts/base-cluster/templates/ingress/validation.tpl
+++ b/charts/base-cluster/templates/ingress/validation.tpl
@@ -2,6 +2,10 @@
   {{- fail "allowNginxConfigurationSnippets cannot be enabled when using traefik as the ingress provider" -}}
 {{- end -}}
 
+{{- if and (eq .Values.ingress.provider "nginx") .Values.ingress.useTraefikNginxCompatibility -}}
+  {{- fail "useTraefikNginxCompatibility cannot be enabled when using nginx as the ingress provider" -}}
+{{- end -}}
+
 {{- if eq .Values.ingress.provider "traefik" -}}
   {{- $existingNginx := lookup "helm.toolkit.fluxcd.io/v2" "HelmRelease" "ingress-nginx" "ingress-nginx" -}}
   {{- if $existingNginx -}}

--- a/charts/base-cluster/tests/ingress_validation_test.yaml
+++ b/charts/base-cluster/tests/ingress_validation_test.yaml
@@ -23,6 +23,14 @@ tests:
       - failedTemplate:
           errorMessage: "allowNginxConfigurationSnippets cannot be enabled when using traefik as the ingress provider"
 
+  - it: fails immediately when nginx traefik compatibility enabled with nginx
+    set:
+      ingress.provider: nginx
+      ingress.useTraefikNginxCompatibility: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "useTraefikNginxCompatibility cannot be enabled when using nginx as the ingress provider"
+
   - it: fails when switching to traefik while nginx HelmRelease exists
     kubernetesProvider:
       scheme:

--- a/charts/base-cluster/values.schema.json
+++ b/charts/base-cluster/values.schema.json
@@ -1363,6 +1363,10 @@
           "type": "boolean",
           "description": "Please don't do it if not absolutely necessary, it goes against all best practices. Ref.: https://docs.nginx.com/nginx-ingress-controller/configuration/global-configuration/command-line-arguments#cmdoption-enable-snippets"
         },
+        "useTraefikNginxCompatibility": {
+          "type": "boolean",
+          "description": "Enables the kubernetesIngressNGINX provider in traefik, which supports a subset of the annotations from the deprecated nginx ingress. Ref.: https://doc.traefik.io/traefik/reference/routing-configuration/kubernetes/ingress-nginx/"
+        },
         "useProxyProtocol": {
           "oneOf": [
             {

--- a/charts/base-cluster/values.yaml
+++ b/charts/base-cluster/values.yaml
@@ -462,6 +462,7 @@ flux:
 ingress:
   provider: traefik
   allowNginxConfigurationSnippets: false
+  useTraefikNginxCompatibility: false
   useProxyProtocol: auto
   replicas: 2
   resourcesPreset: nano


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional Traefik NGINX “annotation compatibility” mode for ingress, including automatic watching behavior when enabled.

* **Bug Fixes / Validation**
  * Added template validation to block enabling this compatibility mode when the ingress provider is set to NGINX (to avoid unsupported configurations).

* **Tests**
  * Added a negative test case to confirm the template fails immediately with a clear error message.

* **Chores**
  * Updated the ingress values schema and defaults to include the new compatibility setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->