### PR TITLE
feat(base-cluster/ingress): keep traefik Service on provider switch

### DIFF
--- a/charts/base-cluster/templates/ingress/traefik.yaml
+++ b/charts/base-cluster/templates/ingress/traefik.yaml
@@ -66,6 +66,7 @@ spec:
       {{- end }}
     service:
       annotations:
+        helm.sh/resource-policy: keep
         loadbalancer.openstack.org/timeout-client-data: "2073600000"
         loadbalancer.openstack.org/timeout-member-connect: "2073600000"
         loadbalancer.openstack.org/timeout-member-data: "2073600000"

--- a/charts/base-cluster/tests/ingress_traefik_test.yaml
+++ b/charts/base-cluster/tests/ingress_traefik_test.yaml
@@ -20,3 +20,9 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: traefik Service carries resource-policy keep annotation
+    asserts:
+      - equal:
+          path: spec.values.service.annotations["helm.sh/resource-policy"]
+          value: keep


### PR DESCRIPTION
Adds `helm.sh/resource-policy: keep` to the traefik-managed Service so it survives a HelmRelease that switches `ingress.provider` away from traefik. This enables a non-breaking-then-breaking two-phase rollout when adopting the new envoy provider: deploy this first (keeps the Service around when traefik is disabled), then switch providers in a later release without the Service getting deleted out from under in-flight connections/DNS.

Second of a stacked series:
1. #2270 (`charts/common`)
2. this PR (`charts/base-cluster`)
3. `feat/base-cluster/envoy-ingress-provider`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Traefik’s ingress service is now retained when its Helm release is deleted, helping prevent accidental service removal.

* **Tests**
  * Added coverage to verify the service-retention setting is applied correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->