### PR TITLE
fix(t8s-cluster): set hubble cert renew method to cronJob

### DIFF
--- a/.github/image_licenses.yaml
+++ b/.github/image_licenses.yaml
@@ -149,6 +149,9 @@ licenses:
   quay.io/cilium/hubble-ui-backend:
     license: Apache-2.0
     licenseLink: https://raw.githubusercontent.com/cilium/hubble-ui/refs/heads/master/LICENSE
+  quay.io/cilium/certgen:
+    license: Apache-2.0
+    licenseLink: https://github.com/cilium/certgen/blob/main/LICENSE
   quay.io/cilium/operator-generic:
     license: Apache-2.0
     licenseLink: https://raw.githubusercontent.com/cilium/cilium/refs/heads/main/LICENSE

--- a/.github/image_licenses.yaml
+++ b/.github/image_licenses.yaml
@@ -151,7 +151,7 @@ licenses:
     licenseLink: https://raw.githubusercontent.com/cilium/hubble-ui/refs/heads/master/LICENSE
   quay.io/cilium/certgen:
     license: Apache-2.0
-    licenseLink: https://github.com/cilium/certgen/blob/main/LICENSE
+    licenseLink: https://raw.githubusercontent.com/cilium/certgen/refs/heads/main/LICENSE
   quay.io/cilium/operator-generic:
     license: Apache-2.0
     licenseLink: https://raw.githubusercontent.com/cilium/cilium/refs/heads/main/LICENSE

--- a/charts/t8s-cluster/templates/workload-cluster/cni-cilium.yaml
+++ b/charts/t8s-cluster/templates/workload-cluster/cni-cilium.yaml
@@ -79,6 +79,9 @@ spec:
       prometheus:
         enabled: true
     hubble:
+      tls:
+        auto:
+          method: cronJob
       metrics:
         enabled:
           - dns


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated Cilium Hubble TLS auto-configuration to use a scheduled job-based method for certificate management.
  * Added an optional Traefik compatibility mode for Kubernetes Ingress resources without an IngressClass.
* **Bug Fixes**
  * Added validation to prevent incompatible combinations of Traefik compatibility mode and the NGINX ingress provider.
* **Tests**
  * Added coverage for invalid ingress configuration combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->