### PR TITLE
feat(common): expose serviceName/serviceNamespace in telemetry.conf

### DIFF
--- a/charts/common/templates/_telemetry.tpl
+++ b/charts/common/templates/_telemetry.tpl
@@ -33,7 +33,7 @@
 {{- end -}}
 
 {{/*
-Returns a dict for configuring otel traces, containing `enabled`, `host`, `port`, `endpoint`, `serviceProtocol`, `insecure`.
+Returns a dict for configuring otel traces, containing `enabled`, `host`, `port`, `endpoint`, `serviceProtocol`, `insecure`. `serviceName` and `serviceNamespace` are also set, but only when the endpoint was auto-discovered.
 {{- $telemetryConf := include "common.telemetry.conf" (dict "protocol" "otlp" "serviceProtocol" "grpc" "global" $) | fromYaml }}
 `serviceProtocol` is optional, will just not be used (probably using `grpc`).
 Be sure to cast the port back to int by using `{{ int64 $telemetryConf.port }}` for usage, it's a float by default
@@ -46,6 +46,8 @@ Be sure to cast the port back to int by using `{{ int64 $telemetryConf.port }}` 
   {{- $host := "" -}}
   {{- $port := 0 -}}
   {{- $endpoint := "" -}}
+  {{- $discoveredServiceName := "" -}}
+  {{- $discoveredServiceNamespace := "" -}}
   {{- $serviceProtocol := .serviceProtocol -}}
   {{- $insecure := dig "insecure" true $config -}}
   {{- if eq (dig "endpoint" "auto" $config) "auto" -}}
@@ -59,7 +61,7 @@ Be sure to cast the port back to int by using `{{ int64 $telemetryConf.port }}` 
             {{- $servicePortName := dig "name" "" $portSpec -}}
             {{- $appProtocol := dig "appProtocol" "" $portSpec -}}
             {{- if and (hasPrefix $protocol $servicePortName) (or (not $serviceProtocol) (hasSuffix (printf "-%s" $serviceProtocol) $servicePortName) (eq $appProtocol $serviceProtocol)) -}}
-              {{- $servicePortPort = dig "port" 0 $portSpec -}}
+              {{- $servicePortPort = dig "port" 0 $portSpec | int64 -}}
               {{/* see https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/#otel_exporter_otlp_protocol */}}
               {{- if and (not $serviceProtocol) (eq $protocol "otlp") (has $appProtocol (list "grpc" "http/protobuf" "http/json")) -}}
                 {{- $serviceProtocol = $appProtocol -}}
@@ -69,6 +71,8 @@ Be sure to cast the port back to int by using `{{ int64 $telemetryConf.port }}` 
             {{- end -}}
           {{- end -}}
           {{- if $enabled -}}
+            {{- $discoveredServiceName = $serviceName -}}
+            {{- $discoveredServiceNamespace = $namespace -}}
             {{- $host = printf "%s.%s" $serviceName $namespace -}}
             {{- $port = $servicePortPort -}}
             {{- $endpoint = printf "%s:%d" $host $port -}}
@@ -108,6 +112,10 @@ Be sure to cast the port back to int by using `{{ int64 $telemetryConf.port }}` 
     {{- $conf = set $conf "host" $host -}}
     {{- $conf = set $conf "port" $port -}}
     {{- $conf = set $conf "endpoint" $endpoint -}}
+    {{- if $discoveredServiceName -}}
+      {{- $conf = set $conf "serviceName" $discoveredServiceName -}}
+      {{- $conf = set $conf "serviceNamespace" $discoveredServiceNamespace -}}
+    {{- end -}}
   {{- end -}}
   {{- toYaml $conf -}}
 {{- end -}}

--- a/charts/common/tests/tests/telemetry_test.yaml
+++ b/charts/common/tests/tests/telemetry_test.yaml
@@ -34,6 +34,61 @@ tests:
           path: port
           value: 4317
 
+  - it: exposes serviceName and serviceNamespace when auto-discovered
+    set:
+      protocol: otlp
+    kubernetesProvider:
+      scheme:
+        "v1/Service":
+          gvr:
+            group: ""
+            version: "v1"
+            resource: "services"
+          namespaced: true
+      objects:
+        - apiVersion: v1
+          kind: Service
+          metadata:
+            name: alloy
+            namespace: monitoring
+          spec:
+            ports:
+              - name: otlp-grpc
+                port: 4317.0
+                appProtocol: grpc
+    asserts:
+      - equal:
+          path: enabled
+          value: true
+      - equal:
+          path: serviceName
+          value: alloy
+      - equal:
+          path: serviceNamespace
+          value: monitoring
+      - equal:
+          path: host
+          value: alloy.monitoring
+      - equal:
+          path: port
+          value: 4317
+      - equal:
+          path: endpoint
+          value: http://alloy.monitoring:4317
+
+  - it: does not expose serviceName/serviceNamespace for an explicit external endpoint
+    set:
+      protocol: otlp
+      global.telemetry.otlp.endpoint: "otel-collector.example.com:4317"
+    asserts:
+      - equal:
+          path: enabled
+          value: true
+      - notExists:
+          path: serviceName
+      - notExists:
+          path: serviceNamespace
+
   - it: uses explicit port when provided
     set:
       protocol: otlp


### PR DESCRIPTION
Adds `serviceName`/`serviceNamespace` fields to `common.telemetry.conf`, needed by the upcoming envoy ingress provider in `base-cluster` to point tracing exporters at the envoy proxy service.

First of a stacked series splitting the envoy-ingress-provider feature into per-chart PRs:
1. this PR (`charts/common`)
2. `feat/base-cluster/traefik-service-adoption-prep`
3. `feat/base-cluster/envoy-ingress-provider`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Telemetry auto-discovery now includes the discovered service name and namespace in the generated OTEL traces configuration.

* **Bug Fixes**
  * Improved telemetry configuration details for automatically discovered services, including consistent host/port/endpoint derivation from the discovered service metadata.

* **Tests**
  * Added coverage for Kubernetes-based auto-discovery scenarios and for explicit external OTLP endpoint behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->