### PR TITLE
revert(ci): drop gpu-operator split-field image extraction (#2252)

### DIFF
--- a/.github/scripts/extract-artifacthub-images.sh
+++ b/.github/scripts/extract-artifacthub-images.sh
@@ -28,22 +28,9 @@ function getImages() {
     cd "$tmpDir/helmRelease"
     rm -f -- */HelmRelease/*.yaml
     (
-      grep -Er '\s+image: \S+[/:]\S+$' |
+      grep -Er '\s+image: \S+$' |
         grep -v 'artifacthub-ignore' || { if [[ "$?" == 2 ]]; then exit 2; fi; }
     )
-    # some charts (e.g. nvidia/gpu-operator's ClusterPolicy) split the image
-    # reference into sibling `repository`/`image`/`version`(or `tag`) keys
-    # instead of a single `image: repo/name:tag` string
-    while IFS= read -r -d '' file; do
-      local ignoredImages
-      ignoredImages="$(grep -oP 'image:\s*\K\S+(?=.*artifacthub-ignore)' "$file" || true)"
-      yq -r --arg file "${file#./}" --arg ignored "$ignoredImages" '
-        ($ignored | split("\n")) as $ignoredList
-        | [.. | objects | select(has("repository") and has("image") and (.image | type == "string") and ((.version != null) or (.tag != null)) and ((.image as $i | $ignoredList | index($i)) == null))]
-        | .[]
-        | "\($file):  image: \(.repository)/\(.image):\(.version // .tag)"
-      ' "$file"
-    done < <(find . -name '*.yaml' -print0)
   )
 }
 


### PR DESCRIPTION
## Summary
- Reverts #2252. The gpu-operator ClusterPolicy CRD's split `repository`/`image`/`version` fields describe images that are never actually scheduled by anything in the rendered manifests — they're read by gpu-operator's own controller at runtime, in-cluster, to construct the real DaemonSets later. We can't reliably trust/license/scan images we can't statically verify are even used as declared.
- `extract-artifacthub-images.sh` goes back to only picking up images from vanilla `image:` fields on real k8s resources.

## Test plan
- [x] Ran `extract-artifacthub-images.sh` against t8s-cluster's `ci/artifacthub-values.yaml` scenario (GPU nodepools enabled) before/after — split-field nvcr.io images no longer appear in `Chart.yaml`; standard images (cluster-autoscaler, node-feature-discovery, gpu-operator's own pod image) still detected correctly.