### PR TITLE
chore(t8s-cluster/management-cluster): set rootCaCertificateDuration to 10 Years

### DIFF
--- a/charts/t8s-cluster/templates/management-cluster/clusterClass/hostedControlPlaneTemplate/_hostedControlPlaneTemplateSpec.yaml
+++ b/charts/t8s-cluster/templates/management-cluster/clusterClass/hostedControlPlaneTemplate/_hostedControlPlaneTemplateSpec.yaml
@@ -51,4 +51,6 @@ oidcProviders: {{- toYaml . | nindent 2 }}
 gateway:
   namespace: capi-hosted-control-plane-system
   name: controlplane
+certificates:
+  rootCaCertificateDuration: 87600h
 {{- end -}}


### PR DESCRIPTION
As we still have some legacy applications/setups on our clusters we
can't (yet) let the certificates rotate that often.

This should change as soon as we use publicly trusted certificates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated management cluster certificate settings to include a longer root CA certificate duration, helping reduce unexpected certificate renewal issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->