### PR TITLE
fix(ci): disable kubescape for base-cluster

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -92,10 +92,10 @@ jobs:
       - run: pluto detect-files -d /tmp/templated -o custom --columns 'FILEPATH,NAME,KIND,VERSION,REPLACEMENT,REMOVED,DEPRECATED,REPL AVAIL'
         if: ${{ steps.templateChart.outputs.skipped == 'false' }}
       - name: Install kubescape
-        if: ${{ steps.templateChart.outputs.skipped == 'false' }}
+        if: ${{ steps.templateChart.outputs.skipped == 'false' && matrix.chart != 'base-cluster' }} # base-cluster just times this step out...
         run: /home/linuxbrew/.linuxbrew/bin/brew install kubescape
       - name: Run kubescape
-        if: ${{ steps.templateChart.outputs.skipped == 'false' }}
+        if: ${{ steps.templateChart.outputs.skipped == 'false' && matrix.chart != 'base-cluster' }} # base-cluster just times this step out...
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           kubescape_args=(/tmp/templated)


### PR DESCRIPTION
this just takes too long for github CI, we should look into running this
on our own infrastructure


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the validation workflow to adjust which chart scans run during automated checks.
  * The `base-cluster` chart is now excluded from a specific security scan step, while other chart scans continue as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->