### PR TITLE
fix(ci): require slash or colon in artifacthub image grep match

### DIFF
--- a/.github/scripts/extract-artifacthub-images.sh
+++ b/.github/scripts/extract-artifacthub-images.sh
@@ -28,7 +28,7 @@ function getImages() {
     cd "$tmpDir/helmRelease"
     rm -f -- */HelmRelease/*.yaml
     (
-      grep -Er '\s+image: \S+$' |
+      grep -Er '\s+image: \S+[/:]\S+$' |
         grep -v 'artifacthub-ignore' || { if [[ "$?" == 2 ]]; then exit 2; fi; }
     )
   )


### PR DESCRIPTION
## Summary
- PR #2266 fully reverted commit 18092d37 (#2252), but that commit bundled two independent changes: the gpu-operator split-field extraction (correctly reverted) and a grep tightening that required a `/` or `:` in the `image:` value (also reverted, unintentionally).
- Without the tightening, `extract-artifacthub-images.sh` matches bare `image: <name>` lines from split-field CRDs like nvidia/gpu-operator's `ClusterPolicy` (e.g. `image: container-toolkit`), which then fail `enforce-trusted-registries.sh` as untrusted images.
- Restores just the grep tightening, without reintroducing split-field support.

## Test plan
- [x] Ran `prepare-values.sh` + `extract-artifacthub-images.sh` + `enforce-trusted-registries.sh` locally against `charts/t8s-cluster` — no more false-positive untrusted images from `ClusterPolicy`.