### PR TITLE
feat(ci): skip non-artifacthub ci-values files in templating scripts

### DIFF
--- a/.github/scripts/create-values-diff.sh
+++ b/.github/scripts/create-values-diff.sh
@@ -71,7 +71,7 @@ function generateComment() {
   local newResourcesDir
   local originalResourcesDir
 
-  for values in "$chart/values.yaml" "$chart/ci/"*-values.yaml; do
+  for values in "$chart/values.yaml" "$chart/ci/artifacthub-values"*.yaml; do
     [[ -f "$values" ]] || continue
     (
       set -e
@@ -96,7 +96,7 @@ function generateComment() {
     ) &
   done
   wait
-  for values in "$chart/values.yaml" "$chart/ci/"*-values.yaml; do
+  for values in "$chart/values.yaml" "$chart/ci/artifacthub-values"*.yaml; do
     [[ -f "$values" ]] || continue
     originalResourcesDir="$TMP_DIR/original-$(basename -s .yaml "$values")"
     newResourcesDir="$TMP_DIR/new-$(basename -s .yaml "$values")"

--- a/.github/scripts/extract-artifacthub-images.sh
+++ b/.github/scripts/extract-artifacthub-images.sh
@@ -28,9 +28,22 @@ function getImages() {
     cd "$tmpDir/helmRelease"
     rm -f -- */HelmRelease/*.yaml
     (
-      grep -Er '\s+image: \S+$' |
+      grep -Er '\s+image: \S+[/:]\S+$' |
         grep -v 'artifacthub-ignore' || { if [[ "$?" == 2 ]]; then exit 2; fi; }
     )
+    # some charts (e.g. nvidia/gpu-operator's ClusterPolicy) split the image
+    # reference into sibling `repository`/`image`/`version`(or `tag`) keys
+    # instead of a single `image: repo/name:tag` string
+    while IFS= read -r -d '' file; do
+      local ignoredImages
+      ignoredImages="$(grep -oP 'image:\s*\K\S+(?=.*artifacthub-ignore)' "$file" || true)"
+      yq -r --arg file "${file#./}" --arg ignored "$ignoredImages" '
+        ($ignored | split("\n")) as $ignoredList
+        | [.. | objects | select(has("repository") and has("image") and (.image | type == "string") and ((.version != null) or (.tag != null)) and ((.image as $i | $ignoredList | index($i)) == null))]
+        | .[]
+        | "\($file):  image: \(.repository)/\(.image):\(.version // .tag)"
+      ' "$file"
+    done < <(find . -name '*.yaml' -print0)
   )
 }
 

--- a/.github/scripts/templateHelmChartRecursivelyToFolder.sh
+++ b/.github/scripts/templateHelmChartRecursivelyToFolder.sh
@@ -35,4 +35,4 @@ function templateAndSplit() {
 export -f templateAndSplit
 
 export BIN="$(dirname "$0")"
-parallel $([[ -v GITHUB_JOB ]] || printf -- --bar) -P 100% templateAndSplit {} "$chart" "$targetDir" ::: "$chart/values.yaml" "$chart/ci/"*-values.yaml
+parallel $([[ -v GITHUB_JOB ]] || printf -- --bar) -P 100% templateAndSplit {} "$chart" "$targetDir" ::: "$chart/values.yaml" "$chart/ci/artifacthub-values"*.yaml


### PR DESCRIPTION
## Summary
- \`create-values-diff.sh\` and \`templateHelmChartRecursivelyToFolder.sh\` now only process \`values.yaml\` + \`ci/artifacthub-values*.yaml\`, instead of every \`ci/*-values.yaml\` file.
- Other \`ci/*-values.yaml\` files stay on disk for reference/documentation but are no longer templated (including recursively) by the PR-diff-comment and pluto/kubescape scan steps.
- \`ct lint\` is untouched and still validates every \`ci/*-values.yaml\` file, as does \`extract-artifacthub-images.sh\` (already artifacthub-only).

## Test plan
- [ ] CI passes on this branch (linter, pr-comment-diff)
- [ ] Spot-check a chart with many \`ci/*-values.yaml\` (e.g. \`base-cluster\`, \`teuto-cnpg\`) that lint still runs against all of them, while the diff comment / kubescape scan only cover \`values.yaml\` + artifacthub values