### PR TITLE
feat(ci): support gpu-operator split-field images in artifacthub extraction

### DIFF
--- a/.github/scripts/extract-artifacthub-images.sh
+++ b/.github/scripts/extract-artifacthub-images.sh
@@ -28,9 +28,22 @@ function getImages() {
     cd "$tmpDir/helmRelease"
     rm -f -- */HelmRelease/*.yaml
     (
-      grep -Er '\s+image: \S+$' |
+      grep -Er '\s+image: \S+[/:]\S+$' |
         grep -v 'artifacthub-ignore' || { if [[ "$?" == 2 ]]; then exit 2; fi; }
     )
+    # some charts (e.g. nvidia/gpu-operator's ClusterPolicy) split the image
+    # reference into sibling `repository`/`image`/`version`(or `tag`) keys
+    # instead of a single `image: repo/name:tag` string
+    while IFS= read -r -d '' file; do
+      local ignoredImages
+      ignoredImages="$(grep -oP 'image:\s*\K\S+(?=.*artifacthub-ignore)' "$file" || true)"
+      yq -r --arg file "${file#./}" --arg ignored "$ignoredImages" '
+        ($ignored | split("\n")) as $ignoredList
+        | [.. | objects | select(has("repository") and has("image") and (.image | type == "string") and ((.version != null) or (.tag != null)) and ((.image as $i | $ignoredList | index($i)) == null))]
+        | .[]
+        | "\($file):  image: \(.repository)/\(.image):\(.version // .tag)"
+      ' "$file"
+    done < <(find . -name '*.yaml' -print0)
   )
 }
 


### PR DESCRIPTION
## Summary
- `extract-artifacthub-images.sh` only matched `image: repo/name:tag`-style lines. NVIDIA gpu-operator-style charts split the image across separate `repository`/`image`/`version` (or `tag`) fields, so those images were silently missing from the `artifacthub.io/images` annotation.
- Adds a supplementary yq pass that detects that split-field pattern and emits the same `path:  image: repo/name:tag` format the grep-based path produces, and tightens the original grep to require a slash in the image value.

## Test plan
- [x] Ran the extraction script across the full repo (all charts) before/after — zero unintended changes elsewhere, only the previously-missing split-field images are picked up now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of container image references used for Artifact Hub metadata.
  * Added YAML-structure-aware extraction to support charts that provide repository plus image name, along with either version or tag.
  * Normalizes emitted image references for more accurate `artifacthub.io/images` annotations.
  * Continues to ignore any images explicitly marked to be excluded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->