### PR TITLE
feat(base-cluster/ingress): Add sub-support for dual mode

### DIFF
--- a/charts/base-cluster/CLAUDE.md
+++ b/charts/base-cluster/CLAUDE.md
@@ -1,0 +1,4 @@
+# base-cluster ingress architecture
+
+- `.Values.ingress.provider` is the sole source of truth for which controller HelmRelease actually deploys (`templates/ingress/nginx.yaml`/`traefik.yaml`) — never gate that on dual-mode detection.
+- "Dual-mode" (`base-cluster.ingress.dualMode`/`hasNginx`/`hasTraefik` in `_helpers.tpl`) only widens *supporting* config — cert-manager's `enableGatewayAPI`, gateway-api CRDs, Grafana dashboards — for a manual provider migration. It is not a supported deployment topology.

--- a/charts/base-cluster/templates/_helpers.tpl
+++ b/charts/base-cluster/templates/_helpers.tpl
@@ -12,6 +12,26 @@
   {{- include "common.helm.chartSpec" (dict "context" .context "repo" .repo "chart" .chart "prependReleaseName" false "reconcileStrategy" .reconcileStrategy) -}}
 {{- end -}}
 
+{{- define "base-cluster.ingress.existingNginx" -}}
+  {{- not (empty (lookup "helm.toolkit.fluxcd.io/v2" "HelmRelease" "ingress-nginx" "ingress-nginx")) | ternary "true" "" -}}
+{{- end -}}
+
+{{- define "base-cluster.ingress.existingTraefik" -}}
+  {{- not (empty (lookup "helm.toolkit.fluxcd.io/v2" "HelmRelease" "ingress" "ingress-controller")) | ternary "true" "" -}}
+{{- end -}}
+
+{{- define "base-cluster.ingress.dualMode" -}}
+  {{- and (eq (include "base-cluster.ingress.existingNginx" .) "true") (eq (include "base-cluster.ingress.existingTraefik" .) "true") | ternary "true" "" -}}
+{{- end -}}
+
+{{- define "base-cluster.ingress.hasNginx" -}}
+  {{- or (eq .Values.ingress.provider "nginx") (eq (include "base-cluster.ingress.dualMode" .) "true") | ternary "true" "" -}}
+{{- end -}}
+
+{{- define "base-cluster.ingress.hasTraefik" -}}
+  {{- or (eq .Values.ingress.provider "traefik") (eq (include "base-cluster.ingress.dualMode" .) "true") | ternary "true" "" -}}
+{{- end -}}
+
 {{- define "base-cluster.monitoring.alertmanager.receiver.splitName" -}}
   {{- $name := .name -}}
   {{- $type := $name -}}

--- a/charts/base-cluster/templates/cert-manager/cert-manager.yaml
+++ b/charts/base-cluster/templates/cert-manager/cert-manager.yaml
@@ -40,7 +40,7 @@ spec:
     extraArgs:
       - --dns01-recursive-nameservers={{- $nameservers | sortAlpha | join "," }}
     {{- end }}
-    {{- if eq .Values.ingress.provider "traefik" }}
+    {{- if include "base-cluster.ingress.hasTraefik" . }}
     config:
       apiVersion: controller.config.cert-manager.io/v1alpha1
       kind: ControllerConfiguration

--- a/charts/base-cluster/templates/ingress/gateway-api.yaml
+++ b/charts/base-cluster/templates/ingress/gateway-api.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.ingress.provider "traefik" -}}
+{{- if include "base-cluster.ingress.hasTraefik" . -}}
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:

--- a/charts/base-cluster/templates/ingress/validation.tpl
+++ b/charts/base-cluster/templates/ingress/validation.tpl
@@ -6,8 +6,8 @@
   {{- fail "useTraefikNginxCompatibility cannot be enabled when using nginx as the ingress provider" -}}
 {{- end -}}
 
-{{- $existingNginx := lookup "helm.toolkit.fluxcd.io/v2" "HelmRelease" "ingress-nginx" "ingress-nginx" -}}
-{{- $existingTraefik := lookup "helm.toolkit.fluxcd.io/v2" "HelmRelease" "ingress" "ingress-controller" -}}
+{{- $existingNginx := include "base-cluster.ingress.existingNginx" . -}}
+{{- $existingTraefik := include "base-cluster.ingress.existingTraefik" . -}}
 {{- if and $existingNginx $existingTraefik -}}
   {{/* both are deployed, skip any checks; manual dual-mode */}}
 {{- else -}}

--- a/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_grafana-config.yaml
+++ b/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_grafana-config.yaml
@@ -126,12 +126,13 @@ dashboards:
     metrics:
       <<: *dashboard
       gnetId: 8588
-    {{- if eq .Values.ingress.provider "nginx" }}
+    {{- if include "base-cluster.ingress.hasNginx" . }}
     ingress-nginx:
       <<: *dashboard
       gnetId: 9614
       revision: 1
-    {{- else if eq .Values.ingress.provider "traefik" }}
+    {{- end }}
+    {{- if include "base-cluster.ingress.hasTraefik" . }}
     traefik:
       <<: *dashboard
       gnetId: 17347

--- a/charts/base-cluster/tests/ingress_cert_manager_test.yaml
+++ b/charts/base-cluster/tests/ingress_cert_manager_test.yaml
@@ -1,0 +1,95 @@
+suite: ingress dual-mode helper functions
+templates:
+  - templates/cert-manager/cert-manager.yaml
+release:
+  name: base-cluster
+tests:
+  - it: cert-manager gatewayAPI enabled when provider is traefik (default)
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.values.config.enableGatewayAPI
+          value: true
+
+  - it: cert-manager gatewayAPI not set when provider is nginx
+    set:
+      ingress.provider: nginx
+    asserts:
+      - hasDocuments:
+          count: 1
+      - notExists:
+          path: spec.values.config
+
+  - it: cert-manager gatewayAPI enabled in dual-mode (both HelmReleases exist, provider is traefik)
+    kubernetesProvider:
+      scheme:
+        helm.toolkit.fluxcd.io/v2/HelmRelease:
+          gvr:
+            group: helm.toolkit.fluxcd.io
+            version: v2
+            resource: helmreleases
+          namespaced: true
+      objects:
+        - apiVersion: helm.toolkit.fluxcd.io/v2
+          kind: HelmRelease
+          metadata:
+            name: ingress-nginx
+            namespace: ingress-nginx
+        - apiVersion: helm.toolkit.fluxcd.io/v2
+          kind: HelmRelease
+          metadata:
+            name: ingress-controller
+            namespace: ingress
+    asserts:
+      - equal:
+          path: spec.values.config.enableGatewayAPI
+          value: true
+
+  - it: cert-manager gatewayAPI enabled in dual-mode (both HelmReleases exist, provider is nginx)
+    set:
+      ingress.provider: nginx
+    kubernetesProvider:
+      scheme:
+        helm.toolkit.fluxcd.io/v2/HelmRelease:
+          gvr:
+            group: helm.toolkit.fluxcd.io
+            version: v2
+            resource: helmreleases
+          namespaced: true
+      objects:
+        - apiVersion: helm.toolkit.fluxcd.io/v2
+          kind: HelmRelease
+          metadata:
+            name: ingress-nginx
+            namespace: ingress-nginx
+        - apiVersion: helm.toolkit.fluxcd.io/v2
+          kind: HelmRelease
+          metadata:
+            name: ingress-controller
+            namespace: ingress
+    asserts:
+      - equal:
+          path: spec.values.config.enableGatewayAPI
+          value: true
+
+  - it: cert-manager gatewayAPI not set when only nginx HelmRelease exists (no dual-mode)
+    set:
+      ingress.provider: nginx
+    kubernetesProvider:
+      scheme:
+        helm.toolkit.fluxcd.io/v2/HelmRelease:
+          gvr:
+            group: helm.toolkit.fluxcd.io
+            version: v2
+            resource: helmreleases
+          namespaced: true
+      objects:
+        - apiVersion: helm.toolkit.fluxcd.io/v2
+          kind: HelmRelease
+          metadata:
+            name: ingress-nginx
+            namespace: ingress-nginx
+    asserts:
+      - notExists:
+          path: spec.values.config

--- a/charts/base-cluster/tests/ingress_gateway_api_test.yaml
+++ b/charts/base-cluster/tests/ingress_gateway_api_test.yaml
@@ -1,0 +1,67 @@
+suite: ingress gateway-api dual-mode
+templates:
+  - templates/ingress/gateway-api.yaml
+release:
+  name: base-cluster
+tests:
+  - it: gateway-api renders when provider is traefik (default)
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: gateway-api does not render when provider is nginx
+    set:
+      ingress.provider: nginx
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: gateway-api renders in dual-mode with traefik provider
+    kubernetesProvider:
+      scheme:
+        helm.toolkit.fluxcd.io/v2/HelmRelease:
+          gvr:
+            group: helm.toolkit.fluxcd.io
+            version: v2
+            resource: helmreleases
+          namespaced: true
+      objects:
+        - apiVersion: helm.toolkit.fluxcd.io/v2
+          kind: HelmRelease
+          metadata:
+            name: ingress-nginx
+            namespace: ingress-nginx
+        - apiVersion: helm.toolkit.fluxcd.io/v2
+          kind: HelmRelease
+          metadata:
+            name: ingress-controller
+            namespace: ingress
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: gateway-api renders in dual-mode with nginx provider
+    set:
+      ingress.provider: nginx
+    kubernetesProvider:
+      scheme:
+        helm.toolkit.fluxcd.io/v2/HelmRelease:
+          gvr:
+            group: helm.toolkit.fluxcd.io
+            version: v2
+            resource: helmreleases
+          namespaced: true
+      objects:
+        - apiVersion: helm.toolkit.fluxcd.io/v2
+          kind: HelmRelease
+          metadata:
+            name: ingress-nginx
+            namespace: ingress-nginx
+        - apiVersion: helm.toolkit.fluxcd.io/v2
+          kind: HelmRelease
+          metadata:
+            name: ingress-controller
+            namespace: ingress
+    asserts:
+      - hasDocuments:
+          count: 2

--- a/charts/base-cluster/tests/ingress_grafana_dashboards_test.yaml
+++ b/charts/base-cluster/tests/ingress_grafana_dashboards_test.yaml
@@ -1,0 +1,130 @@
+suite: grafana ingress dashboard dual-mode
+templates:
+  - templates/monitoring/kube-prometheus-stack/prometheus-operator.yaml
+  - templates/monitoring/kube-prometheus-stack/grafana-secret.yaml
+release:
+  name: base-cluster
+tests:
+  - it: only renders the ingress-nginx dashboard when provider is nginx
+    template: templates/monitoring/kube-prometheus-stack/prometheus-operator.yaml
+    set:
+      global.clusterName: test
+      monitoring.grafana.adminPassword: test
+      monitoring.prometheus.enabled: true
+      ingress.provider: nginx
+    asserts:
+      - exists:
+          path: spec.values.grafana.dashboards.custom.ingress-nginx
+      - notExists:
+          path: spec.values.grafana.dashboards.custom.traefik
+
+  - it: only renders the traefik dashboard when provider is traefik (default)
+    template: templates/monitoring/kube-prometheus-stack/prometheus-operator.yaml
+    set:
+      global.clusterName: test
+      monitoring.grafana.adminPassword: test
+      monitoring.prometheus.enabled: true
+    asserts:
+      - notExists:
+          path: spec.values.grafana.dashboards.custom.ingress-nginx
+      - exists:
+          path: spec.values.grafana.dashboards.custom.traefik
+
+  - it: renders both dashboards in dual-mode (provider nginx, traefik HelmRelease also exists)
+    template: templates/monitoring/kube-prometheus-stack/prometheus-operator.yaml
+    set:
+      global.clusterName: test
+      monitoring.grafana.adminPassword: test
+      monitoring.prometheus.enabled: true
+      monitoring.prometheus.kubeProxy: false
+      monitoring.prometheus.kubeScheduler: false
+      monitoring.prometheus.kubeControllerManager: false
+      ingress.provider: nginx
+    kubernetesProvider:
+      scheme:
+        helm.toolkit.fluxcd.io/v2/HelmRelease:
+          gvr:
+            group: helm.toolkit.fluxcd.io
+            version: v2
+            resource: helmreleases
+          namespaced: true
+      objects:
+        - apiVersion: helm.toolkit.fluxcd.io/v2
+          kind: HelmRelease
+          metadata:
+            name: ingress-nginx
+            namespace: ingress-nginx
+        - apiVersion: helm.toolkit.fluxcd.io/v2
+          kind: HelmRelease
+          metadata:
+            name: ingress-controller
+            namespace: ingress
+    asserts:
+      - exists:
+          path: spec.values.grafana.dashboards.custom.ingress-nginx
+      - exists:
+          path: spec.values.grafana.dashboards.custom.traefik
+
+  - it: renders both dashboards in dual-mode (provider traefik, nginx HelmRelease also exists)
+    template: templates/monitoring/kube-prometheus-stack/prometheus-operator.yaml
+    set:
+      global.clusterName: test
+      monitoring.grafana.adminPassword: test
+      monitoring.prometheus.enabled: true
+      monitoring.prometheus.kubeProxy: false
+      monitoring.prometheus.kubeScheduler: false
+      monitoring.prometheus.kubeControllerManager: false
+    kubernetesProvider:
+      scheme:
+        helm.toolkit.fluxcd.io/v2/HelmRelease:
+          gvr:
+            group: helm.toolkit.fluxcd.io
+            version: v2
+            resource: helmreleases
+          namespaced: true
+      objects:
+        - apiVersion: helm.toolkit.fluxcd.io/v2
+          kind: HelmRelease
+          metadata:
+            name: ingress-nginx
+            namespace: ingress-nginx
+        - apiVersion: helm.toolkit.fluxcd.io/v2
+          kind: HelmRelease
+          metadata:
+            name: ingress-controller
+            namespace: ingress
+    asserts:
+      - exists:
+          path: spec.values.grafana.dashboards.custom.ingress-nginx
+      - exists:
+          path: spec.values.grafana.dashboards.custom.traefik
+
+  - it: renders only the provider dashboard when an unrelated HelmRelease exists in those namespaces
+    template: templates/monitoring/kube-prometheus-stack/prometheus-operator.yaml
+    set:
+      global.clusterName: test
+      monitoring.grafana.adminPassword: test
+      monitoring.prometheus.enabled: true
+      monitoring.prometheus.kubeProxy: false
+      monitoring.prometheus.kubeScheduler: false
+      monitoring.prometheus.kubeControllerManager: false
+      ingress.provider: nginx
+    kubernetesProvider:
+      scheme:
+        helm.toolkit.fluxcd.io/v2/HelmRelease:
+          gvr:
+            group: helm.toolkit.fluxcd.io
+            version: v2
+            resource: helmreleases
+          namespaced: true
+      objects:
+        - apiVersion: helm.toolkit.fluxcd.io/v2
+          kind: HelmRelease
+          metadata:
+            name: unrelated
+            namespace: ingress
+    asserts:
+      - exists:
+          path: spec.values.grafana.dashboards.custom.ingress-nginx
+      - notExists:
+          path: spec.values.grafana.dashboards.custom.traefik

--- a/charts/base-cluster/tests/ingress_nginx_test.yaml
+++ b/charts/base-cluster/tests/ingress_nginx_test.yaml
@@ -1,0 +1,22 @@
+suite: ingress nginx
+templates:
+  - templates/ingress/nginx.yaml
+release:
+  name: base-cluster
+tests:
+  - it: nginx HelmRelease renders when provider is nginx
+    set:
+      ingress.provider: nginx
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HelmRelease
+      - equal:
+          path: metadata.name
+          value: ingress-nginx
+
+  - it: nginx HelmRelease does not render when provider is traefik (default)
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/base-cluster/tests/ingress_traefik_test.yaml
+++ b/charts/base-cluster/tests/ingress_traefik_test.yaml
@@ -1,0 +1,22 @@
+suite: ingress traefik
+templates:
+  - templates/ingress/traefik.yaml
+release:
+  name: base-cluster
+tests:
+  - it: traefik HelmRelease renders when provider is traefik (default)
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HelmRelease
+      - equal:
+          path: metadata.name
+          value: ingress-controller
+
+  - it: traefik HelmRelease does not render when provider is nginx
+    set:
+      ingress.provider: nginx
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/base-cluster/tests/prometheus_control_plane_test.yaml
+++ b/charts/base-cluster/tests/prometheus_control_plane_test.yaml
@@ -57,12 +57,23 @@ tests:
             version: v1
             resource: daemonsets
           namespaced: true
+        helm.toolkit.fluxcd.io/v2/HelmRelease:
+          gvr:
+            group: helm.toolkit.fluxcd.io
+            version: v2
+            resource: helmreleases
+          namespaced: true
       objects:
         - kind: DaemonSet
           apiVersion: apps/v1
           metadata:
             name: kube-proxy
             namespace: kube-system
+        - apiVersion: helm.toolkit.fluxcd.io/v2
+          kind: HelmRelease
+          metadata:
+            name: unrelated
+            namespace: unrelated
     set:
       global.clusterName: test
       monitoring.grafana.adminPassword: test
@@ -92,6 +103,12 @@ tests:
             version: v1
             resource: pods
           namespaced: true
+        helm.toolkit.fluxcd.io/v2/HelmRelease:
+          gvr:
+            group: helm.toolkit.fluxcd.io
+            version: v2
+            resource: helmreleases
+          namespaced: true
       objects:
         - kind: Pod
           apiVersion: v1
@@ -100,6 +117,11 @@ tests:
             namespace: kube-system
             labels:
               component: kube-scheduler
+        - apiVersion: helm.toolkit.fluxcd.io/v2
+          kind: HelmRelease
+          metadata:
+            name: unrelated
+            namespace: unrelated
     set:
       global.clusterName: test
       monitoring.grafana.adminPassword: test
@@ -127,6 +149,12 @@ tests:
             version: v1
             resource: pods
           namespaced: true
+        helm.toolkit.fluxcd.io/v2/HelmRelease:
+          gvr:
+            group: helm.toolkit.fluxcd.io
+            version: v2
+            resource: helmreleases
+          namespaced: true
       objects:
         - kind: Pod
           apiVersion: v1
@@ -135,6 +163,11 @@ tests:
             namespace: kube-system
             labels:
               component: kube-controller-manager
+        - apiVersion: helm.toolkit.fluxcd.io/v2
+          kind: HelmRelease
+          metadata:
+            name: unrelated
+            namespace: unrelated
     set:
       global.clusterName: test
       monitoring.grafana.adminPassword: test
@@ -162,6 +195,12 @@ tests:
             version: v1
             resource: pods
           namespaced: true
+        helm.toolkit.fluxcd.io/v2/HelmRelease:
+          gvr:
+            group: helm.toolkit.fluxcd.io
+            version: v2
+            resource: helmreleases
+          namespaced: true
       objects:
         - kind: DaemonSet
           apiVersion: apps/v1
@@ -182,6 +221,11 @@ tests:
             namespace: kube-system
             labels:
               component: kube-controller-manager
+        - apiVersion: helm.toolkit.fluxcd.io/v2
+          kind: HelmRelease
+          metadata:
+            name: unrelated
+            namespace: unrelated
     set:
       global.clusterName: test
       monitoring.grafana.adminPassword: test


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic detection of available ingress controllers and dual-mode handling.
  * Updated Gateway API, certificate management, and monitoring dashboards to reflect the detected ingress controller(s).

* **Bug Fixes**
  * Fixed ingress-related rendering/config selection when an ingress controller is already installed or when both controllers are present.

* **Tests**
  * Added/expanded Helm test suites covering nginx vs Traefik selection, dual-mode scenarios, Gateway API enablement, cert-manager behavior, Grafana dashboard rendering, and ingress controller templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->