### PR TITLE
feat(ci): enforce license links to be real, verified license files

### DIFF
--- a/.github/image_licenses.yaml
+++ b/.github/image_licenses.yaml
@@ -1,70 +1,70 @@
 licenses:
   docker.io/aelbakry/kdave-server:
     license: MIT
-    licenseLink: https://github.com/wayfair-incubator/kdave/blob/main/LICENSE
+    licenseLink: https://raw.githubusercontent.com/wayfair-incubator/kdave/refs/heads/main/LICENSE
   docker.io/bats/bats:
     license: MIT
-    licenseLink: https://github.com/bats-core/bats-core/blob/master/LICENSE.md
+    licenseLink: https://raw.githubusercontent.com/bats-core/bats-core/refs/heads/master/LICENSE.md
   docker.io/bitnami/external-dns:
     license: Apache-2.0
-    licenseLink: https://hub.docker.com/r/bitnami/external-dns
+    licenseLink: https://raw.githubusercontent.com/kubernetes-sigs/external-dns/refs/heads/master/LICENSE.md
   docker.io/bitnami/grafana-tempo:
-    license: Apache-2.0
-    licenseLink: https://hub.docker.com/r/bitnami/grafana-tempo
+    license: AGPL-3.0-only
+    licenseLink: https://raw.githubusercontent.com/grafana/tempo/refs/heads/main/LICENSE
   docker.io/bitnami/grafana-tempo-vulture:
-    license: Apache-2.0
-    licenseLink: https://hub.docker.com/r/bitnami/grafana-tempo-vulture
+    license: AGPL-3.0-only
+    licenseLink: https://raw.githubusercontent.com/grafana/tempo/refs/heads/main/LICENSE
   docker.io/bitnami/memcached:
-    license: Apache-2.0
-    licenseLink: https://hub.docker.com/r/bitnami/memcached
+    license: BSD-3
+    licenseLink: https://raw.githubusercontent.com/memcached/memcached/refs/heads/master/LICENSE
   docker.io/bitnami/metrics-server:
     license: Apache-2.0
-    licenseLink: https://hub.docker.com/r/bitnami/metrics-server
+    licenseLink: https://raw.githubusercontent.com/bitnami/containers/main/LICENSE.md
   docker.io/bitnamilegacy/kubectl:
     license: Apache-2.0
-    licenseLink: https://hub.docker.com/r/bitnamilegacy/kubectl
+    licenseLink: https://raw.githubusercontent.com/kubernetes/kubernetes/refs/heads/master/LICENSE
   docker.io/bitnamilegacy/postgresql:
     license: PostgreSQL
-    licenseLink: https://www.postgresql.org/about/licence/
+    licenseLink: https://raw.githubusercontent.com/postgres/postgres/master/COPYRIGHT
   docker.io/bitnamilegacy/valkey:
     license: BSD-3
-    licenseLink: https://hub.docker.com/r/bitnamilegacy/valkey
+    licenseLink: https://raw.githubusercontent.com/valkey-io/valkey/refs/heads/unstable/COPYING
   docker.io/bitnamilegacy/zookeeper:
     license: Apache-2.0
-    licenseLink: https://zookeeper.apache.org/
+    licenseLink: https://raw.githubusercontent.com/apache/zookeeper/master/LICENSE.txt
   docker.io/busybox:
     license: GPL-2.0-only
-    licenseLink: http://www.busybox.net/license.html
+    licenseLink: https://www.busybox.net/license.html
   docker.io/ckan/ckan-base-datapusher:
     license: AGPL-3.0-only
-    licenseLink: https://github.com/ckan/datapusher
+    licenseLink: https://raw.githubusercontent.com/ckan/datapusher/refs/heads/master/LICENSE
   docker.io/confluentinc/cp-kafka:
     license: Apache-2.0
-    licenseLink: https://github.com/confluentinc/kafka-images/blob/master/LICENSE
+    licenseLink: https://raw.githubusercontent.com/confluentinc/kafka-images/refs/heads/master/LICENSE
   docker.io/curlimages/curl:
     license: curl
     licenseLink: https://curl.se/docs/copyright.html
   docker.io/emberstack/kubernetes-reflector:
     license: MIT
-    licenseLink: https://github.com/emberstack/kubernetes-reflector/blob/main/LICENSE
+    licenseLink: https://raw.githubusercontent.com/emberstack/kubernetes-reflector/refs/heads/main/LICENSE
   docker.io/fluxcd/flux-cli:
     license: Apache-2.0
-    licenseLink: https://github.com/fluxcd/flux2/blob/main/LICENSE
+    licenseLink: https://raw.githubusercontent.com/fluxcd/flux2/refs/heads/main/LICENSE
   docker.io/grafana/alloy:
     license: Apache-2.0
-    licenseLink: https://github.com/grafana/alloy/blob/main/LICENSE
+    licenseLink: https://raw.githubusercontent.com/grafana/alloy/refs/heads/main/LICENSE
   docker.io/grafana/grafana:
     license: AGPL-3.0-only
-    licenseLink: https://github.com/grafana/grafana/blob/main/LICENSING.md
+    licenseLink: https://raw.githubusercontent.com/grafana/grafana/refs/heads/main/LICENSE
   docker.io/grafana/grafana-image-renderer:
     license: Apache-2.0
-    licenseLink: https://github.com/grafana/grafana-image-renderer/blob/master/LICENSE
+    licenseLink: https://raw.githubusercontent.com/grafana/grafana-image-renderer/refs/heads/master/LICENSE
   docker.io/grafana/loki:
     license: AGPL-3.0-only
-    licenseLink: https://github.com/grafana/loki/blob/main/LICENSE
+    licenseLink: https://raw.githubusercontent.com/grafana/loki/refs/heads/main/LICENSE
   docker.io/grafana/promtail:
     license: AGPL-3.0-only
-    licenseLink: https://github.com/grafana/loki/blob/main/LICENSE
+    licenseLink: https://raw.githubusercontent.com/grafana/loki/refs/heads/main/LICENSE
   docker.io/grafana/tempo:
     license: AGPL-3.0-only
     licenseLink: https://raw.githubusercontent.com/grafana/tempo/refs/heads/main/LICENSE
@@ -73,40 +73,40 @@ licenses:
     licenseLink: https://raw.githubusercontent.com/memcached/memcached/refs/heads/master/LICENSE
   docker.io/otel/opentelemetry-collector-contrib:
     license: Apache-2.0
-    licenseLink: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/LICENSE
+    licenseLink: https://raw.githubusercontent.com/open-telemetry/opentelemetry-collector-contrib/refs/heads/main/LICENSE
   docker.io/stellio/stellio-api-gateway:
     license: Apache-2.0
-    licenseLink: https://github.com/stellio-hub/stellio-context-broker/blob/develop/LICENSE.txt
+    licenseLink: https://raw.githubusercontent.com/stellio-hub/stellio-context-broker/refs/heads/develop/LICENSE.txt
   docker.io/stellio/stellio-search-service:
     license: Apache-2.0
-    licenseLink: https://github.com/stellio-hub/stellio-context-broker/blob/develop/LICENSE.txt
+    licenseLink: https://raw.githubusercontent.com/stellio-hub/stellio-context-broker/refs/heads/develop/LICENSE.txt
   docker.io/stellio/stellio-subscription-service:
     license: Apache-2.0
-    licenseLink: https://github.com/stellio-hub/stellio-context-broker/blob/develop/LICENSE.txt
+    licenseLink: https://raw.githubusercontent.com/stellio-hub/stellio-context-broker/refs/heads/develop/LICENSE.txt
   docker.io/stellio/stellio-timescale-postgis:
     license: Apache-2.0
-    licenseLink: https://github.com/stellio-hub/stellio-context-broker/blob/develop/LICENSE.txt
+    licenseLink: https://raw.githubusercontent.com/stellio-hub/stellio-context-broker/refs/heads/develop/LICENSE.txt
   docker.io/traefik:
     license: MIT
     licenseLink: https://raw.githubusercontent.com/traefik/traefik/refs/heads/master/LICENSE.md
   docker.io/valkey/valkey:
     license: BSD-3
-    licenseLink: https://github.com/valkey-io/valkey/blob/unstable/COPYING
+    licenseLink: https://raw.githubusercontent.com/valkey-io/valkey/refs/heads/unstable/COPYING
   docker.io/velero/velero:
     license: Apache-2.0
-    licenseLink: https://github.com/vmware-tanzu/velero/blob/main/LICENSE
+    licenseLink: https://raw.githubusercontent.com/vmware-tanzu/velero/refs/heads/main/LICENSE
   docker.io/velero/velero-plugin-for-aws:
     license: Apache-2.0
-    licenseLink: https://github.com/vmware-tanzu/velero-plugin-for-aws/blob/main/LICENSE
+    licenseLink: https://raw.githubusercontent.com/vmware-tanzu/velero-plugin-for-aws/refs/heads/main/LICENSE
   docker.io/vladgh/gpg:
     license: Apache-2.0
-    licenseLink: https://github.com/vladgh/docker_base_images/blob/main/LICENSE
+    licenseLink: https://raw.githubusercontent.com/vladgh/docker_base_images/refs/heads/main/LICENSE
   ghcr.io/aquasecurity/trivy-operator:
     license: Apache-2.0
-    licenseLink: https://github.com/aquasecurity/trivy-operator/blob/main/LICENSE
+    licenseLink: https://raw.githubusercontent.com/aquasecurity/trivy-operator/refs/heads/main/LICENSE
   ghcr.io/jimmidyson/configmap-reload:
     license: Apache-2.0
-    licenseLink: https://github.com/jimmidyson/configmap-reload/blob/main/LICENSE.txt
+    licenseLink: https://raw.githubusercontent.com/jimmidyson/configmap-reload/refs/heads/main/LICENSE.txt
   ghcr.io/jkroepke/kube-webhook-certgen:
     license: Apache-2.0
     licenseLink: https://raw.githubusercontent.com/jkroepke/kube-webhook-certgen/refs/heads/main/LICENSE
@@ -115,115 +115,115 @@ licenses:
     licenseLink: https://raw.githubusercontent.com/k8up-io/k8up/refs/heads/master/LICENSE
   ghcr.io/kyverno/kyverno-cli:
     license: Apache-2.0
-    licenseLink: https://github.com/kyverno/kyverno/blob/main/LICENSE
+    licenseLink: https://raw.githubusercontent.com/kyverno/kyverno/refs/heads/main/LICENSE
   ghcr.io/kyverno/readiness-checker:
     license: Apache-2.0
-    licenseLink: https://github.com/kyverno/kyverno/blob/main/LICENSE
+    licenseLink: https://raw.githubusercontent.com/kyverno/kyverno/refs/heads/main/LICENSE
   ghcr.io/teutonet/oci-images/ckan:
     license: MIT
-    licenseLink: https://github.com/teutonet/oci-images/blob/main/LICENSE
+    licenseLink: https://raw.githubusercontent.com/teutonet/oci-images/refs/heads/main/LICENSE
   ghcr.io/teutonet/oci-images/solr-ckan:
     license: MIT
-    licenseLink: https://github.com/teutonet/oci-images/blob/main/LICENSE
+    licenseLink: https://raw.githubusercontent.com/teutonet/oci-images/refs/heads/main/LICENSE
   ghcr.io/twin/k8s-ttl-controller:
     license: MIT
-    licenseLink: https://github.com/TwiN/k8s-ttl-controller/blob/master/LICENSE
+    licenseLink: https://raw.githubusercontent.com/TwiN/k8s-ttl-controller/refs/heads/master/LICENSE
   mirror.gcr.io/aquasec/trivy-operator:
     license: Apache-2.0
-    licenseLink: https://github.com/aquasecurity/trivy-operator/blob/main/LICENSE
+    licenseLink: https://raw.githubusercontent.com/aquasecurity/trivy-operator/refs/heads/main/LICENSE
   quay.io/cilium/cilium:
     license: Apache-2.0
-    licenseLink: https://github.com/cilium/cilium/blob/main/LICENSE
+    licenseLink: https://raw.githubusercontent.com/cilium/cilium/refs/heads/main/LICENSE
   quay.io/cilium/cilium-envoy:
     license: Apache-2.0
-    licenseLink: https://github.com/cilium/cilium/blob/main/LICENSE
+    licenseLink: https://raw.githubusercontent.com/cilium/proxy/refs/heads/main/LICENSE
   quay.io/cilium/hubble-relay:
     license: Apache-2.0
-    licenseLink: https://github.com/cilium/cilium/blob/main/LICENSE
+    licenseLink: https://raw.githubusercontent.com/cilium/cilium/refs/heads/main/LICENSE
   quay.io/cilium/hubble-ui:
     license: Apache-2.0
-    licenseLink: https://github.com/cilium/cilium/blob/main/LICENSE
+    licenseLink: https://raw.githubusercontent.com/cilium/hubble-ui/refs/heads/master/LICENSE
   quay.io/cilium/hubble-ui-backend:
     license: Apache-2.0
-    licenseLink: https://github.com/cilium/hubble-ui/blob/master/LICENSE
+    licenseLink: https://raw.githubusercontent.com/cilium/hubble-ui/refs/heads/master/LICENSE
   quay.io/cilium/operator-generic:
     license: Apache-2.0
-    licenseLink: https://github.com/cilium/cilium/blob/main/LICENSE
+    licenseLink: https://raw.githubusercontent.com/cilium/cilium/refs/heads/main/LICENSE
   quay.io/jetstack/cert-manager-cainjector:
     license: Apache-2.0
-    licenseLink: https://github.com/cert-manager/cert-manager/blob/master/LICENSE
+    licenseLink: https://raw.githubusercontent.com/cert-manager/cert-manager/refs/heads/master/LICENSE
   quay.io/jetstack/cert-manager-controller:
     license: Apache-2.0
-    licenseLink: https://github.com/cert-manager/cert-manager/blob/master/LICENSE
+    licenseLink: https://raw.githubusercontent.com/cert-manager/cert-manager/refs/heads/master/LICENSE
   quay.io/jetstack/cert-manager-startupapicheck:
     license: Apache-2.0
-    licenseLink: https://github.com/cert-manager/cert-manager/blob/master/LICENSE
+    licenseLink: https://raw.githubusercontent.com/cert-manager/cert-manager/refs/heads/master/LICENSE
   quay.io/jetstack/cert-manager-webhook:
     license: Apache-2.0
-    licenseLink: https://github.com/cert-manager/cert-manager/blob/master/LICENSE
+    licenseLink: https://raw.githubusercontent.com/cert-manager/cert-manager/refs/heads/master/LICENSE
   quay.io/kiwigrid/k8s-sidecar:
     license: MIT
-    licenseLink: https://github.com/kiwigrid/k8s-sidecar/blob/master/LICENSE
+    licenseLink: https://raw.githubusercontent.com/kiwigrid/k8s-sidecar/refs/heads/master/LICENSE
   quay.io/oauth2-proxy/oauth2-proxy:
     license: MIT
     licenseLink: https://raw.githubusercontent.com/oauth2-proxy/oauth2-proxy/refs/heads/master/LICENSE
   quay.io/prometheus-operator/prometheus-config-reloader:
     license: Apache-2.0
-    licenseLink: https://github.com/prometheus-operator/prometheus-operator/blob/main/LICENSE
+    licenseLink: https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/refs/heads/main/LICENSE
   quay.io/prometheus-operator/prometheus-operator:
     license: Apache-2.0
-    licenseLink: https://github.com/prometheus-operator/prometheus-operator/blob/main/LICENSE
+    licenseLink: https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/refs/heads/main/LICENSE
   quay.io/prometheus/alertmanager:
     license: Apache-2.0
-    licenseLink: https://github.com/prometheus/alertmanager/blob/main/LICENSE
+    licenseLink: https://raw.githubusercontent.com/prometheus/alertmanager/refs/heads/main/LICENSE
   quay.io/prometheus/blackbox-exporter:
     license: Apache-2.0
-    licenseLink: https://github.com/prometheus/blackbox_exporter/blob/master/LICENSE
+    licenseLink: https://raw.githubusercontent.com/prometheus/blackbox_exporter/refs/heads/master/LICENSE
   quay.io/prometheus/node-exporter:
     license: Apache-2.0
-    licenseLink: https://github.com/prometheus/node_exporter/blob/master/LICENSE
+    licenseLink: https://raw.githubusercontent.com/prometheus/node_exporter/refs/heads/master/LICENSE
   quay.io/prometheus/prometheus:
     license: Apache-2.0
-    licenseLink: https://github.com/prometheus/prometheus/blob/main/LICENSE
+    licenseLink: https://raw.githubusercontent.com/prometheus/prometheus/refs/heads/main/LICENSE
   reg.kyverno.io/kyverno/background-controller:
     license: Apache-2.0
-    licenseLink: https://github.com/kyverno/kyverno/blob/main/LICENSE
+    licenseLink: https://raw.githubusercontent.com/kyverno/kyverno/refs/heads/main/LICENSE
   reg.kyverno.io/kyverno/cleanup-controller:
     license: Apache-2.0
-    licenseLink: https://github.com/kyverno/kyverno/blob/main/LICENSE
+    licenseLink: https://raw.githubusercontent.com/kyverno/kyverno/refs/heads/main/LICENSE
   reg.kyverno.io/kyverno/kyverno:
     license: Apache-2.0
-    licenseLink: https://github.com/kyverno/kyverno/blob/main/LICENSE
+    licenseLink: https://raw.githubusercontent.com/kyverno/kyverno/refs/heads/main/LICENSE
   reg.kyverno.io/kyverno/kyvernopre:
     license: Apache-2.0
-    licenseLink: https://github.com/kyverno/kyverno/blob/main/LICENSE
+    licenseLink: https://raw.githubusercontent.com/kyverno/kyverno/refs/heads/main/LICENSE
   reg.kyverno.io/kyverno/reports-controller:
     license: Apache-2.0
-    licenseLink: https://github.com/kyverno/kyverno/blob/main/LICENSE
+    licenseLink: https://raw.githubusercontent.com/kyverno/kyverno/refs/heads/main/LICENSE
   registry-gitlab.teuto.net/4teuto/dev/teuto-portal/teuto-portal-k8s-worker/teuto-portal-k8s-worker:
     license: Apache-2.0
     licenseLink: https://gitlab.teuto.net/4teuto/dev/teuto-portal/teuto-portal-k8s-worker
   registry.k8s.io/descheduler/descheduler:
     license: Apache-2.0
-    licenseLink: https://github.com/kubernetes-sigs/descheduler/blob/master/LICENSE
+    licenseLink: https://raw.githubusercontent.com/kubernetes-sigs/descheduler/refs/heads/master/LICENSE
   registry.k8s.io/etcd:
     license: Apache-2.0
-    licenseLink: https://github.com/etcd-io/etcd/blob/main/LICENSE
+    licenseLink: https://raw.githubusercontent.com/etcd-io/etcd/refs/heads/main/LICENSE
   registry.k8s.io/external-dns/external-dns:
     license: Apache-2.0
     licenseLink: https://raw.githubusercontent.com/kubernetes-sigs/external-dns/refs/heads/master/LICENSE.md
   registry.k8s.io/ingress-nginx/controller:
     license: Apache-2.0
-    licenseLink: https://github.com/kubernetes/ingress-nginx/blob/main/LICENSE
+    licenseLink: https://raw.githubusercontent.com/kubernetes/ingress-nginx/refs/heads/main/LICENSE
   registry.k8s.io/ingress-nginx/kube-webhook-certgen:
     license: Apache-2.0
-    licenseLink: https://github.com/kubernetes/ingress-nginx/blob/main/LICENSE
+    licenseLink: https://raw.githubusercontent.com/kubernetes/ingress-nginx/refs/heads/main/LICENSE
   registry.k8s.io/ingress-nginx/opentelemetry-1.25.3:
     license: Apache-2.0
-    licenseLink: https://github.com/kubernetes/ingress-nginx/blob/main/LICENSE
+    licenseLink: https://raw.githubusercontent.com/kubernetes/ingress-nginx/refs/heads/main/LICENSE
   registry.k8s.io/kube-state-metrics/kube-state-metrics:
     license: Apache-2.0
-    licenseLink: https://github.com/kubernetes/kube-state-metrics/blob/main/LICENSE
+    licenseLink: https://raw.githubusercontent.com/kubernetes/kube-state-metrics/refs/heads/main/LICENSE
   registry.k8s.io/kubectl:
     license: Apache-2.0
     licenseLink: https://raw.githubusercontent.com/kubernetes/kubernetes/refs/heads/master/LICENSE
@@ -232,28 +232,28 @@ licenses:
     licenseLink: https://raw.githubusercontent.com/kubernetes-sigs/metrics-server/refs/heads/master/LICENSE
   registry.k8s.io/provider-os/cinder-csi-plugin:
     license: Apache-2.0
-    licenseLink: https://github.com/kubernetes/cloud-provider-openstack/blob/master/LICENSE
+    licenseLink: https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/refs/heads/master/LICENSE
   registry.k8s.io/provider-os/openstack-cloud-controller-manager:
     license: Apache-2.0
-    licenseLink: https://github.com/kubernetes/cloud-provider-openstack/blob/master/LICENSE
+    licenseLink: https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/refs/heads/master/LICENSE
   registry.k8s.io/sig-storage/csi-attacher:
     license: Apache-2.0
-    licenseLink: https://github.com/kubernetes-csi/external-attacher/blob/master/LICENSE
+    licenseLink: https://raw.githubusercontent.com/kubernetes-csi/external-attacher/refs/heads/master/LICENSE
   registry.k8s.io/sig-storage/csi-node-driver-registrar:
     license: Apache-2.0
-    licenseLink: https://github.com/kubernetes-csi/node-driver-registrar/blob/master/LICENSE
+    licenseLink: https://raw.githubusercontent.com/kubernetes-csi/node-driver-registrar/refs/heads/master/LICENSE
   registry.k8s.io/sig-storage/csi-provisioner:
     license: Apache-2.0
-    licenseLink: https://github.com/kubernetes-csi/external-provisioner/blob/master/LICENSE
+    licenseLink: https://raw.githubusercontent.com/kubernetes-csi/external-provisioner/refs/heads/master/LICENSE
   registry.k8s.io/sig-storage/csi-resizer:
     license: Apache-2.0
-    licenseLink: https://github.com/kubernetes-csi/external-resizer/blob/master/LICENSE
+    licenseLink: https://raw.githubusercontent.com/kubernetes-csi/external-resizer/refs/heads/master/LICENSE
   registry.k8s.io/sig-storage/csi-snapshotter:
     license: Apache-2.0
-    licenseLink: https://github.com/kubernetes-csi/external-snapshotter/blob/master/LICENSE
+    licenseLink: https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/refs/heads/master/LICENSE
   registry.k8s.io/sig-storage/livenessprobe:
     license: Apache-2.0
-    licenseLink: https://github.com/kubernetes-csi/livenessprobe/blob/master/LICENSE
+    licenseLink: https://raw.githubusercontent.com/kubernetes-csi/livenessprobe/refs/heads/master/LICENSE
   registry.k8s.io/sig-storage/nfs-provisioner:
     license: Apache-2.0
-    licenseLink: https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/blob/master/LICENSE
+    licenseLink: https://raw.githubusercontent.com/kubernetes-sigs/nfs-subdir-external-provisioner/refs/heads/master/LICENSE

--- a/.github/scripts/check-license-links.sh
+++ b/.github/scripts/check-license-links.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+
+[[ "$RUNNER_DEBUG" == 1 ]] && set -x
+[[ -o xtrace ]] && export RUNNER_DEBUG=1
+
+set -eu
+set -o pipefail
+
+# Images whose license can't be linked to a real, public file (e.g. a private registry
+# without a public license file). Skipped entirely, both link-shape and content checks.
+IGNORED_IMAGES=(
+  "registry-gitlab.teuto.net/4teuto/dev/teuto-portal/teuto-portal-k8s-worker/teuto-portal-k8s-worker"
+)
+
+# Images whose licenseLink is real but whose content can't be verified by licensee:
+# - docker.io/bats/bats: LICENSE.md concatenates two MIT notices (its own + inherited from the
+#   predecessor "bats" project), which defeats licensee's text matcher.
+# - docker.io/busybox: no plain-text mirror of the license exists, only the official HTML page.
+# - docker.io/curlimages/curl: curl's license text isn't in licensee's bundled SPDX corpus.
+NOT_CONTENT_VERIFIABLE=(
+  "docker.io/bats/bats"
+  "docker.io/busybox"
+  "docker.io/curlimages/curl"
+)
+
+# licensee's SPDX corpus doesn't carry the "-only"/"-or-later" GPL-family suffixes, and uses
+# "-Clause" for BSD variants. Normalize both sides before comparing.
+function normalizeLicense() {
+  local license="${1?}"
+
+  license="$(echo "$license" | tr '[:lower:]' '[:upper:]')"
+  case "$license" in
+    AGPL-3.0-ONLY | AGPL-3.0-OR-LATER) echo "AGPL-3.0" ;;
+    GPL-2.0-ONLY | GPL-2.0-OR-LATER) echo "GPL-2.0" ;;
+    GPL-3.0-ONLY | GPL-3.0-OR-LATER) echo "GPL-3.0" ;;
+    LGPL-2.1-ONLY | LGPL-2.1-OR-LATER) echo "LGPL-2.1" ;;
+    LGPL-3.0-ONLY | LGPL-3.0-OR-LATER) echo "LGPL-3.0" ;;
+    BSD-2) echo "BSD-2-CLAUSE" ;;
+    BSD-3) echo "BSD-3-CLAUSE" ;;
+    *) echo "$license" ;;
+  esac
+}
+
+function isInList() {
+  local needle="${1?}"
+  shift
+  local hay
+
+  for hay in "$@"; do
+    [[ "$needle" == "$hay" ]] && return 0
+  done
+  return 1
+}
+
+# This runs on pull_request_target against a PR-controlled licenseLink value, and
+# checkLicenseContent curls whatever host is given. Without an allowlist, a PR could point
+# licenseLink at an internal address (loopback, cloud metadata, ...) and turn this into an
+# SSRF probe from a privileged runner. Only fetch from hosts we've actually reviewed.
+ALLOWED_HOSTS=(
+  "raw.githubusercontent.com"
+  "gitlab.teuto.net"
+  "curl.se"
+  "www.busybox.net"
+)
+
+function isRealLicenseLink() {
+  local link="${1?}"
+  local path host
+
+  # Only https is ever legitimate here; other schemes (plain http, or curl's
+  # other supported protocols) are either insecure or pointless against these hosts.
+  [[ "$link" =~ ^https:// ]] || return 1
+
+  host="$(echo "$link" | sed -E 's#^[a-z]+://([^/]+).*#\1#')"
+  isInList "$host" "${ALLOWED_HOSTS[@]}" || return 1
+
+  # A link to a GitHub/GitLab repo root isn't a license file, it must point into the repo.
+  if [[ "$link" =~ ^https?://(github\.com|gitlab\.[^/]+)/[^/]+/[^/]+/?$ ]]; then
+    return 1
+  fi
+
+  # Reject bare domain roots (e.g. a project homepage instead of its license page).
+  path="$(echo "$link" | sed -E 's#^[a-z]+://[^/]+##')"
+  [[ "$path" =~ ^/?$ ]] && return 1
+
+  return 0
+}
+
+# Fetches a licenseLink into its own directory. Pure network I/O, and the only part of this
+# script worth running concurrently, so it's split out to be driven by GNU parallel below
+# instead of being called inline. Runs concurrently, so a failure is marked with a sentinel
+# file rather than reported directly.
+function fetchLicenseLink() {
+  local link="${1?}"
+  local dir="${2?}"
+
+  if ! curl -s -f -L --proto '=https' --connect-timeout 10 --max-time 30 --retry 2 -o "$dir/LICENSE" "$link"; then
+    touch "$dir/.failed"
+  fi
+}
+
+# Runs licensee against every already-fetched license file in a single Ruby process. Spawning
+# a Ruby interpreter (and reloading licensee's whole SPDX corpus) per image is the expensive
+# part, not the actual license matching, so this batches all of them into one process instead
+# of shelling out to the `licensee` CLI once per image.
+function detectLicenses() {
+  ruby -rlicensee -e '
+    # Without this, licensee hides any match below its own default confidence
+    # threshold behind a "other"/nil placeholder, losing the exact signal our
+    # own >=90%-confident-mismatch-vs-warning logic below needs.
+    Licensee.confidence_threshold = 0
+
+    STDIN.each_line do |line|
+      dir = line.chomp
+      file = Licensee::Projects::FSProject.new(dir).matched_files.first
+      if file&.license
+        puts [dir, file.license.spdx_id, file.confidence].join("\t")
+      else
+        puts [dir, "NONE", 0].join("\t")
+      end
+    end
+  '
+}
+
+result=0
+tmpRoot="$(mktemp -d)"
+trap 'rm -rf "$tmpRoot"' EXIT
+
+declare -A declaredByImage=()
+declare -A linkByImage=()
+declare -A dirByImage=()
+declare -A imageByDir=()
+toFetch=()
+
+while IFS=$'\t' read -r image declared link; do
+  isInList "$image" "${IGNORED_IMAGES[@]}" && continue
+
+  if ! isRealLicenseLink "$link"; then
+    echo "licenseLink for '$image' is not a real license file: $link" >&2
+    result=1
+    continue
+  fi
+
+  isInList "$image" "${NOT_CONTENT_VERIFIABLE[@]}" && continue
+
+  dir="$tmpRoot/$(echo -n "$image" | sha1sum | cut -d' ' -f1)"
+  mkdir -p "$dir"
+  declaredByImage["$image"]="$declared"
+  linkByImage["$image"]="$link"
+  dirByImage["$image"]="$dir"
+  imageByDir["$dir"]="$image"
+  toFetch+=("$link"$'\t'"$dir")
+done < <(yq -r '.licenses | to_entries[] | [.key, .value.license, .value.licenseLink] | @tsv' .github/image_licenses.yaml)
+
+if [[ "${#toFetch[@]}" -gt 0 ]]; then
+  export -f fetchLicenseLink
+  # shellcheck disable=SC2046
+  printf '%s\n' "${toFetch[@]}" |
+    parallel $([[ -v GITHUB_JOB ]] || printf -- --bar) -P 0 --colsep '\t' fetchLicenseLink "{1}" "{2}"
+fi
+
+toDetect=()
+for image in "${!dirByImage[@]}"; do
+  dir="${dirByImage[$image]}"
+  if [[ -e "$dir/.failed" ]]; then
+    echo "could not fetch licenseLink for '$image': ${linkByImage[$image]}" >&2
+    result=1
+    continue
+  fi
+  toDetect+=("$dir")
+done
+
+if [[ "${#toDetect[@]}" -gt 0 ]]; then
+  while IFS=$'\t' read -r dir detected confidence; do
+    image="${imageByDir[$dir]}"
+    declared="${declaredByImage[$image]}"
+    link="${linkByImage[$image]}"
+
+    if [[ "$detected" == "NONE" ]]; then
+      echo "licenseLink for '$image' doesn't look like a license file at all: $link" >&2
+      result=1
+      continue
+    fi
+
+    declaredNorm="$(normalizeLicense "$declared")"
+    detectedNorm="$(normalizeLicense "$detected")"
+
+    [[ "$declaredNorm" == "$detectedNorm" ]] && continue
+
+    if awk -v c="$confidence" 'BEGIN { exit !(c >= 90) }'; then
+      echo "'$image' declares '$declared' but its licenseLink is confidently '$detected' (${confidence%.*}% confidence): $link" >&2
+      result=1
+    else
+      echo "warning: '$image' declares '$declared', licensee's best (low-confidence, ${confidence%.*}%) guess is '$detected' — please double check: $link" >&2
+    fi
+  done < <(printf '%s\n' "${toDetect[@]}" | detectLicenses)
+fi
+
+exit "$result"

--- a/.github/workflows/check-license-links-schedule.yaml
+++ b/.github/workflows/check-license-links-schedule.yaml
@@ -1,0 +1,35 @@
+name: Check license links (scheduled)
+
+on:
+  schedule:
+    - cron: "0 0 * * 1"
+  workflow_dispatch: {}
+
+jobs:
+  check-license-links:
+    uses: ./.github/workflows/check-license-links.yaml
+    permissions:
+      contents: read
+
+  createIssue:
+    runs-on: ubuntu-latest
+    if: ${{ always() && needs.check-license-links.result == 'failure' }}
+    needs: check-license-links
+    permissions:
+      issues: write
+    name: Create Issue
+    steps:
+      - run: |
+          gh issue create \
+            --title "$TITLE" \
+            --assignee "$ASSIGNEES" \
+            --label "$LABELS" \
+            --body "$BODY"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TITLE: Scheduled license link check failed
+          ASSIGNEES: cwrau,marvinWolff,tasches
+          LABELS: bug
+          BODY: |
+            Last scheduled run of check-license-links failed, see ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}. Likely a stale/drifted licenseLink in .github/image_licenses.yaml, but could also be an infra/checkout failure.

--- a/.github/workflows/check-license-links.yaml
+++ b/.github/workflows/check-license-links.yaml
@@ -1,0 +1,27 @@
+name: Check license links
+
+on:
+  workflow_call: {}
+
+jobs:
+  check-license-links:
+    name: check license links
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          repository: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          path: scripts # needed because otherwise tokens could be stolen
+          sparse-checkout: |
+            .github
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+      - run: pip install yq
+      - run: gem install licensee --no-document --version 10.0.0
+      - run: ./scripts/.github/scripts/check-license-links.sh

--- a/.github/workflows/check-licenses.yaml
+++ b/.github/workflows/check-licenses.yaml
@@ -11,6 +11,8 @@ on:
       - synchronize
     paths:
       - charts/**
+      - .github/image_licenses.yaml
+      - .github/scripts/check-license-links.sh
 
 jobs:
   getChangedChart:
@@ -21,6 +23,7 @@ jobs:
       pr_number: ${{ github.event.pull_request.number }}
   check-licenses:
     name: check licenses
+    if: ${{ needs.getChangedChart.outputs.found == 'true' }}
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -56,3 +59,7 @@ jobs:
           [[ "$RUNNER_DEBUG" == 1 ]] && set -x
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           ./scripts/.github/scripts/scan-for-licenses.sh "charts/${{ needs.getChangedChart.outputs.chart }}"
+  check-license-links:
+    uses: ./.github/workflows/check-license-links.yaml
+    permissions:
+      contents: read


### PR DESCRIPTION
## Summary
- Replace vague `licenseLink`s (Docker Hub pages, project homepages, bare repo roots) with real license-file URLs; convert all `github.com/.../blob/...` links to `raw.githubusercontent.com` since blob pages serve HTML, not the file content.
- Add `.github/scripts/check-license-links.sh`, run in the license-check workflow:
  - Rejects Docker Hub links, GitHub/GitLab repo-root links, and bare domain roots.
  - Fetches each `licenseLink` and uses `licensee` to verify the declared `license:` field actually matches the file's content (SPDX-suffix-normalized), hard-failing on a confident mismatch and warning on a low-confidence one.
  - Documented exceptions for the private `teuto-portal-k8s-worker` image (no public license file) and three images `licensee` can't classify from content (`bats/bats`, `busybox`, `curlimages/curl`).
- Fixed two links found by the new check that pointed at the wrong file: `grafana/grafana` (was `LICENSING.md`, an explainer doc) and `bitnamilegacy/postgresql` (was a marketing page).

Closes #1475

## Test plan
- [x] `./.github/scripts/check-license-links.sh` passes locally against the updated `image_licenses.yaml`
- [x] Verified all `raw.githubusercontent.com` links resolve (200)
- [x] Injected a bad license-link (Docker Hub URL) and a bad declared-license value locally to confirm the script fails as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated container image license references to use direct upstream raw file URLs and refreshed license details for additional images.
- **CI**
  - Added automated license-link validation that ensures links are public and checks declared licenses against detected content.
  - Limited when license checks run to relevant file changes, and introduced a weekly scheduled check that creates an issue if validation fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->