### PR TITLE
feat(base-cluster/ingress): don't throw errors when both conrollers are (manually) deployed

### DIFF
--- a/charts/base-cluster/templates/ingress/validation.tpl
+++ b/charts/base-cluster/templates/ingress/validation.tpl
@@ -6,15 +6,19 @@
   {{- fail "useTraefikNginxCompatibility cannot be enabled when using nginx as the ingress provider" -}}
 {{- end -}}
 
-{{- if eq .Values.ingress.provider "traefik" -}}
-  {{- $existingNginx := lookup "helm.toolkit.fluxcd.io/v2" "HelmRelease" "ingress-nginx" "ingress-nginx" -}}
-  {{- if $existingNginx -}}
-    {{- fail "Cannot switch to traefik while nginx is installed. If you want to switch to traefik, please delete the HelmRelease 'ingress-nginx/ingress-nginx' first. Note: You might want to set .Values.ingress.IP to the current nginx LoadBalancer IP to keep the same IP. Warning: Switching providers will cause downtime until the new provider is fully deployed." -}}
-  {{- end -}}
-{{- else if eq .Values.ingress.provider "nginx" -}}
-  {{- $existingTraefik := lookup "helm.toolkit.fluxcd.io/v2" "HelmRelease" "ingress" "ingress-controller" -}}
-  {{- if $existingTraefik -}}
-    {{- fail "Cannot switch to nginx while traefik is installed. If you want to switch to nginx, please delete the HelmRelease 'ingress/ingress-controller' first. Note: You might want to set .Values.ingress.IP to the current traefik LoadBalancer IP to keep the same IP. Warning: Switching providers will cause downtime until the new provider is fully deployed." -}}
+{{- $existingNginx := lookup "helm.toolkit.fluxcd.io/v2" "HelmRelease" "ingress-nginx" "ingress-nginx" -}}
+{{- $existingTraefik := lookup "helm.toolkit.fluxcd.io/v2" "HelmRelease" "ingress" "ingress-controller" -}}
+{{- if and $existingNginx $existingTraefik -}}
+  {{/* both are deployed, skip any checks; manual dual-mode */}}
+{{- else -}}
+  {{- if eq .Values.ingress.provider "traefik" -}}
+    {{- if $existingNginx -}}
+      {{- fail "Cannot switch to traefik while nginx is installed. If you want to switch to traefik, please delete the HelmRelease 'ingress-nginx/ingress-nginx' first. Note: You might want to set .Values.ingress.IP to the current nginx LoadBalancer IP to keep the same IP. Warning: Switching providers will cause downtime until the new provider is fully deployed." -}}
+    {{- end -}}
+  {{- else if eq .Values.ingress.provider "nginx" -}}
+    {{- if $existingTraefik -}}
+      {{- fail "Cannot switch to nginx while traefik is installed. If you want to switch to nginx, please delete the HelmRelease 'ingress/ingress-controller' first. Note: You might want to set .Values.ingress.IP to the current traefik LoadBalancer IP to keep the same IP. Warning: Switching providers will cause downtime until the new provider is fully deployed." -}}
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 

--- a/charts/base-cluster/tests/ingress_validation_test.yaml
+++ b/charts/base-cluster/tests/ingress_validation_test.yaml
@@ -71,6 +71,56 @@ tests:
       - failedTemplate:
           errorMessage: "Cannot switch to nginx while traefik is installed. If you want to switch to nginx, please delete the HelmRelease 'ingress/ingress-controller' first. Note: You might want to set .Values.ingress.IP to the current traefik LoadBalancer IP to keep the same IP. Warning: Switching providers will cause downtime until the new provider is fully deployed."
 
+  - it: no error when both nginx and traefik HelmReleases exist with traefik provider
+    kubernetesProvider:
+      scheme:
+        "helm.toolkit.fluxcd.io/v2/HelmRelease":
+          gvr:
+            group: "helm.toolkit.fluxcd.io"
+            version: "v2"
+            resource: "helmreleases"
+          namespaced: true
+      objects:
+        - apiVersion: helm.toolkit.fluxcd.io/v2
+          kind: HelmRelease
+          metadata:
+            name: ingress-nginx
+            namespace: ingress-nginx
+        - apiVersion: helm.toolkit.fluxcd.io/v2
+          kind: HelmRelease
+          metadata:
+            name: ingress-controller
+            namespace: ingress
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: no error when both nginx and traefik HelmReleases exist with nginx provider
+    set:
+      ingress.provider: nginx
+    kubernetesProvider:
+      scheme:
+        "helm.toolkit.fluxcd.io/v2/HelmRelease":
+          gvr:
+            group: "helm.toolkit.fluxcd.io"
+            version: "v2"
+            resource: "helmreleases"
+          namespaced: true
+      objects:
+        - apiVersion: helm.toolkit.fluxcd.io/v2
+          kind: HelmRelease
+          metadata:
+            name: ingress-nginx
+            namespace: ingress-nginx
+        - apiVersion: helm.toolkit.fluxcd.io/v2
+          kind: HelmRelease
+          metadata:
+            name: ingress-controller
+            namespace: ingress
+    asserts:
+      - hasDocuments:
+          count: 0
+
   - it: fails when desired IP differs from existing service loadBalancerIP
     set:
       ingress.IP: 10.0.0.100


### PR DESCRIPTION
That way customers with special/legacy setups can run both in parallel
during migration


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ingress validation to avoid false provider-switch conflicts when both nginx and Traefik are already present.
  * Allowed dual-provider deployments to pass validation when the selected ingress setup is intentionally shared.
* **Tests**
  * Added coverage for nginx and Traefik coexistence scenarios to confirm validation succeeds for both provider choices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->