### PR TITLE
fix(base-cluster/monitoring): disable monitoring of hosted/disabled components

### DIFF
--- a/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_helpers.yaml
+++ b/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_helpers.yaml
@@ -63,3 +63,32 @@ privileged: false
     {{- and (not (empty .Values.global.authentication.config)) (dig "enabled" true $ingress) | ternary true "" -}}
   {{- end -}}
 {{- end -}}
+
+{{- define "base-cluster.prometheus.controlPlaneComponents" -}}
+  {{- $kubeProxy := false -}}
+  {{- if typeIs "bool" .Values.monitoring.prometheus.kubeProxy -}}
+    {{- $kubeProxy = .Values.monitoring.prometheus.kubeProxy -}}
+  {{- else -}}
+    {{- $kubeProxy = not (empty (lookup "apps/v1" "DaemonSet" "kube-system" "kube-proxy")) -}}
+  {{- end -}}
+  {{- $kubeScheduler := false -}}
+  {{- $kubeControllerManager := false -}}
+  {{- if typeIs "bool" .Values.monitoring.prometheus.kubeScheduler -}}
+    {{- $kubeScheduler = .Values.monitoring.prometheus.kubeScheduler -}}
+  {{- end -}}
+  {{- if typeIs "bool" .Values.monitoring.prometheus.kubeControllerManager -}}
+    {{- $kubeControllerManager = .Values.monitoring.prometheus.kubeControllerManager -}}
+  {{- end -}}
+  {{- if or (not (typeIs "bool" .Values.monitoring.prometheus.kubeScheduler)) (not (typeIs "bool" .Values.monitoring.prometheus.kubeControllerManager)) -}}
+    {{- range (dig "items" (list) (lookup "v1" "Pod" "kube-system" "")) -}}
+      {{- $component := dig "metadata" "labels" "component" "" . -}}
+      {{- if and (eq $component "kube-scheduler") (not (typeIs "bool" $.Values.monitoring.prometheus.kubeScheduler)) -}}
+        {{- $kubeScheduler = true -}}
+      {{- end -}}
+      {{- if and (eq $component "kube-controller-manager") (not (typeIs "bool" $.Values.monitoring.prometheus.kubeControllerManager)) -}}
+        {{- $kubeControllerManager = true -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- dict "kubeProxy" $kubeProxy "kubeScheduler" $kubeScheduler "kubeControllerManager" $kubeControllerManager | toYaml -}}
+{{- end -}}

--- a/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_prometheus-stack-config.yaml
+++ b/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_prometheus-stack-config.yaml
@@ -1,4 +1,5 @@
 {{- define "base-cluster.prometheus.config" -}}
+{{- $cp := include "base-cluster.prometheus.controlPlaneComponents" . | fromYaml -}}
 global:
   rbac:
     createAggregateClusterRoles: true
@@ -16,9 +17,18 @@ prometheusOperator:
 defaultRules:
   disabled:
     etcdHighNumberOfFailedGRPCRequests: true
-    PrometheusNotConnectedToAlertmanagers: {{- not (include "base-cluster.prometheus-stack.alertmanager.enabled" .) -}}
+    PrometheusNotConnectedToAlertmanagers: {{ not (include "base-cluster.prometheus-stack.alertmanager.enabled" .) }}
   rules:
     kubeApiserverAvailability: false
+    kubeProxy: {{ $cp.kubeProxy }}
+    kubeScheduler: {{ $cp.kubeScheduler }}
+    kubeControllerManager: {{ $cp.kubeControllerManager }}
+kubeProxy:
+  enabled: {{ $cp.kubeProxy }}
+kubeScheduler:
+  enabled: {{ $cp.kubeScheduler }}
+kubeControllerManager:
+  enabled: {{ $cp.kubeControllerManager }}
 kubelet:
   serviceMonitor:
     resource: false

--- a/charts/base-cluster/tests/prometheus_control_plane_test.yaml
+++ b/charts/base-cluster/tests/prometheus_control_plane_test.yaml
@@ -1,0 +1,297 @@
+suite: prometheus control plane component detection
+templates:
+  - templates/monitoring/kube-prometheus-stack/prometheus-operator.yaml
+  - templates/monitoring/kube-prometheus-stack/grafana-secret.yaml
+release:
+  name: base-cluster
+tests:
+  - it: auto disables kubeProxy when lookup returns empty (no live cluster)
+    template: templates/monitoring/kube-prometheus-stack/prometheus-operator.yaml
+    set:
+      global.clusterName: test
+      monitoring.grafana.adminPassword: test
+      monitoring.prometheus.enabled: true
+    asserts:
+      - equal:
+          path: spec.values.kubeProxy.enabled
+          value: false
+      - equal:
+          path: spec.values.defaultRules.rules.kubeProxy
+          value: false
+
+  - it: auto disables kubeScheduler when lookup returns empty
+    template: templates/monitoring/kube-prometheus-stack/prometheus-operator.yaml
+    set:
+      global.clusterName: test
+      monitoring.grafana.adminPassword: test
+      monitoring.prometheus.enabled: true
+    asserts:
+      - equal:
+          path: spec.values.kubeScheduler.enabled
+          value: false
+      - equal:
+          path: spec.values.defaultRules.rules.kubeScheduler
+          value: false
+
+  - it: auto disables kubeControllerManager when lookup returns empty
+    template: templates/monitoring/kube-prometheus-stack/prometheus-operator.yaml
+    set:
+      global.clusterName: test
+      monitoring.grafana.adminPassword: test
+      monitoring.prometheus.enabled: true
+    asserts:
+      - equal:
+          path: spec.values.kubeControllerManager.enabled
+          value: false
+      - equal:
+          path: spec.values.defaultRules.rules.kubeControllerManager
+          value: false
+
+  - it: auto enables kubeProxy when kube-proxy DaemonSet is present
+    template: templates/monitoring/kube-prometheus-stack/prometheus-operator.yaml
+    kubernetesProvider:
+      scheme:
+        apps/v1/DaemonSet:
+          gvr:
+            group: apps
+            version: v1
+            resource: daemonsets
+          namespaced: true
+      objects:
+        - kind: DaemonSet
+          apiVersion: apps/v1
+          metadata:
+            name: kube-proxy
+            namespace: kube-system
+    set:
+      global.clusterName: test
+      monitoring.grafana.adminPassword: test
+      monitoring.prometheus.enabled: true
+      monitoring.prometheus.kubeScheduler: false
+      monitoring.prometheus.kubeControllerManager: false
+    asserts:
+      - equal:
+          path: spec.values.kubeProxy.enabled
+          value: true
+      - equal:
+          path: spec.values.defaultRules.rules.kubeProxy
+          value: true
+
+  - it: auto enables kubeScheduler when kube-scheduler Pod is present
+    template: templates/monitoring/kube-prometheus-stack/prometheus-operator.yaml
+    kubernetesProvider:
+      scheme:
+        apps/v1/DaemonSet:
+          gvr:
+            group: apps
+            version: v1
+            resource: daemonsets
+          namespaced: true
+        v1/Pod:
+          gvr:
+            version: v1
+            resource: pods
+          namespaced: true
+      objects:
+        - kind: Pod
+          apiVersion: v1
+          metadata:
+            name: kube-scheduler-master
+            namespace: kube-system
+            labels:
+              component: kube-scheduler
+    set:
+      global.clusterName: test
+      monitoring.grafana.adminPassword: test
+      monitoring.prometheus.enabled: true
+    asserts:
+      - equal:
+          path: spec.values.kubeScheduler.enabled
+          value: true
+      - equal:
+          path: spec.values.defaultRules.rules.kubeScheduler
+          value: true
+
+  - it: auto enables kubeControllerManager when kube-controller-manager Pod is present
+    template: templates/monitoring/kube-prometheus-stack/prometheus-operator.yaml
+    kubernetesProvider:
+      scheme:
+        apps/v1/DaemonSet:
+          gvr:
+            group: apps
+            version: v1
+            resource: daemonsets
+          namespaced: true
+        v1/Pod:
+          gvr:
+            version: v1
+            resource: pods
+          namespaced: true
+      objects:
+        - kind: Pod
+          apiVersion: v1
+          metadata:
+            name: kube-controller-manager-master
+            namespace: kube-system
+            labels:
+              component: kube-controller-manager
+    set:
+      global.clusterName: test
+      monitoring.grafana.adminPassword: test
+      monitoring.prometheus.enabled: true
+    asserts:
+      - equal:
+          path: spec.values.kubeControllerManager.enabled
+          value: true
+      - equal:
+          path: spec.values.defaultRules.rules.kubeControllerManager
+          value: true
+
+  - it: auto enables all three when all control plane components are present
+    template: templates/monitoring/kube-prometheus-stack/prometheus-operator.yaml
+    kubernetesProvider:
+      scheme:
+        apps/v1/DaemonSet:
+          gvr:
+            group: apps
+            version: v1
+            resource: daemonsets
+          namespaced: true
+        v1/Pod:
+          gvr:
+            version: v1
+            resource: pods
+          namespaced: true
+      objects:
+        - kind: DaemonSet
+          apiVersion: apps/v1
+          metadata:
+            name: kube-proxy
+            namespace: kube-system
+        - kind: Pod
+          apiVersion: v1
+          metadata:
+            name: kube-scheduler-master
+            namespace: kube-system
+            labels:
+              component: kube-scheduler
+        - kind: Pod
+          apiVersion: v1
+          metadata:
+            name: kube-controller-manager-master
+            namespace: kube-system
+            labels:
+              component: kube-controller-manager
+    set:
+      global.clusterName: test
+      monitoring.grafana.adminPassword: test
+      monitoring.prometheus.enabled: true
+    asserts:
+      - equal:
+          path: spec.values.kubeProxy.enabled
+          value: true
+      - equal:
+          path: spec.values.kubeScheduler.enabled
+          value: true
+      - equal:
+          path: spec.values.kubeControllerManager.enabled
+          value: true
+      - equal:
+          path: spec.values.defaultRules.rules.kubeProxy
+          value: true
+      - equal:
+          path: spec.values.defaultRules.rules.kubeScheduler
+          value: true
+      - equal:
+          path: spec.values.defaultRules.rules.kubeControllerManager
+          value: true
+
+  - it: explicit true overrides auto for kubeProxy
+    template: templates/monitoring/kube-prometheus-stack/prometheus-operator.yaml
+    set:
+      global.clusterName: test
+      monitoring.grafana.adminPassword: test
+      monitoring.prometheus.enabled: true
+      monitoring.prometheus.kubeProxy: true
+    asserts:
+      - equal:
+          path: spec.values.kubeProxy.enabled
+          value: true
+      - equal:
+          path: spec.values.defaultRules.rules.kubeProxy
+          value: true
+
+  - it: explicit false overrides auto for kubeProxy
+    template: templates/monitoring/kube-prometheus-stack/prometheus-operator.yaml
+    set:
+      global.clusterName: test
+      monitoring.grafana.adminPassword: test
+      monitoring.prometheus.enabled: true
+      monitoring.prometheus.kubeProxy: false
+    asserts:
+      - equal:
+          path: spec.values.kubeProxy.enabled
+          value: false
+      - equal:
+          path: spec.values.defaultRules.rules.kubeProxy
+          value: false
+
+  - it: explicit true overrides auto for kubeScheduler
+    template: templates/monitoring/kube-prometheus-stack/prometheus-operator.yaml
+    set:
+      global.clusterName: test
+      monitoring.grafana.adminPassword: test
+      monitoring.prometheus.enabled: true
+      monitoring.prometheus.kubeScheduler: true
+    asserts:
+      - equal:
+          path: spec.values.kubeScheduler.enabled
+          value: true
+      - equal:
+          path: spec.values.defaultRules.rules.kubeScheduler
+          value: true
+
+  - it: explicit false overrides auto for kubeScheduler
+    template: templates/monitoring/kube-prometheus-stack/prometheus-operator.yaml
+    set:
+      global.clusterName: test
+      monitoring.grafana.adminPassword: test
+      monitoring.prometheus.enabled: true
+      monitoring.prometheus.kubeScheduler: false
+    asserts:
+      - equal:
+          path: spec.values.kubeScheduler.enabled
+          value: false
+      - equal:
+          path: spec.values.defaultRules.rules.kubeScheduler
+          value: false
+
+  - it: explicit true overrides auto for kubeControllerManager
+    template: templates/monitoring/kube-prometheus-stack/prometheus-operator.yaml
+    set:
+      global.clusterName: test
+      monitoring.grafana.adminPassword: test
+      monitoring.prometheus.enabled: true
+      monitoring.prometheus.kubeControllerManager: true
+    asserts:
+      - equal:
+          path: spec.values.kubeControllerManager.enabled
+          value: true
+      - equal:
+          path: spec.values.defaultRules.rules.kubeControllerManager
+          value: true
+
+  - it: explicit false overrides auto for kubeControllerManager
+    template: templates/monitoring/kube-prometheus-stack/prometheus-operator.yaml
+    set:
+      global.clusterName: test
+      monitoring.grafana.adminPassword: test
+      monitoring.prometheus.enabled: true
+      monitoring.prometheus.kubeControllerManager: false
+    asserts:
+      - equal:
+          path: spec.values.kubeControllerManager.enabled
+          value: false
+      - equal:
+          path: spec.values.defaultRules.rules.kubeControllerManager
+          value: false

--- a/charts/base-cluster/values.schema.json
+++ b/charts/base-cluster/values.schema.json
@@ -719,6 +719,15 @@
               "required": [
                 "defaultReceiver"
               ]
+            },
+            "kubeProxy": {
+              "$ref": "#/$defs/triState"
+            },
+            "kubeScheduler": {
+              "$ref": "#/$defs/triState"
+            },
+            "kubeControllerManager": {
+              "$ref": "#/$defs/triState"
             }
           },
           "additionalProperties": false
@@ -1385,33 +1394,52 @@
           "description": "Try to use specified IP as loadbalancer IP"
         },
         "extraPorts": {
-              "type": "object",
-              "additionalProperties": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "required": [
+              "port",
+              "exposedPort",
+              "protocol"
+            ],
+            "properties": {
+              "port": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 65535
+              },
+              "exposedPort": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 65535
+              },
+              "protocol": {
+                "type": "string",
+                "enum": [
+                  "TCP",
+                  "UDP"
+                ]
+              },
+              "expose": {
                 "type": "object",
-                "required": ["port", "exposedPort", "protocol"],
                 "properties": {
-                  "port": { "type": "integer", "minimum": 1, "maximum": 65535  },
-                  "exposedPort": { "type": "integer", "minimum": 1, "maximum": 65535  },
-                  "protocol": {
-                    "type": "string",
-                    "enum": ["TCP", "UDP"]
-                  },
-                  "expose": {
-                    "type": "object",
-                    "properties": {
-                      "default": { "type": "boolean" }
-                    }
-                  },
-                  "proxyProtocol": {
-                    "type": "object",
-                    "properties": {
-                      "insecure": { "type": "boolean" }
-                    }
+                  "default": {
+                    "type": "boolean"
                   }
-                },
-                "additionalProperties": true
+                }
+              },
+              "proxyProtocol": {
+                "type": "object",
+                "properties": {
+                  "insecure": {
+                    "type": "boolean"
+                  }
+                }
               }
-            }
+            },
+            "additionalProperties": true
+          }
+        }
       },
       "additionalProperties": false
     },
@@ -1456,14 +1484,7 @@
       "type": "object",
       "properties": {
         "enabled": {
-          "oneOf": [
-            {
-              "const": "auto"
-            },
-            {
-              "type": "boolean"
-            }
-          ]
+          "$ref": "#/$defs/triState"
         }
       },
       "additionalProperties": false
@@ -1835,6 +1856,16 @@
         "privileged",
         "baseline",
         "restricted"
+      ]
+    },
+    "triState": {
+      "oneOf": [
+        {
+          "const": "auto"
+        },
+        {
+          "type": "boolean"
+        }
       ]
     }
   }

--- a/charts/base-cluster/values.yaml
+++ b/charts/base-cluster/values.yaml
@@ -334,6 +334,9 @@ monitoring:
       persistence:
         storageClass: ""
         size: 1Gi
+    kubeProxy: auto
+    kubeScheduler: auto
+    kubeControllerManager: auto
   loki:
     enabled: true
     retentionPeriod: 45d


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prometheus now auto-detects control-plane component presence (kube-proxy, kube-scheduler, kube-controller-manager) and enables the corresponding monitoring rules.
  * Added tri-state configuration options for `kubeProxy`, `kubeScheduler`, and `kubeControllerManager` (`auto`, `true`, `false`) and updated defaults accordingly.
* **Bug Fixes**
  * Improved rule enablement configuration so control-plane monitoring aligns with detected or explicitly overridden component availability.
* **Tests**
  * Added Helm tests covering auto-detection and explicit override behavior for all three components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->