### PR TITLE
feat(ci): run linter on self-hosted in hopes of not timing out CI

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+self-hosted-runner:
+  labels:
+    - self-hosted-big
+    - self-hosted-small

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -36,27 +36,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install Homebrew
-        run: |
-          NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-          {
-            echo "/home/linuxbrew/.linuxbrew/bin"
-            echo "/home/linuxbrew/.linuxbrew/sbin"
-          } >> "$GITHUB_PATH"
-          {
-            echo "HOMEBREW_PREFIX=/home/linuxbrew/.linuxbrew"
-            echo "HOMEBREW_CELLAR=/home/linuxbrew/.linuxbrew/Cellar"
-            echo "HOMEBREW_REPOSITORY=/home/linuxbrew/.linuxbrew/Homebrew"
-          } >> "$GITHUB_ENV"
-      - name: Install kubectl
-        run: brew install kubectl
-
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-        with:
-          python-version: 3.14
-      - run: pip install yq
-      - name: Install apt dependencies
-        run: sudo apt-get -yq update && sudo apt-get -yq install jq moreutils parallel
       - name: Extract helm repos
         id: helm-repos
         run: |
@@ -66,8 +45,6 @@ jobs:
             yq -r '.dependencies[] | .repository' "charts/$CHART/Chart.yaml" | sort -u | grep https:// | awk '{printf (NR>1 ? "," : "") NR "=" $1}'
             echo
           ) | tee -a "$GITHUB_OUTPUT"
-
-      - uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
 
       - name: Build test wrapper dependencies
         if: hashFiles(format('charts/{0}/tests/Chart.yaml', env.CHART)) != ''
@@ -101,14 +78,8 @@ jobs:
 
       - run: ./.github/scripts/templateHelmChartRecursivelyToFolder.sh "charts/$CHART" /tmp/templated
         id: templateChart
-      - name: Install Pluto
-        if: ${{ steps.templateChart.outputs.skipped == 'false' }}
-        run: brew install pluto
       - run: pluto detect-files -d /tmp/templated -o custom --columns 'FILEPATH,NAME,KIND,VERSION,REPLACEMENT,REMOVED,DEPRECATED,REPL AVAIL'
         if: ${{ steps.templateChart.outputs.skipped == 'false' }}
-      - name: Install kubescape
-        if: ${{ steps.templateChart.outputs.skipped == 'false' }}
-        run: /home/linuxbrew/.linuxbrew/bin/brew install kubescape
       - name: Run kubescape
         if: ${{ steps.templateChart.outputs.skipped == 'false' }}
         run: |

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -22,7 +22,7 @@ jobs:
     name: lint helm chart
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs:
       - getChangedCharts
     strategy:
@@ -36,9 +36,27 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install Homebrew
+        run: |
+          NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+          {
+            echo "/home/linuxbrew/.linuxbrew/bin"
+            echo "/home/linuxbrew/.linuxbrew/sbin"
+          } >> "$GITHUB_PATH"
+          {
+            echo "HOMEBREW_PREFIX=/home/linuxbrew/.linuxbrew"
+            echo "HOMEBREW_CELLAR=/home/linuxbrew/.linuxbrew/Cellar"
+            echo "HOMEBREW_REPOSITORY=/home/linuxbrew/.linuxbrew/Homebrew"
+          } >> "$GITHUB_ENV"
+      - name: Install kubectl
+        run: brew install kubectl
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: 3.14
       - run: pip install yq
-      - name: Install sponge
-        run: sudo apt-get -yq install moreutils
+      - name: Install apt dependencies
+        run: sudo apt-get -yq update && sudo apt-get -yq install jq moreutils parallel
       - name: Extract helm repos
         id: helm-repos
         run: |
@@ -49,9 +67,7 @@ jobs:
             echo
           ) | tee -a "$GITHUB_OUTPUT"
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-        with:
-          python-version: 3.14
+      - uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
 
       - name: Build test wrapper dependencies
         if: hashFiles(format('charts/{0}/tests/Chart.yaml', env.CHART)) != ''
@@ -69,7 +85,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - run: ./.github/scripts/prepare-values.sh "charts/$CHART"
-      - uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
 
       - name: Lint chart
         env:
@@ -86,18 +101,17 @@ jobs:
 
       - run: ./.github/scripts/templateHelmChartRecursivelyToFolder.sh "charts/$CHART" /tmp/templated
         id: templateChart
-      - name: Download Pluto
-        uses: FairwindsOps/pluto/github-action@dd5ec8cccce5e42dfe8054b8250baa35546056a0 # v5.24.0
+      - name: Install Pluto
         if: ${{ steps.templateChart.outputs.skipped == 'false' }}
+        run: brew install pluto
       - run: pluto detect-files -d /tmp/templated -o custom --columns 'FILEPATH,NAME,KIND,VERSION,REPLACEMENT,REMOVED,DEPRECATED,REPL AVAIL'
         if: ${{ steps.templateChart.outputs.skipped == 'false' }}
       - name: Install kubescape
-        if: ${{ steps.templateChart.outputs.skipped == 'false' && matrix.chart != 'base-cluster' }} # base-cluster just times this step out...
+        if: ${{ steps.templateChart.outputs.skipped == 'false' }}
         run: /home/linuxbrew/.linuxbrew/bin/brew install kubescape
       - name: Run kubescape
-        if: ${{ steps.templateChart.outputs.skipped == 'false' && matrix.chart != 'base-cluster' }} # base-cluster just times this step out...
+        if: ${{ steps.templateChart.outputs.skipped == 'false' }}
         run: |
-          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           kubescape_args=(/tmp/templated)
           if [[ -f "charts/$CHART/kubescape-exceptions.json" ]]; then
             kubescape_args+=(--exceptions <(jq -s 'add' .github/kubescape-exceptions.json "charts/$CHART/kubescape-exceptions.json"))

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -52,14 +52,12 @@ jobs:
 
       - name: Run helm unit tests
         if: hashFiles(format('charts/{0}/tests/**', env.CHART)) != ''
-        uses: d3adb5/helm-unittest-action@850bc76597579183998069830d5fa8c3ef0ea34a # v2.5.0
-        with:
-          helm-version: v3.20.2
-          charts: >-
-            ${{ hashFiles(format('charts/{0}/tests/Chart.yaml', env.CHART)) != ''
-              && format('charts/{0}/tests', env.CHART)
-              || format('charts/{0}', env.CHART) }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [[ -f "charts/$CHART/tests/Chart.yaml" ]]; then
+            helm unittest "charts/$CHART/tests"
+          else
+            helm unittest "charts/$CHART"
+          fi
 
       - run: ./.github/scripts/prepare-values.sh "charts/$CHART"
 

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -22,7 +22,7 @@ jobs:
     name: lint helm chart
     permissions:
       contents: read
-    runs-on: self-hosted
+    runs-on: self-hosted-big
     needs:
       - getChangedCharts
     strategy:

--- a/charts/base-cluster/templates/global/reflector.yaml
+++ b/charts/base-cluster/templates/global/reflector.yaml
@@ -13,9 +13,9 @@ spec:
   driftDetection:
     mode: enabled
   values:
-    priorityClassName: cluster-components
     image:
       repository: {{ printf "%s/emberstack/kubernetes-reflector" ($.Values.global.imageRegistry | default (include "base-cluster.defaultRegistry" (dict))) }}
+    priorityClassName: cluster-components
     securityContext:
       privileged: false
       allowPrivilegeEscalation: false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the chart linting workflow to run on self-hosted infrastructure, revising tool installation (Homebrew-based `kubectl`, expanded apt packages) and reordering lint steps.
  * Switched Pluto setup to a direct Homebrew install and run, and streamlined kubescape execution/conditions.
* **Refactor**
  * Reorganized the Helm chart reflector configuration layout without changing the effective values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->