### PR TITLE
feat(base-cluster/ingress): force ingress-controller to sync GatewayClass

### DIFF
--- a/charts/base-cluster/templates/ingress/traefik.yaml
+++ b/charts/base-cluster/templates/ingress/traefik.yaml
@@ -21,6 +21,16 @@ spec:
     crds: Skip
   upgrade:
     crds: Skip
+  postRenderers:
+    - kustomize:
+        patches:
+          # this forces traefik to sync the class after each update
+          - target:
+              kind: GatewayClass
+            patch: |
+              - op: add
+                path: /spec/description
+                value: {{ .Values.global.helmRepositories.traefik.charts.traefik | quote }}
   values:
     fullnameOverride: ingress-controller
     {{- with .Values.global.imageRegistry }}


### PR DESCRIPTION
otherwise the status won't get updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Traefik GatewayClass descriptions are now automatically populated from the configured chart repository URL during installation and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->