### PR TITLE
feat(base-cluster/monitoring): add blackbox-exporter

### DIFF
--- a/.github/image_licenses.yaml
+++ b/.github/image_licenses.yaml
@@ -173,6 +173,9 @@ licenses:
   quay.io/prometheus/alertmanager:
     license: Apache-2.0
     licenseLink: https://github.com/prometheus/alertmanager/blob/main/LICENSE
+  quay.io/prometheus/blackbox-exporter:
+    license: Apache-2.0
+    licenseLink: https://github.com/prometheus/blackbox_exporter/blob/master/LICENSE
   quay.io/prometheus/node-exporter:
     license: Apache-2.0
     licenseLink: https://github.com/prometheus/node_exporter/blob/master/LICENSE

--- a/charts/base-cluster/ci/artifacthub-values.yaml
+++ b/charts/base-cluster/ci/artifacthub-values.yaml
@@ -40,6 +40,8 @@ monitoring:
       receivers:
         pagerduty:
           integrationKey: INTEGRATION_KEY__INTEGRATION_KEY
+    blackboxExporter:
+      enabled: true
   loki:
     enabled: true
   metricsServer:

--- a/charts/base-cluster/templates/monitoring/kube-prometheus-stack/blackbox-exporter.yaml
+++ b/charts/base-cluster/templates/monitoring/kube-prometheus-stack/blackbox-exporter.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.monitoring.prometheus.enabled .Values.monitoring.prometheus.blackboxExporter.enabled }}
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: prometheus-blackbox-exporter
+  namespace: monitoring
+  labels: {{- include "common.labels.standard" $ | nindent 4 }}
+    app.kubernetes.io/component: blackbox-exporter
+    app.kubernetes.io/part-of: monitoring
+spec:
+  chart:
+    spec: {{- include "base-cluster.helm.chartSpec" (dict "repo" "prometheus" "chart" "prometheus-blackbox-exporter" "context" $) | nindent 6 }}
+  interval: 1h
+  driftDetection:
+    mode: enabled
+  dependsOn:
+    - name: kube-prometheus-stack
+      namespace: monitoring
+  values:
+    {{- if .Values.global.imageRegistry }}
+    global:
+      imageRegistry: {{ .Values.global.imageRegistry }}
+    {{- end }}
+    priorityClassName: monitoring-components
+    resources: {{- include "common.resources" .Values.monitoring.prometheus.blackboxExporter | nindent 6 }}
+    serviceMonitor:
+      selfMonitor:
+        enabled: true
+{{- end }}

--- a/charts/base-cluster/values.schema.json
+++ b/charts/base-cluster/values.schema.json
@@ -728,6 +728,21 @@
             },
             "kubeControllerManager": {
               "$ref": "#/$defs/triState"
+            },
+            "blackboxExporter": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "resourcesPreset": {
+                  "$ref": "#/$defs/resourcesPreset"
+                },
+                "resources": {
+                  "$ref": "#/$defs/resourceRequirements"
+                }
+              },
+              "additionalProperties": false
             }
           },
           "additionalProperties": false

--- a/charts/base-cluster/values.yaml
+++ b/charts/base-cluster/values.yaml
@@ -117,6 +117,7 @@ global:
       url: https://prometheus-community.github.io/helm-charts
       charts:
         kube-prometheus-stack: 84.5.0
+        prometheus-blackbox-exporter: 11.15.1
       type: helm
       condition: "{{ .Values.monitoring.prometheus.enabled }}"
       interval: 5m
@@ -319,6 +320,10 @@ monitoring:
         limits:
           cpu: 2
           memory: 64Mi
+    blackboxExporter:
+      enabled: false
+      resourcesPreset: nano
+      resources: {}
     ingress:
       host: prometheus
       customDomain: ""


### PR DESCRIPTION
this is required for the `Probes` CRD


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Prometheus Blackbox Exporter support for monitoring deployments.
  * Added configuration for enabling the exporter and assigning resource settings.
  * Enabled self-monitoring and integrated the exporter with the existing Prometheus stack.
* **Configuration**
  * Added the exporter’s chart configuration and license information.
  * The exporter remains disabled by default and can be enabled through monitoring settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->