### PR TITLE
feat(ci): specify breaking changes in "unreleased breaking changes"

### DIFF
--- a/.github/workflows/release-update-metadata.yaml
+++ b/.github/workflows/release-update-metadata.yaml
@@ -120,8 +120,8 @@ jobs:
           old_major=$(( new_major - 1 ))
           new_header="### ${old_major}.x.x -> ${new_major}.0.0"
 
-          sed -i "0,/^### [Uu]nreleased [Bb]reaking [Cc]hanges$/{s/^### [Uu]nreleased [Bb]reaking [Cc]hanges$/${new_header}/}" "$readme"
-          sed -i "/^$/{N;/\n### [Uu]nreleased [Bb]reaking [Cc]hanges$/d}" "$readme"
+          sed -i -E "0,/^### unreleased breaking changes[[:space:]]*$/I{s/^### unreleased breaking changes[[:space:]]*$/${new_header}/I}" "$readme"
+          sed -i -E "/^$/{N;/\n### unreleased breaking changes[[:space:]]*$/Id}" "$readme"
       - name: Commit README.md.gotmpl
         uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10
         with:

--- a/.github/workflows/release-update-metadata.yaml
+++ b/.github/workflows/release-update-metadata.yaml
@@ -104,6 +104,31 @@ jobs:
             exit 0
           fi
           generate-schema-doc --config-file .github/json-schema-to-md.yaml "charts/$CHART/values.schema.json" "charts/$CHART/values.md"
+      - name: Replace unreleased migration sections in README.md.gotmpl
+        run: |
+          [[ "$RUNNER_DEBUG" == 1 ]] && set -x
+          set -e
+          set -o pipefail
+
+          readme="charts/${CHART}/README.md.gotmpl"
+          if ! grep -qiF "### unreleased breaking changes" "$readme"; then
+            exit 0
+          fi
+
+          version="$(jq -er --arg chart "${CHART}" '.["charts/\($chart)"]' .github/release-please/manifest.json)"
+          new_major="${version%%.*}"
+          old_major=$(( new_major - 1 ))
+          new_header="### ${old_major}.x.x -> ${new_major}.0.0"
+
+          sed -i "0,/^### [Uu]nreleased [Bb]reaking [Cc]hanges$/{s/^### [Uu]nreleased [Bb]reaking [Cc]hanges$/${new_header}/}" "$readme"
+          sed -i "/^$/{N;/\n### [Uu]nreleased [Bb]reaking [Cc]hanges$/d}" "$readme"
+      - name: Commit README.md.gotmpl
+        uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10
+        with:
+          message: "ci: [bot] Replace unreleased migration sections in 'README.md.gotmpl'"
+          default_author: github_actions
+          push: false
+          add: charts/${{ env.CHART }}/README.md.gotmpl
       - name: generate Docs
         uses: docker://jnorwood/helm-docs:v1.14.2@sha256:7e562b49ab6b1dbc50c3da8f2dd6ffa8a5c6bba327b1c6335cc15ce29267979c
         with:

--- a/.github/workflows/validate-readme.yaml
+++ b/.github/workflows/validate-readme.yaml
@@ -59,11 +59,9 @@ jobs:
           done
 
           if [[ "$hasBreakingChange" == true ]]; then
-            major="$(gh api --paginate "/repos/${GITHUB_REPOSITORY}/contents/charts/${CHANGED_CHART}/Chart.yaml?ref=${HEAD_COMMIT}" | jq -er .content | base64 -d | yq -er '.version | split(".")[0]')"
-            migrationLine="### $major.x.x -> $(( major + 1)).0.0"
-            if [[ "$(gh api --paginate "/repos/${GITHUB_REPOSITORY}/contents/charts/${CHANGED_CHART}/README.md.gotmpl?ref=${HEAD_COMMIT}" | jq -er .content | base64 -d | grep -Fc "$migrationLine")" != 1 ]]; then
-              echo "You need to provide a migration info for this breaking change, and exactly one" >&2
-              echo "Add > $migrationLine < to README.md.gotmpl" >&2
+            if [[ "$(gh api --paginate "/repos/${GITHUB_REPOSITORY}/contents/charts/${CHANGED_CHART}/README.md.gotmpl?ref=${HEAD_COMMIT}" | jq -er .content | base64 -d | grep -Fci "### unreleased breaking changes")" -lt 1 ]]; then
+              echo "You need to provide a migration info for this breaking change" >&2
+              echo 'Add "### unreleased breaking changes" section to README.md.gotmpl' >&2
               exit 1
             fi
           fi

--- a/.github/workflows/validate-readme.yaml
+++ b/.github/workflows/validate-readme.yaml
@@ -59,7 +59,7 @@ jobs:
           done
 
           if [[ "$hasBreakingChange" == true ]]; then
-            if [[ "$(gh api --paginate "/repos/${GITHUB_REPOSITORY}/contents/charts/${CHANGED_CHART}/README.md.gotmpl?ref=${HEAD_COMMIT}" | jq -er .content | base64 -d | grep -Fci "### unreleased breaking changes")" -lt 1 ]]; then
+            if ! gh api --paginate "/repos/${GITHUB_REPOSITORY}/contents/charts/${CHANGED_CHART}/README.md.gotmpl?ref=${HEAD_COMMIT}" | jq -er .content | base64 -d | grep -qiF "### unreleased breaking changes"; then
               echo "You need to provide a migration info for this breaking change" >&2
               echo 'Add "### unreleased breaking changes" section to README.md.gotmpl' >&2
               exit 1


### PR DESCRIPTION
Currently, the user has to know the next version and parallel breaking
change PR have the risk of diverging;

1. A and B PR are created with 2.x.x -> 3.0.0
2. A gets merged and released
3. B does _not_ get updated to bump the versions

- even if CI fails at this point, the user has to manually update this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved chart README maintenance for breaking changes by automatically updating the migration section heading to align with chart versioning.
  * Enhanced release checks to confirm that chart README templates include the required “unreleased breaking changes” section when a commit marks a breaking change.

* **Chores**
  * Streamlined release metadata updates and README verification for major chart releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->