### PR TITLE
feat(base-cluster): add extra ports for traefik and gatewayapi

### DIFF
--- a/charts/base-cluster/ci/traefik-extra-ports-values.yaml
+++ b/charts/base-cluster/ci/traefik-extra-ports-values.yaml
@@ -1,0 +1,16 @@
+ingress:
+  extraPorts:
+    mqtt:
+      expose:
+        default: true
+      exposedPort: 1883
+      port: 1883
+      protocol: TCP
+    mqtts:
+      expose:
+        default: true
+      exposedPort: 8883
+      port: 8883
+      protocol: TCP
+      proxyProtocol:
+        insecure: true

--- a/charts/base-cluster/templates/ingress/traefik.yaml
+++ b/charts/base-cluster/templates/ingress/traefik.yaml
@@ -42,6 +42,18 @@ spec:
       websecure:
         proxyProtocol:
           insecure: {{ include "base-cluster.ingress.useProxyProtocol" (dict "context" $) }}
+      {{- range $name, $cfg := .Values.ingress.extraPorts }}
+      {{ $name }}:
+        expose:
+          default: {{ $cfg.expose.default }}
+        exposedPort: {{ $cfg.exposedPort }}
+        port: {{ $cfg.port }}
+        protocol: {{ $cfg.protocol }}
+        {{- with $cfg.proxyProtocol }}
+        proxyProtocol:
+          insecure: {{ .insecure }}
+        {{- end }}
+      {{- end }}
     service:
       annotations:
         loadbalancer.openstack.org/timeout-client-data: "2073600000"

--- a/charts/base-cluster/values.schema.json
+++ b/charts/base-cluster/values.schema.json
@@ -1379,7 +1379,35 @@
           "type": "string",
           "pattern": "^((25[0-5]|(2[0-4]|1\\d|[1-9]|)\\d)\\.?\\b){4}$",
           "description": "Try to use specified IP as loadbalancer IP"
-        }
+        },
+        "extraPorts": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "object",
+                "required": ["port", "exposedPort", "protocol"],
+                "properties": {
+                  "port": { "type": "integer", "minimum": 1, "maximum": 65535  },
+                  "exposedPort": { "type": "integer", "minimum": 1, "maximum": 65535  },
+                  "protocol": {
+                    "type": "string",
+                    "enum": ["TCP", "UDP"]
+                  },
+                  "expose": {
+                    "type": "object",
+                    "properties": {
+                      "default": { "type": "boolean" }
+                    }
+                  },
+                  "proxyProtocol": {
+                    "type": "object",
+                    "properties": {
+                      "insecure": { "type": "boolean" }
+                    }
+                  }
+                },
+                "additionalProperties": true
+              }
+            }
       },
       "additionalProperties": false
     },

--- a/charts/base-cluster/values.yaml
+++ b/charts/base-cluster/values.yaml
@@ -468,6 +468,7 @@ ingress:
   resources:
     limits:
       cpu: 1
+  extraPorts: {}
 
 storage:
   readWriteMany:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Traefik ingress now supports configurable additional ports for flexible service exposure
  * Select TCP/UDP protocol for each custom port mapping
  * Optional proxy protocol configuration for enhanced port management
<!-- end of auto-generated comment: release notes by coderabbit.ai -->