### PR TITLE
fix(base-cluster/monitoring): disallow unsupported receivers

### DIFF
--- a/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_alertmanager-config.yaml
+++ b/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_alertmanager-config.yaml
@@ -3,13 +3,14 @@
 {{- end -}}
 
 {{- define "base-cluster.prometheus-stack.alertmanager.validateReceiverInRoute" -}}
+  {{- $_ := set . "path" ($.path | default ".alertmanager")  -}}
   {{- if .route.receiver -}}
     {{- if not (hasKey .receivers .route.receiver) -}}
-      {{- fail (printf "Receiver '%s' is not configured" .route.receiver) -}}
+      {{- fail (printf "Receiver '%s' (path: '%s.receiver') is not configured" .route.receiver .path) -}}
     {{- end -}}
   {{- end -}}
-  {{- range $route := dig "routes" (list) .route -}}
-    {{- include "base-cluster.prometheus-stack.alertmanager.validateReceiverInRoute" (dict "route" $route "receivers" $.receivers) -}}
+  {{- range $index, $route := dig "routes" (list) .route -}}
+    {{- include "base-cluster.prometheus-stack.alertmanager.validateReceiverInRoute" (dict "route" $route "receivers" $.receivers "path" (printf "%s%s%d%s" $.path ".routes[" $index "]")) -}}
   {{- end -}}
 {{- end -}}
 
@@ -124,6 +125,7 @@ config:
     )
   -}}
   {{- with .Values.monitoring.prometheus.alertmanager.routes -}}
+    {{- include "base-cluster.prometheus-stack.alertmanager.validateReceiverInRoute" (dict "route" (dict "routes" .) "receivers" $receivers) -}}
     {{- $routes = concat $routes . -}}
   {{- end -}}
 

--- a/charts/base-cluster/values.schema.json
+++ b/charts/base-cluster/values.schema.json
@@ -686,7 +686,8 @@
                       "additionalProperties": false
                     },
                     "additionalProperties": false
-                  }
+                  },
+                  "additionalProperties": false
                 },
                 "routes": {
                   "$ref": "#/$defs/alertmanagerConfigRoutes"

--- a/charts/base-cluster/values.schema.json
+++ b/charts/base-cluster/values.schema.json
@@ -684,8 +684,7 @@
                         "botToken"
                       ],
                       "additionalProperties": false
-                    },
-                    "additionalProperties": false
+                    }
                   },
                   "additionalProperties": false
                 },
@@ -1386,33 +1385,52 @@
           "description": "Try to use specified IP as loadbalancer IP"
         },
         "extraPorts": {
-              "type": "object",
-              "additionalProperties": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "required": [
+              "port",
+              "exposedPort",
+              "protocol"
+            ],
+            "properties": {
+              "port": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 65535
+              },
+              "exposedPort": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 65535
+              },
+              "protocol": {
+                "type": "string",
+                "enum": [
+                  "TCP",
+                  "UDP"
+                ]
+              },
+              "expose": {
                 "type": "object",
-                "required": ["port", "exposedPort", "protocol"],
                 "properties": {
-                  "port": { "type": "integer", "minimum": 1, "maximum": 65535  },
-                  "exposedPort": { "type": "integer", "minimum": 1, "maximum": 65535  },
-                  "protocol": {
-                    "type": "string",
-                    "enum": ["TCP", "UDP"]
-                  },
-                  "expose": {
-                    "type": "object",
-                    "properties": {
-                      "default": { "type": "boolean" }
-                    }
-                  },
-                  "proxyProtocol": {
-                    "type": "object",
-                    "properties": {
-                      "insecure": { "type": "boolean" }
-                    }
+                  "default": {
+                    "type": "boolean"
                   }
-                },
-                "additionalProperties": true
+                }
+              },
+              "proxyProtocol": {
+                "type": "object",
+                "properties": {
+                  "insecure": {
+                    "type": "boolean"
+                  }
+                }
               }
-            }
+            },
+            "additionalProperties": true
+          }
+        }
       },
       "additionalProperties": false
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened validation for Alertmanager receiver settings so only supported receiver fields are accepted.
  * This helps catch misconfigurations earlier and prevents unexpected values from being deployed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->