### PR TITLE
fix(t8s-cluster/management-cluster): cert-manager has [an integer overflow bug](https://github.com/cert-manager/cert-manager/issues/8937)

### DIFF
--- a/charts/t8s-cluster/templates/management-cluster/clusterClass/hostedControlPlaneTemplate/_hostedControlPlaneTemplateSpec.yaml
+++ b/charts/t8s-cluster/templates/management-cluster/clusterClass/hostedControlPlaneTemplate/_hostedControlPlaneTemplateSpec.yaml
@@ -52,5 +52,5 @@ gateway:
   namespace: capi-hosted-control-plane-system
   name: controlplane
 certificates:
-  rootCaCertificateDuration: 87600h
+  rootCaCertificateDuration: 43800h
 {{- end -}}


### PR DESCRIPTION
5 years are tested to work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the root CA certificate lifetime for hosted control planes, reducing its duration from 10 years to 5 years.
  * This may improve certificate rotation practices and align cluster security settings with current expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->