### PR TITLE
docs(base-cluster): add short description

### DIFF
--- a/charts/base-cluster/Chart.yaml
+++ b/charts/base-cluster/Chart.yaml
@@ -3,7 +3,11 @@ dependencies:
   - name: common
     repository: oci://ghcr.io/teutonet/teutonet-helm-charts
     version: 2.1.1
-description: A common base for every kubernetes cluster
+description: >-
+  A common base for every kubernetes cluster. This chart bootstraps a cluster
+  with the shared components every teuto.net cluster needs. It is managed via
+  Flux and intended to be installed once, after which Flux takes over further
+  reconciliation of the chart itself.
 home: https://teuto.net
 icon: https://teuto.net/favicon.ico
 kubeVersion: '>=1.27.0-0'

--- a/charts/base-cluster/README.md.gotmpl
+++ b/charts/base-cluster/README.md.gotmpl
@@ -49,7 +49,7 @@ helm install -n flux-system flux flux2 --repo https://fluxcd-community.github.io
 
 # manual initial installation of the chart, afterwards the chart takes over
 # after the installation finished, follow the on-screen instructions to configure your flux, distribute KUBECONFIGs, ...
-helm install -n flux-system base-cluster oci://ghcr.io/teutonet/teutonet-helm-charts/base-cluster --version {{ $majorVersion }}.x.x --atomic --values <(cat cluster.yaml | yq -y .spec.values)
+helm install -n flux-system base-cluster oci://ghcr.io/teutonet/teutonet-helm-charts/base-cluster --version {{ $majorVersion }}.x.x --values <(cat cluster.yaml | yq -y .spec.values)
 
 # you can use this command to get the instructions again
 # e.g. when adding users, gitRepositories, ...


### PR DESCRIPTION
remove bad --atomic flag


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated cluster bootstrap instructions for installing the base-cluster chart.
  * The command now applies values from the cluster configuration and uses the chart’s OCI reference and major version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->