### PR TITLE
feat(base-cluster/ingress)!: add envoy as the default ingress provider

### DIFF
--- a/.github/image_licenses.yaml
+++ b/.github/image_licenses.yaml
@@ -47,6 +47,12 @@ licenses:
   docker.io/emberstack/kubernetes-reflector:
     license: MIT
     licenseLink: https://raw.githubusercontent.com/emberstack/kubernetes-reflector/refs/heads/main/LICENSE
+  docker.io/envoyproxy/gateway:
+    license: Apache-2.0
+    licenseLink: https://raw.githubusercontent.com/envoyproxy/gateway/refs/heads/main/LICENSE
+  docker.io/envoyproxy/ratelimit:
+    license: Apache-2.0
+    licenseLink: https://raw.githubusercontent.com/envoyproxy/ratelimit/refs/heads/main/LICENSE
   docker.io/fluxcd/flux-cli:
     license: Apache-2.0
     licenseLink: https://raw.githubusercontent.com/fluxcd/flux2/refs/heads/main/LICENSE

--- a/.github/trusted_registries.yaml
+++ b/.github/trusted_registries.yaml
@@ -14,6 +14,9 @@ docker.io:
     curl: ALL_TAGS
   emberstack:
     kubernetes-reflector: ALL_TAGS
+  envoyproxy:
+    gateway: ALL_TAGS
+    ratelimit: ALL_TAGS
   fluxcd: ALL_IMAGES
   grafana: ALL_IMAGES
   memcached: ALL_TAGS

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,15 @@
 
 Try to keep this CLAUDE file up to date with any gotchas you encounter while working on this repo. It is not a replacement for the official Helm docs, but a supplement to them.
 
+## Style
+
+- branches are always $type/$scope/$name
+  - $type and $scope are from <https://www.conventionalcommits.org>
+  - meaning a docs change for base-cluster would be docs/base-cluster/add-info-about-new-feature
+- commits are always conventional commits, often without any body, but if a body is useful, a rather short one
+  - big explanations can be written in the PR body
+  - don't set footers like `BREAKING CHANGE:`, this is parsed automatically via the `!` in the first line
+
 ## helm-unittest gotchas
 
 - Once a test sets `kubernetesProvider:`, ALL `lookup` calls in the rendered template chain go through the fake client — not just the ones under test. Every GVR touched by any lookup in that render path needs a `scheme:` entry, or it panics: `coding error: you must register resource to list kind...`.
@@ -11,6 +20,12 @@ Try to keep this CLAUDE file up to date with any gotchas you encounter while wor
 - Testing "does resource X exist / is it ready" logic (a GET-style `lookup` by name) only needs `kubernetesProvider` on the specific `it:` cases that assert against a live object — the default (no `kubernetesProvider`) case already exercises the "doesn't exist" branch, since unmocked `lookup` returns nil.
 - A suite's top-level `templates:` list is rendered in full for every `it:` case, regardless of which one the case's own `template:` field targets. If any rendered template pulls in another via `common.utils.checksumTemplate` (or similar), that other template must be listed too, or it fails with `no template "..." associated with template "gotpl"`. Same consequence for `kubernetesProvider` scheme entries: they must cover every `lookup` reachable from the whole suite's template set, not just the one under test.
 - `kubernetesProvider` can also be set at the suite level (sibling to `templates:`/`tests:`), not just per `it:`. Its `scheme` gets merged into every test's own scheme, and its `objects` get appended after each test's own objects. Hoist a shared `scheme:` block to suite level freely — merging it in doesn't activate the fake client by itself. Do NOT hoist shared `objects:` to suite level unless every test in that suite already sets `kubernetesProvider` — the fake client only activates when a test's (post-merge) object list is non-empty, so adding suite-level objects would silently pull tests that currently rely on "no `kubernetesProvider` → all lookups nil" into fake-client mode, requiring scheme coverage for every GVR they touch.
+
+## Chart README gotchas
+
+- `charts/*/README.md` is a generated artifact — never hand-edit it. Only edit `charts/*/README.md.gotmpl`; regeneration happens via the `release-update-metadata` CI workflow at release time (and needs `values.md`, see below).
+- `go-task chart:docs CHART=<chart>` runs bare `helm-docs`, which reads `{{ .Files.Get "values.md" }}` for the Values section. `values.md` is gitignored and only produced in CI (`generate-schema-doc` from `json-schema-for-humans`, driven by `.github/workflows/release-update-metadata.yaml`). Running `chart:docs` locally without first generating `values.md` silently wipes the entire Values section from `README.md` instead of erroring.
+- Any instruction to "adjust/update/fix the README" (or similar) for a chart always means `README.md.gotmpl`, never the rendered `README.md` — except the repo-root `README.md`, which is a plain hand-written file (no `.gotmpl` source) and is edited directly.
 
 ## Go template gotchas
 

--- a/charts/base-cluster/Chart.lock
+++ b/charts/base-cluster/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: oci://ghcr.io/teutonet/teutonet-helm-charts
   version: 2.2.0
 digest: sha256:77aed2c2c3fc11684bc09d67f1ec51c8a14cdac58fce7d3233b370d050634053
-generated: "2026-08-10T08:33:54.962131488Z"
+generated: "2026-08-03T10:21:58.444141275+02:00"

--- a/charts/base-cluster/README.md.gotmpl
+++ b/charts/base-cluster/README.md.gotmpl
@@ -107,16 +107,36 @@ which is also supported by [cert-manager](https://cert-manager.io/docs/configura
 
 ### Component [ingress](#ingress)
 
-The chart supports two ingress controllers:
+The chart supports three ingress controllers:
 
-1. [`nginx` ingress-controller](https://docs.nginx.com/nginx-ingress-controller) (default)
+1. [`nginx` ingress-controller](https://docs.nginx.com/nginx-ingress-controller)
    - Works with `IngressClassName: nginx` or if none is defined
    - Provides built-in metrics and tracing support
 
-2. [`traefik`](https://traefik.io) (recommended)
+2. [`traefik`](https://traefik.io)
    - Works with `IngressClassName: ingress-controller` or if none is defined
    - Provides built-in metrics and tracing support
    - Also supports [Gateway API](https://gateway-api.sigs.k8s.io)
+
+3. [`envoy`](https://gateway.envoyproxy.io) (default)
+   - [Gateway API](https://gateway-api.sigs.k8s.io)-based, deployed via [Envoy Gateway](https://gateway.envoyproxy.io)
+   - Full feature parity with `traefik` for IP handling, resources and proxy-protocol
+   - Tracing requires the OTLP endpoint to be auto-discovered (the default): envoy
+     wires up tracing via a Gateway API-style backend reference to the discovered
+     collector Service, whereas `traefik`/`nginx` accept any host:port. Setting
+     `global.telemetry.otlp.endpoint` explicitly is not yet supported with `envoy`
+     and fails the template render
+   - `customDomain` on the grafana/prometheus/alertmanager ingresses is served via a
+     per-component [Gateway API `ListenerSet`](https://gateway-api.sigs.k8s.io/geps/gep-1713/)
+     attached to the shared `Gateway`, each with its own cert-manager-issued certificate;
+     requires the cluster's Gateway API CRDs to include `ListenerSet` (Gateway API >= v1.5)
+   - Migrates cleanly from `traefik`: same `ingress` namespace, no namespace deletion, and
+     the existing Service - including its LoadBalancer IP - keeps being used as-is (reuse
+     comes from `envoy` targeting the same Service name/namespace as `traefik`, not from
+     the `helm.sh/resource-policy: keep` annotation, which only stops Helm from deleting
+     the Service when the `traefik` HelmRelease is removed)
+   - Cannot be adopted directly from `nginx` - there is no dual-mode path for that
+     combination, migrate to `traefik` first, then to `envoy`
 
 #### TLS
 
@@ -130,7 +150,7 @@ The chart supports two ingress controllers:
 
 If you want to make sure that, in the event of a catastrophic failure, you keep the
 same IP address, you should roll this out, get the assigned IP
-(`kubectl -n ingress-nginx get svc ingress-nginx-controller -o jsonpath='{.status.loadBalancer.ingress}'` for nginx or `kubectl -n ingress get svc ingress-controller -o jsonpath='{.status.loadBalancer.ingress}'` for traefik)
+(`kubectl -n ingress-nginx get svc ingress-nginx-controller -o jsonpath='{.status.loadBalancer.ingress}'` for nginx or `kubectl -n ingress get svc ingress-controller -o jsonpath='{.status.loadBalancer.ingress}'` for traefik or envoy)
 and set `.ingress.IP=<ip>` in the values. This makes sure the IP is kept in your
 project (may incur cost!), which means you can reuse it later or after recovery.
 
@@ -434,6 +454,44 @@ of `.monitoring.tracing.ingester.<field>`
 
 - This release disables the trivy-operator by default.
   To continue using the operator set `.monitoring.securityScanning.enabled` to `true`.
+
+### Unreleased Breaking Changes
+
+This release makes [envoy](https://gateway.envoyproxy.io) (deployed via
+[Envoy Gateway](https://gateway.envoyproxy.io)) the default ingress provider instead
+of `traefik`.
+
+If you are currently on `traefik` (the previous default) and don't change anything,
+you will be switched over to `envoy` on the next reconcile.
+
+This is a clean migration: `envoy` uses the same `ingress` namespace and the same
+`ingress-controller` Service name as `traefik`, so the existing Service - including its
+LoadBalancer IP - keeps being used as-is; no namespace gets deleted, and no new Service
+needs to be provisioned. The `helm.sh/resource-policy: keep` annotation already present
+on the `traefik` Service only prevents Helm from deleting it when the `traefik`
+HelmRelease is removed - the reuse itself comes from `envoy` targeting that same
+name/namespace, not from the annotation. There will still be a short downtime while the
+new controller becomes ready.
+
+Because the `default` `GatewayClass` is rendered by `base-cluster`'s own release under
+`envoy` but by the nested `ingress-controller` release under `traefik`, the two
+HelmReleases reconciling out of order during the exact cutover moment can cause a
+transient Helm ownership-conflict error on that one object; it self-heals on the next
+reconcile once the old release's prune and the new release's create have both settled.
+
+If you are currently on `nginx`, you cannot switch directly to `envoy`; there is no
+dual-mode path for that combination. Migrate to `traefik` first (see the
+`7.x.x -> 8.0.0` notes above), then migrate to `envoy` afterwards.
+
+`customDomain` on the grafana/prometheus/alertmanager ingresses now works with `envoy`
+too, via a per-component `ListenerSet` attached to the shared `Gateway`. This requires
+the cluster's Gateway API CRDs to include the `ListenerSet` kind (Gateway API >= v1.5).
+If your cluster's CRDs aren't updated yet, stay on `traefik` for now:
+
+```yaml
+ingress:
+  provider: traefik
+```
 {{ .Files.Get "values.md"  }}
 
 - This release remove the field `.monitoring.prometheus.retentionSize` as the retention is now automatically calculated

--- a/charts/base-cluster/templates/_helpers.tpl
+++ b/charts/base-cluster/templates/_helpers.tpl
@@ -32,6 +32,10 @@
   {{- or (eq .Values.ingress.provider "traefik") (eq (include "base-cluster.ingress.dualMode" .) "true") | ternary "true" "" -}}
 {{- end -}}
 
+{{- define "base-cluster.ingress.hasEnvoy" -}}
+  {{- eq .Values.ingress.provider "envoy" | ternary "true" "" -}}
+{{- end -}}
+
 {{- define "base-cluster.monitoring.alertmanager.receiver.splitName" -}}
   {{- $name := .name -}}
   {{- $type := $name -}}

--- a/charts/base-cluster/templates/cert-manager/cert-manager.yaml
+++ b/charts/base-cluster/templates/cert-manager/cert-manager.yaml
@@ -40,7 +40,7 @@ spec:
     extraArgs:
       - --dns01-recursive-nameservers={{- $nameservers | sortAlpha | join "," }}
     {{- end }}
-    {{- if include "base-cluster.ingress.hasTraefik" . }}
+    {{- if or (include "base-cluster.ingress.hasTraefik" .) (include "base-cluster.ingress.hasEnvoy" .) }}
     config:
       apiVersion: controller.config.cert-manager.io/v1alpha1
       kind: ControllerConfiguration

--- a/charts/base-cluster/templates/global/cluster-ingress.yaml
+++ b/charts/base-cluster/templates/global/cluster-ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.dns.provider .Values.global.baseDomain (ne .Values.ingress.provider "none") }}
+{{- if and .Values.dns.provider .Values.global.baseDomain (ne .Values.ingress.provider "none") (not (include "base-cluster.ingress.hasEnvoy" $)) }}
 {{- if false }}
 apiVersion: networking.k8s.io/v1
 {{- else }}

--- a/charts/base-cluster/templates/ingress/_proxy_protocol.tpl
+++ b/charts/base-cluster/templates/ingress/_proxy_protocol.tpl
@@ -1,34 +1,38 @@
 {{- define "base-cluster.ingress.useProxyProtocol" -}}
   {{- $_ := mustMerge . (pick .context "Values") -}}
-  {{- if eq .Values.ingress.useProxyProtocol "auto" -}}
-    {{- $cloudProvider := .Values.global.autoConfiguration.cloudProvider }}
-    {{- if eq $cloudProvider "auto" }}
-      {{- $randomNodeProviderID := dig "spec" "providerID" "" (dig "items" (list) (lookup "v1" "Node" "" "") | first | default (dict)) -}}
-      {{- if regexMatch "^openstack://" $randomNodeProviderID -}}
-        {{- $cloudProvider = "openstack" -}}
+  {{- if kindIs "string" .Values.ingress.useProxyProtocol -}}
+    {{- if eq .Values.ingress.useProxyProtocol "auto" -}}
+      {{- $cloudProvider := .Values.global.autoConfiguration.cloudProvider }}
+      {{- if eq $cloudProvider "auto" }}
+        {{- $randomNodeProviderID := dig "spec" "providerID" "" (dig "items" (list) (lookup "v1" "Node" "" "") | first | default (dict)) -}}
+        {{- if regexMatch "^openstack://" $randomNodeProviderID -}}
+          {{- $cloudProvider = "openstack" -}}
+        {{- end -}}
       {{- end -}}
-    {{- end -}}
 
-    {{- $useProxyProtocol := true -}}
+      {{- $useProxyProtocol := true -}}
 
-    {{- if eq $cloudProvider "auto" -}}
-      {{/* Cloud provider could not be detected (including empty/missing providerID); treat as unknown cloud and keep proxy protocol enabled as a safe default. */}}
-    {{- else if eq $cloudProvider "openstack" -}}
-      {{- with .Values.global.autoConfiguration.openstack -}}
-        {{- $cloudConfig := lookup "v1" .cloudConfiguration.type .cloudConfiguration.namespace .cloudConfiguration.name -}}
-        {{- if $cloudConfig -}}
-          {{- $cloudConfigData := dig "data" .cloudConfiguration.field "" $cloudConfig -}}
-          {{- if eq .cloudConfiguration.type "Secret" -}}
-            {{- $cloudConfigData = b64dec $cloudConfigData -}}
-          {{- end -}}
-          {{- $lbProvider := regexFind "lb-provider.*" $cloudConfigData -}}
-          {{- if regexMatch "ovn" $lbProvider -}}
-            {{- $useProxyProtocol = false -}}
+      {{- if eq $cloudProvider "auto" -}}
+        {{/* Cloud provider could not be detected (including empty/missing providerID); treat as unknown cloud and keep proxy protocol enabled as a safe default. */}}
+      {{- else if eq $cloudProvider "openstack" -}}
+        {{- with .Values.global.autoConfiguration.openstack -}}
+          {{- $cloudConfig := lookup "v1" .cloudConfiguration.type .cloudConfiguration.namespace .cloudConfiguration.name -}}
+          {{- if $cloudConfig -}}
+            {{- $cloudConfigData := dig "data" .cloudConfiguration.field "" $cloudConfig -}}
+            {{- if eq .cloudConfiguration.type "Secret" -}}
+              {{- $cloudConfigData = b64dec $cloudConfigData -}}
+            {{- end -}}
+            {{- $lbProvider := regexFind "lb-provider.*" $cloudConfigData -}}
+            {{- if regexMatch "ovn" $lbProvider -}}
+              {{- $useProxyProtocol = false -}}
+            {{- end -}}
           {{- end -}}
         {{- end -}}
       {{- end -}}
+      {{- $useProxyProtocol -}}
+    {{- else -}}
+      {{- .Values.ingress.useProxyProtocol -}}
     {{- end -}}
-    {{- $useProxyProtocol -}}
   {{- else -}}
     {{- .Values.ingress.useProxyProtocol -}}
   {{- end -}}

--- a/charts/base-cluster/templates/ingress/envoy.yaml
+++ b/charts/base-cluster/templates/ingress/envoy.yaml
@@ -1,0 +1,204 @@
+{{- if eq .Values.ingress.provider "envoy" -}}
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: envoy-gateway-crds
+  namespace: ingress
+  labels: {{- include "common.labels.standard" $ | nindent 4 }}
+    app.kubernetes.io/component: ingress
+spec:
+  chart:
+    spec: {{- include "base-cluster.helm.chartSpec" (dict "repo" "envoyGatewayCrds" "chart" "gateway-crds-helm" "context" $) | nindent 6 }}
+  interval: 1h
+  driftDetection:
+    mode: enabled
+  values:
+    crds:
+      gatewayAPI:
+        enabled: false
+      envoyGateway:
+        enabled: true
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ingress-controller
+  namespace: ingress
+  labels: {{- include "common.labels.standard" $ | nindent 4 }}
+    app.kubernetes.io/component: ingress
+spec:
+  chart:
+    spec: {{- include "base-cluster.helm.chartSpec" (dict "repo" "envoyGateway" "chart" "gateway-helm" "context" $) | nindent 6 }}
+  interval: 1h
+  driftDetection:
+    mode: enabled
+  dependsOn:
+    - name: envoy-gateway-crds
+      namespace: ingress
+  {{- if .Values.monitoring.prometheus.enabled }}
+    - name: kube-prometheus-stack
+      namespace: monitoring
+  {{- end }}
+  values:
+    fullnameOverride: ingress-controller
+    crds:
+      enabled: false
+    {{- with .Values.global.imageRegistry }}
+    global:
+      imageRegistry: {{ . }}
+    {{- end }}
+    deployment:
+      replicas: {{ .Values.ingress.replicas }}
+    resources: {{- include "common.resources" .Values.ingress | nindent 6 }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: default
+  labels: {{- include "common.labels.standard" $ | nindent 4 }}
+    app.kubernetes.io/component: ingress
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller
+  parametersRef:
+    group: gateway.envoyproxy.io
+    kind: EnvoyProxy
+    name: ingress-controller
+    namespace: ingress
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: ingress-controller
+  namespace: ingress
+  labels: {{- include "common.labels.standard" $ | nindent 4 }}
+    app.kubernetes.io/component: ingress
+spec:
+  provider:
+    type: Kubernetes
+    kubernetes:
+      envoyDeployment:
+        replicas: {{ .Values.ingress.replicas }}
+        pod:
+          labels:
+            app.kubernetes.io/name: ingress-controller
+        container:
+          resources: {{- include "common.resources" .Values.ingress | nindent 12 }}
+  {{- $telemetryConf := include "common.telemetry.conf" (dict "protocol" "otlp" "global" .Values.global) | fromYaml }}
+  {{- if and $telemetryConf.enabled $telemetryConf.serviceName }}
+  telemetry:
+    tracing:
+      provider:
+        type: OpenTelemetry
+        backendRefs:
+          - name: {{ $telemetryConf.serviceName }}
+            namespace: {{ $telemetryConf.serviceNamespace }}
+            port: {{ int64 $telemetryConf.port }}
+  {{- end }}
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: ingress-controller-service
+  namespace: ingress
+  labels: {{- include "common.labels.standard" $ | nindent 4 }}
+    app.kubernetes.io/component: ingress
+spec:
+  # Gateway-scoped so a future additional Gateway on the same GatewayClass can get its own
+  # Service/IP via its own infrastructure.parametersRef, instead of inheriting this one.
+  mergeType: StrategicMerge
+  provider:
+    type: Kubernetes
+    kubernetes:
+      envoyService:
+        name: ingress-controller
+        annotations:
+          loadbalancer.openstack.org/timeout-client-data: "2073600000"
+          loadbalancer.openstack.org/timeout-member-connect: "2073600000"
+          loadbalancer.openstack.org/timeout-member-data: "2073600000"
+          loadbalancer.openstack.org/timeout-tcp-inspect: "2073600000"
+          loadbalancer.openstack.org/proxy-protocol: {{ include "base-cluster.ingress.useProxyProtocol" (dict "context" $) | quote }}
+          load-balancer.hetzner.cloud/uses-proxyprotocol: {{ include "base-cluster.ingress.useProxyProtocol" (dict "context" $) | quote }}
+          load-balancer.hetzner.cloud/disable-private-ingress: "true"
+          {{- if .Values.ingress.IP }}
+          loadbalancer.openstack.org/keep-floatingip: "true"
+          {{- end }}
+        {{- if .Values.ingress.IP }}
+        loadBalancerIP: {{ .Values.ingress.IP | quote }}
+        {{- end }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ingress-controller
+  namespace: ingress
+  labels: {{- include "common.labels.standard" $ | nindent 4 }}
+    app.kubernetes.io/component: ingress
+spec:
+  gatewayClassName: default
+  infrastructure:
+    parametersRef:
+      group: gateway.envoyproxy.io
+      kind: EnvoyProxy
+      name: ingress-controller-service
+  allowedListeners:
+    namespaces:
+      from: All
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: https
+      port: 443
+      protocol: HTTPS
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: cluster-wildcard-certificate
+      allowedRoutes:
+        namespaces:
+          from: All
+    {{- range $name, $cfg := .Values.ingress.extraPorts }}
+    - name: {{ $name }}
+      port: {{ $cfg.exposedPort }}
+      protocol: {{ $cfg.protocol }}
+      allowedRoutes:
+        namespaces:
+          from: All
+    {{- end }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ingress-controller-https-redirect
+  namespace: ingress
+  labels: {{- include "common.labels.standard" $ | nindent 4 }}
+    app.kubernetes.io/component: ingress
+spec:
+  parentRefs:
+    - name: ingress-controller
+      namespace: ingress
+      sectionName: http
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: ClientTrafficPolicy
+metadata:
+  name: ingress-controller
+  namespace: ingress
+  labels: {{- include "common.labels.standard" $ | nindent 4 }}
+    app.kubernetes.io/component: ingress
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ingress-controller
+  enableProxyProtocol: {{ include "base-cluster.ingress.useProxyProtocol" (dict "context" $) }}
+{{- end -}}

--- a/charts/base-cluster/templates/ingress/validation.tpl
+++ b/charts/base-cluster/templates/ingress/validation.tpl
@@ -6,6 +6,26 @@
   {{- fail "useTraefikNginxCompatibility cannot be enabled when using nginx as the ingress provider" -}}
 {{- end -}}
 
+{{- if and (eq .Values.ingress.provider "envoy") .Values.ingress.allowNginxConfigurationSnippets -}}
+  {{- fail "allowNginxConfigurationSnippets cannot be enabled when using envoy as the ingress provider" -}}
+{{- end -}}
+
+{{- if and (eq .Values.ingress.provider "envoy") .Values.ingress.useTraefikNginxCompatibility -}}
+  {{- fail "useTraefikNginxCompatibility cannot be enabled when using envoy as the ingress provider" -}}
+{{- end -}}
+
+{{- if eq .Values.ingress.provider "envoy" -}}
+  {{- $telemetryConf := include "common.telemetry.conf" (dict "protocol" "otlp" "global" .Values.global) | fromYaml -}}
+  {{- if and $telemetryConf.enabled (not $telemetryConf.serviceName) -}}
+    {{- fail "Explicit (non-auto-discovered) telemetry endpoints are not supported with the envoy ingress provider yet" -}}
+  {{- end -}}
+  {{- range $name, $cfg := .Values.ingress.extraPorts -}}
+    {{- if or (eq $name "http") (eq $name "https") -}}
+      {{- fail (printf "ingress.extraPorts key %q is reserved for the envoy Gateway's built-in http/https listeners, please choose a different name" $name) -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
 {{- $existingNginx := include "base-cluster.ingress.existingNginx" . -}}
 {{- $existingTraefik := include "base-cluster.ingress.existingTraefik" . -}}
 {{- if and $existingNginx $existingTraefik -}}
@@ -24,8 +44,8 @@
 
 {{- if .Values.ingress.IP -}}
   {{- $loadBalancerIP := (list nil) | first -}}
-  {{- $serviceName := (eq .Values.ingress.provider "traefik") | ternary "ingress-controller" "ingress-nginx-controller" -}}
-  {{- $serviceNamespace := (eq .Values.ingress.provider "traefik") | ternary "ingress" "ingress-nginx" -}}
+  {{- $serviceName := (eq .Values.ingress.provider "nginx") | ternary "ingress-nginx-controller" "ingress-controller" -}}
+  {{- $serviceNamespace := (eq .Values.ingress.provider "nginx") | ternary "ingress-nginx" "ingress" -}}
   {{- $existingService := lookup "v1" "Service" $serviceNamespace $serviceName -}}
   {{- if $existingService -}}
     {{- $existingSpecIP := $existingService.spec.loadBalancerIP -}}

--- a/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_helpers.yaml
+++ b/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_helpers.yaml
@@ -3,6 +3,24 @@
   {{- $ingress := include "base-cluster.monitoring.ingress.config" (dict "name" .name "context" .context) | fromYaml -}}
   {{- if include "base-cluster.monitoring.ingress.enabled" (dict "name" .name "context" .context) -}}
     {{- $host := include (printf "base-cluster.%s.host" .name) .context -}}
+    {{- if include "base-cluster.ingress.hasEnvoy" .context -}}
+route:
+  main:
+    enabled: true
+    hostnames:
+      - {{ $host }}
+    parentRefs:
+    {{- if $ingress.customDomain }}
+      - name: {{ printf "%s-listener-set" .name }}
+        kind: ListenerSet
+        group: gateway.networking.k8s.io
+        sectionName: main
+    {{- else }}
+      - name: ingress-controller
+        namespace: ingress
+        sectionName: https
+    {{- end }}
+    {{- else -}}
 ingress:
   enabled: true
   {{- if or (not .Values.dns.provider) $ingress.customDomain }}
@@ -15,6 +33,7 @@ ingress:
     - hosts:
         - {{ $host }}
       secretName: {{ include "base-cluster.certificate" (dict "name" .name "customDomain" $ingress.customDomain "context" .context) }}
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 

--- a/charts/base-cluster/templates/monitoring/kube-prometheus-stack/listener-sets.yaml
+++ b/charts/base-cluster/templates/monitoring/kube-prometheus-stack/listener-sets.yaml
@@ -1,0 +1,56 @@
+{{- if and (include "base-cluster.ingress.hasEnvoy" $) .Values.monitoring.prometheus.enabled -}}
+{{- $names := list "grafana" "prometheus" -}}
+{{- if include "base-cluster.prometheus-stack.alertmanager.enabled" $ -}}
+  {{- $names = append $names "alertmanager" -}}
+{{- end -}}
+{{- range $name := $names }}
+  {{- $ingress := include "base-cluster.monitoring.ingress.config" (dict "name" $name "context" $) | fromYaml -}}
+  {{- if and (include "base-cluster.monitoring.ingress.enabled" (dict "name" $name "context" $)) $ingress.customDomain }}
+    {{- $secretName := include "base-cluster.certificate" (dict "name" $name "customDomain" $ingress.customDomain "context" $) }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: {{ printf "%s-listener-set" $name }}
+  namespace: ingress
+  labels: {{- include "common.labels.standard" $ | nindent 4 }}
+    app.kubernetes.io/component: ingress
+spec:
+  parentRef:
+    name: ingress-controller
+    namespace: ingress
+    kind: Gateway
+    group: gateway.networking.k8s.io
+  listeners:
+    - name: main
+      hostname: {{ $ingress.customDomain | quote }}
+      protocol: HTTPS
+      port: 443
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            group: ""
+            name: {{ $secretName | quote }}
+      allowedRoutes:
+        namespaces:
+          from: All
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ $secretName }}
+  namespace: ingress
+  labels: {{- include "common.labels.standard" $ | nindent 4 }}
+    app.kubernetes.io/component: ingress
+spec:
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: letsencrypt-production
+  dnsNames:
+    - {{ $ingress.customDomain | quote }}
+  secretName: {{ $secretName | quote }}
+---
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/base-cluster/templates/monitoring/kube-prometheus-stack/oauth-proxy.yaml
+++ b/charts/base-cluster/templates/monitoring/kube-prometheus-stack/oauth-proxy.yaml
@@ -39,6 +39,25 @@ spec:
     nameOverride: {{ printf "cluster-%s-oauth-proxy" $host }}
     redis:
       enabled: false
+    {{- if include "base-cluster.ingress.hasEnvoy" $ }}
+    ingress:
+      enabled: false
+    gatewayApi:
+      enabled: true
+      gatewayRef:
+      {{- if $ingress.customDomain }}
+        name: {{ printf "%s-listener-set" $host }}
+        kind: ListenerSet
+        group: gateway.networking.k8s.io
+        sectionName: main
+      {{- else }}
+        name: ingress-controller
+        namespace: ingress
+        sectionName: https
+      {{- end }}
+      hostnames:
+        - {{ include (printf "base-cluster.%s.host" $host) $ }}
+    {{- else }}
     ingress:
       enabled: true
       {{- if not $.Values.dns.provider }}
@@ -51,6 +70,7 @@ spec:
         - hosts:
             - *host
           secretName: {{ include "base-cluster.certificate" (dict "name" $host "customDomain" $ingress.customDomain "context" $) | quote }}
+    {{- end }}
     replicaCount: 2
     podDisruptionBudget:
       enabled: true

--- a/charts/base-cluster/tests/global_cluster_ingress_test.yaml
+++ b/charts/base-cluster/tests/global_cluster_ingress_test.yaml
@@ -1,0 +1,32 @@
+suite: global cluster-ingress
+templates:
+  - templates/global/cluster-ingress.yaml
+release:
+  name: base-cluster
+set:
+  dns.provider:
+    cloudflare:
+      apiToken: test-token
+  global.baseDomain: example.com
+  global.clusterName: test
+tests:
+  - it: renders for traefik provider
+    set:
+      ingress.provider: traefik
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: does not render for envoy provider
+    set:
+      ingress.provider: envoy
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not render for none provider
+    set:
+      ingress.provider: none
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/base-cluster/tests/hosts_test.yaml
+++ b/charts/base-cluster/tests/hosts_test.yaml
@@ -12,6 +12,7 @@ tests:
       global.clusterName: test-cluster
       global.baseDomain: example.com
       dns.provider.cloudflare.apiToken: fake-token
+      ingress.provider: traefik
     asserts:
       - equal:
           path: spec.rules[0].host
@@ -22,6 +23,7 @@ tests:
       global.clusterName: test-cluster
       global.baseDomain: example.com
       dns.provider.cloudflare.apiToken: fake-token
+      ingress.provider: traefik
     asserts:
       - equal:
           path: spec.rules[1].host
@@ -31,6 +33,7 @@ tests:
     set:
       global.clusterName: test-cluster
       global.baseDomain: example.com
+      ingress.provider: traefik
     asserts:
       - hasDocuments:
           count: 0
@@ -49,6 +52,7 @@ tests:
     set:
       global.baseDomain: example.com
       dns.provider.cloudflare.apiToken: fake-token
+      ingress.provider: traefik
     asserts:
       - failedTemplate:
           errorMessage: "You must provide a cluster name"

--- a/charts/base-cluster/tests/ingress_cert_manager_test.yaml
+++ b/charts/base-cluster/tests/ingress_cert_manager_test.yaml
@@ -12,7 +12,19 @@ kubernetesProvider:
         resource: helmreleases
       namespaced: true
 tests:
-  - it: cert-manager gatewayAPI enabled when provider is traefik (default)
+  - it: cert-manager gatewayAPI enabled when provider is traefik
+    set:
+      ingress.provider: traefik
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.values.config.enableGatewayAPI
+          value: true
+
+  - it: cert-manager gatewayAPI enabled when provider is envoy
+    set:
+      ingress.provider: envoy
     asserts:
       - hasDocuments:
           count: 1
@@ -30,6 +42,8 @@ tests:
           path: spec.values.config
 
   - it: cert-manager gatewayAPI enabled in dual-mode (both HelmReleases exist, provider is traefik)
+    set:
+      ingress.provider: traefik
     kubernetesProvider:
       objects:
         - apiVersion: helm.toolkit.fluxcd.io/v2

--- a/charts/base-cluster/tests/ingress_envoy_test.yaml
+++ b/charts/base-cluster/tests/ingress_envoy_test.yaml
@@ -1,0 +1,223 @@
+suite: ingress envoy provider enum and namespace
+templates:
+  - templates/global/namespaces.yaml
+release:
+  name: base-cluster
+tests:
+  - it: ingress namespace renders when provider is envoy
+    set:
+      ingress.provider: envoy
+      global.baseDomain: example.com
+      global.clusterName: test
+    asserts:
+      - hasDocuments:
+          count: 7
+---
+suite: ingress envoy provider
+templates:
+  - templates/ingress/envoy.yaml
+release:
+  name: base-cluster
+set:
+  ingress.provider: envoy
+  global.baseDomain: example.com
+  global.clusterName: test
+  ingress.useProxyProtocol: false
+tests:
+  - it: renders CRDs HelmRelease, controller HelmRelease, GatewayClass, EnvoyProxy (shared), EnvoyProxy (service), Gateway, redirect HTTPRoute, and ClientTrafficPolicy
+    asserts:
+      - hasDocuments:
+          count: 8
+      - documentIndex: 0
+        isKind:
+          of: HelmRelease
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: envoy-gateway-crds
+      - documentIndex: 0
+        equal:
+          path: spec.values.crds.gatewayAPI.enabled
+          value: false
+      - documentIndex: 0
+        equal:
+          path: spec.values.crds.envoyGateway.enabled
+          value: true
+      - documentIndex: 1
+        isKind:
+          of: HelmRelease
+      - documentIndex: 1
+        equal:
+          path: metadata.name
+          value: ingress-controller
+      - documentIndex: 1
+        equal:
+          path: spec.values.crds.enabled
+          value: false
+      - documentIndex: 1
+        equal:
+          path: spec.dependsOn[0].name
+          value: envoy-gateway-crds
+      - documentIndex: 1
+        equal:
+          path: spec.dependsOn[0].namespace
+          value: ingress
+      - documentIndex: 2
+        isKind:
+          of: GatewayClass
+      - documentIndex: 2
+        equal:
+          path: metadata.name
+          value: default
+      - documentIndex: 2
+        equal:
+          path: spec.controllerName
+          value: gateway.envoyproxy.io/gatewayclass-controller
+      - documentIndex: 2
+        equal:
+          path: spec.parametersRef.name
+          value: ingress-controller
+      - documentIndex: 3
+        isKind:
+          of: EnvoyProxy
+      - documentIndex: 3
+        equal:
+          path: metadata.name
+          value: ingress-controller
+      - documentIndex: 3
+        equal:
+          path: spec.provider.kubernetes.envoyDeployment.replicas
+          value: 2
+      - documentIndex: 3
+        equal:
+          path: spec.provider.kubernetes.envoyDeployment.pod.labels
+          value:
+            app.kubernetes.io/name: ingress-controller
+      - documentIndex: 4
+        isKind:
+          of: EnvoyProxy
+      - documentIndex: 4
+        equal:
+          path: metadata.name
+          value: ingress-controller-service
+      - documentIndex: 4
+        equal:
+          path: spec.mergeType
+          value: StrategicMerge
+      - documentIndex: 4
+        equal:
+          path: spec.provider.kubernetes.envoyService.name
+          value: ingress-controller
+      - documentIndex: 5
+        isKind:
+          of: Gateway
+      - documentIndex: 5
+        equal:
+          path: metadata.name
+          value: ingress-controller
+      - documentIndex: 5
+        equal:
+          path: spec.gatewayClassName
+          value: default
+      - documentIndex: 5
+        equal:
+          path: spec.infrastructure.parametersRef.name
+          value: ingress-controller-service
+      - documentIndex: 5
+        equal:
+          path: spec.allowedListeners.namespaces.from
+          value: All
+      - documentIndex: 5
+        equal:
+          path: spec.listeners[0].name
+          value: http
+      - documentIndex: 5
+        equal:
+          path: spec.listeners[0].port
+          value: 80
+      - documentIndex: 5
+        equal:
+          path: spec.listeners[1].name
+          value: https
+      - documentIndex: 5
+        equal:
+          path: spec.listeners[1].port
+          value: 443
+      - documentIndex: 5
+        equal:
+          path: spec.listeners[1].tls.certificateRefs[0].name
+          value: cluster-wildcard-certificate
+      - documentIndex: 6
+        isKind:
+          of: HTTPRoute
+      - documentIndex: 6
+        equal:
+          path: spec.parentRefs[0].sectionName
+          value: http
+      - documentIndex: 6
+        equal:
+          path: spec.rules[0].filters[0].type
+          value: RequestRedirect
+      - documentIndex: 6
+        equal:
+          path: spec.rules[0].filters[0].requestRedirect.scheme
+          value: https
+      - documentIndex: 7
+        isKind:
+          of: ClientTrafficPolicy
+      - documentIndex: 7
+        equal:
+          path: spec.enableProxyProtocol
+          value: false
+      - documentIndex: 7
+        equal:
+          path: spec.targetRefs[0].name
+          value: ingress-controller
+
+  - it: pins loadBalancerIP and floating-ip annotation when ingress.IP is set
+    set:
+      ingress.IP: 10.0.0.100
+    asserts:
+      - documentIndex: 4
+        equal:
+          path: spec.provider.kubernetes.envoyService.loadBalancerIP
+          value: 10.0.0.100
+      - documentIndex: 4
+        equal:
+          path: spec.provider.kubernetes.envoyService.annotations["loadbalancer.openstack.org/keep-floatingip"]
+          value: "true"
+
+  - it: does not render when provider is traefik
+    set:
+      ingress.provider: traefik
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: sets the OpenTelemetry tracing provider type when telemetry is auto-discovered
+    kubernetesProvider:
+      scheme:
+        "v1/Service":
+          gvr:
+            version: v1
+            resource: services
+          namespaced: true
+      objects:
+        - apiVersion: v1
+          kind: Service
+          metadata:
+            name: telemetry-collector
+            namespace: monitoring
+          spec:
+            ports:
+              - name: otlp
+                port: "4317"
+    asserts:
+      - documentIndex: 3
+        equal:
+          path: spec.telemetry.tracing.provider.type
+          value: OpenTelemetry
+      - documentIndex: 3
+        equal:
+          path: spec.telemetry.tracing.provider.backendRefs[0].name
+          value: telemetry-collector

--- a/charts/base-cluster/tests/ingress_gateway_api_test.yaml
+++ b/charts/base-cluster/tests/ingress_gateway_api_test.yaml
@@ -12,7 +12,9 @@ kubernetesProvider:
         resource: helmreleases
       namespaced: true
 tests:
-  - it: gateway-api renders when provider is traefik (default)
+  - it: gateway-api renders when provider is traefik
+    set:
+      ingress.provider: traefik
     asserts:
       - hasDocuments:
           count: 2
@@ -25,6 +27,8 @@ tests:
           count: 0
 
   - it: gateway-api renders in dual-mode with traefik provider
+    set:
+      ingress.provider: traefik
     kubernetesProvider:
       objects:
         - apiVersion: helm.toolkit.fluxcd.io/v2
@@ -56,6 +60,13 @@ tests:
           metadata:
             name: ingress-controller
             namespace: ingress
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: gateway-api renders when provider is envoy
+    set:
+      ingress.provider: envoy
     asserts:
       - hasDocuments:
           count: 2

--- a/charts/base-cluster/tests/ingress_grafana_dashboards_test.yaml
+++ b/charts/base-cluster/tests/ingress_grafana_dashboards_test.yaml
@@ -31,12 +31,13 @@ tests:
       - notExists:
           path: spec.values.grafana.dashboards.custom.traefik
 
-  - it: only renders the traefik dashboard when provider is traefik (default)
+  - it: only renders the traefik dashboard when provider is traefik
     template: templates/monitoring/kube-prometheus-stack/prometheus-operator.yaml
     set:
       global.clusterName: test
       monitoring.grafana.adminPassword: test
       monitoring.prometheus.enabled: true
+      ingress.provider: traefik
     asserts:
       - notExists:
           path: spec.values.grafana.dashboards.custom.ingress-nginx
@@ -84,6 +85,7 @@ tests:
       monitoring.prometheus.kubeProxy: false
       monitoring.prometheus.kubeScheduler: false
       monitoring.prometheus.kubeControllerManager: false
+      ingress.provider: traefik
     kubernetesProvider:
       objects:
         - apiVersion: helm.toolkit.fluxcd.io/v2

--- a/charts/base-cluster/tests/ingress_nginx_test.yaml
+++ b/charts/base-cluster/tests/ingress_nginx_test.yaml
@@ -16,7 +16,9 @@ tests:
           path: metadata.name
           value: ingress-nginx
 
-  - it: nginx HelmRelease does not render when provider is traefik (default)
+  - it: nginx HelmRelease does not render when provider is traefik
+    set:
+      ingress.provider: traefik
     asserts:
       - hasDocuments:
           count: 0

--- a/charts/base-cluster/tests/ingress_traefik_test.yaml
+++ b/charts/base-cluster/tests/ingress_traefik_test.yaml
@@ -4,7 +4,9 @@ templates:
 release:
   name: base-cluster
 tests:
-  - it: traefik HelmRelease renders when provider is traefik (default)
+  - it: traefik HelmRelease renders when provider is traefik
+    set:
+      ingress.provider: traefik
     asserts:
       - hasDocuments:
           count: 1
@@ -22,6 +24,8 @@ tests:
           count: 0
 
   - it: traefik Service carries resource-policy keep annotation
+    set:
+      ingress.provider: traefik
     asserts:
       - equal:
           path: spec.values.service.annotations["helm.sh/resource-policy"]

--- a/charts/base-cluster/tests/ingress_validation_test.yaml
+++ b/charts/base-cluster/tests/ingress_validation_test.yaml
@@ -17,7 +17,9 @@ kubernetesProvider:
         resource: "services"
       namespaced: true
 tests:
-  - it: no error with default traefik and no existing nginx
+  - it: no error with traefik and no existing nginx
+    set:
+      ingress.provider: traefik
     asserts:
       - hasDocuments:
           count: 0
@@ -31,6 +33,7 @@ tests:
 
   - it: fails immediately when nginx snippets enabled with traefik
     set:
+      ingress.provider: traefik
       ingress.allowNginxConfigurationSnippets: true
     asserts:
       - failedTemplate:
@@ -45,6 +48,8 @@ tests:
           errorMessage: "useTraefikNginxCompatibility cannot be enabled when using nginx as the ingress provider"
 
   - it: fails when switching to traefik while nginx HelmRelease exists
+    set:
+      ingress.provider: traefik
     kubernetesProvider:
       objects:
         - apiVersion: helm.toolkit.fluxcd.io/v2
@@ -71,6 +76,8 @@ tests:
           errorMessage: "Cannot switch to nginx while traefik is installed. If you want to switch to nginx, please delete the HelmRelease 'ingress/ingress-controller' first. Note: You might want to set .Values.ingress.IP to the current traefik LoadBalancer IP to keep the same IP. Warning: Switching providers will cause downtime until the new provider is fully deployed."
 
   - it: no error when both nginx and traefik HelmReleases exist with traefik provider
+    set:
+      ingress.provider: traefik
     kubernetesProvider:
       objects:
         - apiVersion: helm.toolkit.fluxcd.io/v2
@@ -137,3 +144,110 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: fails immediately when nginx snippets enabled with envoy
+    set:
+      ingress.provider: envoy
+      ingress.allowNginxConfigurationSnippets: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "allowNginxConfigurationSnippets cannot be enabled when using envoy as the ingress provider"
+
+  - it: fails immediately when nginx traefik compatibility enabled with envoy
+    set:
+      ingress.provider: envoy
+      ingress.useTraefikNginxCompatibility: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "useTraefikNginxCompatibility cannot be enabled when using envoy as the ingress provider"
+
+  - it: no error when grafana customDomain is set with envoy
+    set:
+      ingress.provider: envoy
+      monitoring.grafana.ingress.customDomain: grafana.custom.example.com
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: no error when prometheus customDomain is set with envoy
+    set:
+      ingress.provider: envoy
+      monitoring.prometheus.ingress.customDomain: prometheus.custom.example.com
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: no error when alertmanager customDomain is set with envoy
+    set:
+      ingress.provider: envoy
+      monitoring.prometheus.alertmanager.ingress.customDomain: alertmanager.custom.example.com
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: fails when telemetry has an explicit non-auto endpoint with envoy
+    set:
+      ingress.provider: envoy
+      global.telemetry.otlp.endpoint: "otel-collector.example.com:4317"
+    asserts:
+      - failedTemplate:
+          errorMessage: "Explicit (non-auto-discovered) telemetry endpoints are not supported with the envoy ingress provider yet"
+
+  - it: fails when an extraPorts entry is named http, colliding with the envoy Gateway's built-in listener
+    set:
+      ingress.provider: envoy
+      ingress.extraPorts:
+        http:
+          port: 8080
+          exposedPort: 8080
+          protocol: TCP
+    asserts:
+      - failedTemplate:
+          errorMessage: "ingress.extraPorts key \"http\" is reserved for the envoy Gateway's built-in http/https listeners, please choose a different name"
+
+  - it: fails when an extraPorts entry is named https, colliding with the envoy Gateway's built-in listener
+    set:
+      ingress.provider: envoy
+      ingress.extraPorts:
+        https:
+          port: 8443
+          exposedPort: 8443
+          protocol: TCP
+    asserts:
+      - failedTemplate:
+          errorMessage: "ingress.extraPorts key \"https\" is reserved for the envoy Gateway's built-in http/https listeners, please choose a different name"
+
+  - it: does not fail when an extraPorts entry uses a non-reserved name with envoy
+    set:
+      ingress.provider: envoy
+      ingress.extraPorts:
+        ssh:
+          port: 22
+          exposedPort: 22
+          protocol: TCP
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: resolves envoy's service identity correctly for the IP-immutability check
+    set:
+      ingress.provider: envoy
+      ingress.IP: 10.0.0.100
+    kubernetesProvider:
+      scheme:
+        "v1/Service":
+          gvr:
+            version: "v1"
+            resource: "services"
+          namespaced: true
+      objects:
+        - apiVersion: v1
+          kind: Service
+          metadata:
+            name: ingress-controller
+            namespace: ingress
+          spec:
+            loadBalancerIP: 10.0.0.200
+    asserts:
+      - failedTemplate:
+          errorMessage: "You cannot change the LoadBalancerIP on an existing service, if you really want to, please delete the service 'ingress/ingress-controller' beforehand"

--- a/charts/base-cluster/tests/monitoring_ingress_envoy_test.yaml
+++ b/charts/base-cluster/tests/monitoring_ingress_envoy_test.yaml
@@ -1,0 +1,296 @@
+suite: monitoring ingress route (envoy)
+templates:
+  - templates/monitoring/kube-prometheus-stack/prometheus-operator.yaml
+  - templates/monitoring/kube-prometheus-stack/grafana-secret.yaml
+release:
+  name: base-cluster
+set:
+  ingress.provider: envoy
+  certManager.email: admin@example.com
+  global.baseDomain: example.com
+  global.clusterName: test
+  monitoring.prometheus.enabled: true
+  monitoring.grafana.ingress.host: grafana
+  monitoring.grafana.ingress.enabled: true
+  monitoring.prometheus.ingress.host: prometheus
+  monitoring.prometheus.ingress.enabled: true
+  monitoring.prometheus.alertmanager.receivers:
+    pagerduty:
+      integrationKey: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  monitoring.prometheus.alertmanager.ingress.host: alertmanager
+  monitoring.prometheus.alertmanager.ingress.enabled: true
+tests:
+  - it: grafana gets a route instead of an ingress
+    template: templates/monitoring/kube-prometheus-stack/prometheus-operator.yaml
+    asserts:
+      - equal:
+          path: spec.values.grafana.route.main.enabled
+          value: true
+      - equal:
+          path: spec.values.grafana.route.main.hostnames[0]
+          value: grafana.test.example.com
+      - equal:
+          path: spec.values.grafana.route.main.parentRefs[0].name
+          value: ingress-controller
+      - equal:
+          path: spec.values.grafana.route.main.parentRefs[0].namespace
+          value: ingress
+      - equal:
+          path: spec.values.grafana.route.main.parentRefs[0].sectionName
+          value: https
+      - notExists:
+          path: spec.values.grafana.ingress.enabled
+
+  - it: prometheus gets a route instead of an ingress
+    template: templates/monitoring/kube-prometheus-stack/prometheus-operator.yaml
+    asserts:
+      - equal:
+          path: spec.values.prometheus.route.main.enabled
+          value: true
+      - equal:
+          path: spec.values.prometheus.route.main.hostnames[0]
+          value: prometheus.test.example.com
+
+  - it: alertmanager gets a route instead of an ingress
+    template: templates/monitoring/kube-prometheus-stack/prometheus-operator.yaml
+    asserts:
+      - equal:
+          path: spec.values.alertmanager.route.main.enabled
+          value: true
+      - equal:
+          path: spec.values.alertmanager.route.main.hostnames[0]
+          value: alertmanager.test.example.com
+
+  - it: grafana gets an ingress (not a route) with traefik
+    template: templates/monitoring/kube-prometheus-stack/prometheus-operator.yaml
+    set:
+      ingress.provider: traefik
+    asserts:
+      - equal:
+          path: spec.values.grafana.ingress.enabled
+          value: true
+      - notExists:
+          path: spec.values.grafana.route
+
+  - it: grafana route targets its ListenerSet instead of the shared Gateway when customDomain is set
+    template: templates/monitoring/kube-prometheus-stack/prometheus-operator.yaml
+    set:
+      monitoring.grafana.ingress.customDomain: grafana.custom.example.com
+    asserts:
+      - equal:
+          path: spec.values.grafana.route.main.hostnames[0]
+          value: grafana.custom.example.com
+      - equal:
+          path: spec.values.grafana.route.main.parentRefs[0]
+          value:
+            name: grafana-listener-set
+            kind: ListenerSet
+            group: gateway.networking.k8s.io
+            sectionName: main
+
+---
+suite: monitoring ListenerSets and certificates (envoy customDomain)
+templates:
+  - templates/monitoring/kube-prometheus-stack/listener-sets.yaml
+release:
+  name: base-cluster
+set:
+  ingress.provider: envoy
+  certManager.email: admin@example.com
+  global.baseDomain: example.com
+  global.clusterName: test
+  monitoring.prometheus.enabled: true
+  monitoring.grafana.ingress.host: grafana
+  monitoring.grafana.ingress.enabled: true
+  monitoring.prometheus.ingress.host: prometheus
+  monitoring.prometheus.ingress.enabled: true
+  monitoring.prometheus.alertmanager.receivers:
+    pagerduty:
+      integrationKey: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  monitoring.prometheus.alertmanager.ingress.host: alertmanager
+  monitoring.prometheus.alertmanager.ingress.enabled: true
+tests:
+  - it: renders nothing when no component has a customDomain
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders a ListenerSet and Certificate for grafana's customDomain
+    set:
+      monitoring.grafana.ingress.customDomain: grafana.custom.example.com
+    asserts:
+      - documentIndex: 0
+        isKind:
+          of: ListenerSet
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: grafana-listener-set
+      - documentIndex: 0
+        equal:
+          path: metadata.namespace
+          value: ingress
+      - documentIndex: 0
+        equal:
+          path: spec.parentRef
+          value:
+            name: ingress-controller
+            namespace: ingress
+            kind: Gateway
+            group: gateway.networking.k8s.io
+      - documentIndex: 0
+        equal:
+          path: spec.listeners[0].hostname
+          value: grafana.custom.example.com
+      - documentIndex: 0
+        equal:
+          path: spec.listeners[0].tls.certificateRefs[0].name
+          value: grafana-certificate
+      - documentIndex: 1
+        isKind:
+          of: Certificate
+      - documentIndex: 1
+        equal:
+          path: metadata.name
+          value: grafana-certificate
+      - documentIndex: 1
+        equal:
+          path: metadata.namespace
+          value: ingress
+      - documentIndex: 1
+        equal:
+          path: spec.dnsNames[0]
+          value: grafana.custom.example.com
+      - documentIndex: 1
+        equal:
+          path: spec.secretName
+          value: grafana-certificate
+      - hasDocuments:
+          count: 2
+
+  - it: renders a ListenerSet and Certificate per component when all three have a customDomain
+    set:
+      monitoring.grafana.ingress.customDomain: grafana.custom.example.com
+      monitoring.prometheus.ingress.customDomain: prometheus.custom.example.com
+      monitoring.prometheus.alertmanager.ingress.customDomain: alertmanager.custom.example.com
+    asserts:
+      - hasDocuments:
+          count: 6
+
+  - it: does not render a ListenerSet when the whole monitoring stack is disabled
+    set:
+      monitoring.prometheus.enabled: false
+      monitoring.grafana.ingress.customDomain: grafana.custom.example.com
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not render a ListenerSet for traefik even with a customDomain set
+    set:
+      ingress.provider: traefik
+      monitoring.grafana.ingress.customDomain: grafana.custom.example.com
+    asserts:
+      - hasDocuments:
+          count: 0
+
+---
+suite: oauth2-proxy gatewayApi routing (envoy)
+templates:
+  - templates/monitoring/kube-prometheus-stack/oauth-proxy.yaml
+  - templates/monitoring/kube-prometheus-stack/oauth-proxy-secret.yaml
+release:
+  name: base-cluster
+set:
+  ingress.provider: envoy
+  certManager.email: admin@example.com
+  global.baseDomain: example.com
+  global.clusterName: test
+  global.authentication.config.clientId: test-client
+  global.authentication.config.clientSecret: test-secret
+  global.authentication.config.issuerHost: sso.example.com
+  monitoring.prometheus.enabled: true
+  monitoring.prometheus.ingress.host: prometheus
+tests:
+  - it: uses gatewayApi instead of ingress
+    template: templates/monitoring/kube-prometheus-stack/oauth-proxy.yaml
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.values.ingress.enabled
+          value: false
+      - equal:
+          path: spec.values.gatewayApi.enabled
+          value: true
+      - equal:
+          path: spec.values.gatewayApi.gatewayRef.name
+          value: ingress-controller
+      - equal:
+          path: spec.values.gatewayApi.gatewayRef.namespace
+          value: ingress
+      - equal:
+          path: spec.values.gatewayApi.gatewayRef.sectionName
+          value: https
+      - equal:
+          path: spec.values.gatewayApi.hostnames[0]
+          value: prometheus.test.example.com
+
+  - it: targets prometheus's ListenerSet instead of the shared Gateway when customDomain is set
+    template: templates/monitoring/kube-prometheus-stack/oauth-proxy.yaml
+    documentIndex: 0
+    set:
+      monitoring.prometheus.ingress.customDomain: prometheus.custom.example.com
+    asserts:
+      - equal:
+          path: spec.values.gatewayApi.gatewayRef
+          value:
+            name: prometheus-listener-set
+            kind: ListenerSet
+            group: gateway.networking.k8s.io
+            sectionName: main
+      - equal:
+          path: spec.values.gatewayApi.hostnames[0]
+          value: prometheus.custom.example.com
+
+  - it: CiliumNetworkPolicy selects the envoy data-plane pods by the same generic name label as traefik/nginx
+    template: templates/monitoring/kube-prometheus-stack/oauth-proxy.yaml
+    documentIndex: 1
+    set:
+      global.networkPolicy.type: cilium
+    asserts:
+      - isKind:
+          of: CiliumNetworkPolicy
+      - equal:
+          path: spec.ingress[0].fromEndpoints[0].matchLabels
+          value:
+            io.kubernetes.pod.namespace: ingress
+            app.kubernetes.io/name: ingress-controller
+
+  - it: CiliumNetworkPolicy still selects the traefik ingress-controller Deployment by name (no regression)
+    template: templates/monitoring/kube-prometheus-stack/oauth-proxy.yaml
+    documentIndex: 1
+    set:
+      ingress.provider: traefik
+      global.networkPolicy.type: cilium
+    asserts:
+      - isKind:
+          of: CiliumNetworkPolicy
+      - equal:
+          path: spec.ingress[0].fromEndpoints[0].matchLabels
+          value:
+            io.kubernetes.pod.namespace: ingress
+            app.kubernetes.io/name: ingress-controller
+
+  - it: CiliumNetworkPolicy still selects the nginx ingress-controller Deployment by name (no regression)
+    template: templates/monitoring/kube-prometheus-stack/oauth-proxy.yaml
+    documentIndex: 1
+    set:
+      ingress.provider: nginx
+      global.networkPolicy.type: cilium
+    asserts:
+      - isKind:
+          of: CiliumNetworkPolicy
+      - equal:
+          path: spec.ingress[0].fromEndpoints[0].matchLabels
+          value:
+            io.kubernetes.pod.namespace: ingress-nginx
+            app.kubernetes.io/name: ingress-nginx

--- a/charts/base-cluster/tests/prometheus_control_plane_test.yaml
+++ b/charts/base-cluster/tests/prometheus_control_plane_test.yaml
@@ -377,6 +377,7 @@ tests:
   - it: renders a plain ingress when unauthenticated (no global.authentication.config)
     template: templates/monitoring/kube-prometheus-stack/prometheus-operator.yaml
     set:
+      ingress.provider: traefik
       global.clusterName: test-cluster
       global.baseDomain: example.com
       certManager.email: admin@example.com

--- a/charts/base-cluster/tests/proxy_protocol_test.yaml
+++ b/charts/base-cluster/tests/proxy_protocol_test.yaml
@@ -3,6 +3,8 @@ templates:
   - templates/ingress/traefik.yaml
 release:
   name: base-cluster
+set:
+  ingress.provider: traefik
 kubernetesProvider:
   scheme:
     "v1/Node":
@@ -87,3 +89,19 @@ tests:
             protocol: TCP
             proxyProtocol:
               insecure: true
+
+  - it: literal boolean true override passes through unchanged
+    set:
+      ingress.useProxyProtocol: true
+    asserts:
+      - equal:
+          path: spec.values.ports.web.proxyProtocol.insecure
+          value: true
+
+  - it: literal boolean false override passes through unchanged
+    set:
+      ingress.useProxyProtocol: false
+    asserts:
+      - equal:
+          path: spec.values.ports.web.proxyProtocol.insecure
+          value: false

--- a/charts/base-cluster/values.schema.json
+++ b/charts/base-cluster/values.schema.json
@@ -1381,6 +1381,7 @@
           "enum": [
             "nginx",
             "traefik",
+            "envoy",
             "external",
             "none"
           ],

--- a/charts/base-cluster/values.yaml
+++ b/charts/base-cluster/values.yaml
@@ -7,7 +7,7 @@ global:
   priorityClasses: {}
   namespaces:
     ingress:
-      condition: '{{ or (not (empty .Values.dns.provider)) (eq .Values.ingress.provider "traefik") }}'
+      condition: '{{ or (not (empty .Values.dns.provider)) (eq .Values.ingress.provider "traefik") (eq .Values.ingress.provider "envoy") }}'
       podSecurityStandards:
         enforce: restricted
       additionalLabels:
@@ -106,9 +106,14 @@ global:
     metricsLabels:
       io.kubernetes.pod.namespace: monitoring
       app.kubernetes.io/name: prometheus
-    ingressLabels:
-      io.kubernetes.pod.namespace: '{{ eq .Values.ingress.provider "nginx" | ternary "ingress-nginx" "ingress" }}'
-      app.kubernetes.io/name: '{{ eq .Values.ingress.provider "nginx" | ternary "ingress-nginx" "ingress-controller" }}'
+    ingressLabels: |-
+      {{- if eq .Values.ingress.provider "nginx" }}
+      io.kubernetes.pod.namespace: ingress-nginx
+      app.kubernetes.io/name: ingress-nginx
+      {{- else }}
+      io.kubernetes.pod.namespace: ingress
+      app.kubernetes.io/name: ingress-controller
+      {{- end }}
   # it's important that the `url` is the first key and `charts` is right below, otherwise renovate won't detect it
   helmRepositories:
     prometheus:
@@ -167,6 +172,16 @@ global:
       charts:
         traefik: 41.2.0
       condition: '{{ eq .Values.ingress.provider "traefik" }}'
+    envoyGatewayCrds:
+      url: oci://docker.io/envoyproxy
+      charts:
+        gateway-crds-helm: v1.8.3
+      condition: '{{ eq .Values.ingress.provider "envoy" }}'
+    envoyGateway:
+      url: oci://docker.io/envoyproxy
+      charts:
+        gateway-helm: v1.8.3
+      condition: '{{ eq .Values.ingress.provider "envoy" }}'
     kyverno:
       url: https://kyverno.github.io/kyverno
       charts:
@@ -461,10 +476,10 @@ flux:
       url: https://github.com/kubernetes-sigs/gateway-api
       semver: 1.6.1
       path: config/crd/experimental
-      condition: '{{ include "base-cluster.ingress.hasTraefik" . }}'
+      condition: '{{ or (include "base-cluster.ingress.hasTraefik" .) (include "base-cluster.ingress.hasEnvoy" .) }}'
 
 ingress:
-  provider: traefik
+  provider: envoy
   allowNginxConfigurationSnippets: false
   useTraefikNginxCompatibility: false
   useProxyProtocol: auto


### PR DESCRIPTION
Adds `envoy` (Envoy Gateway / Gateway API) as a new `ingress.provider` option and makes it the new default — a breaking change for clusters currently relying on the implicit traefik default. Migrates tracing/resources/IP/annotations handling from nginx/traefik into envoy, ships a default Gateway reusing the existing `ingress` namespace IP/annotations, reuses traefik's GatewayClass/HelmRelease naming, and keeps CRD footprint to the two required Gateway API CRD charts (no extra vendor-lock-in CRDs).

Third of a stacked series:
1. #2270 (`charts/common`)
2. #2271 (`charts/base-cluster` — traefik Service `resource-policy: keep`)
3. this PR (`charts/base-cluster` — envoy provider)

**Known blocker:** this PR pins `charts/base-cluster`'s `common` dependency to `2.2.0` (commit "chore(base-cluster): bump common dependency for telemetry backend-ref support"), which does not exist yet. That version is cut by release-please only after #2270 merges to `main` and the `common` chart is republished. Until then, `helm dependency update` on this branch will fail to resolve — this PR cannot be merged/released before #2270's release lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Envoy Gateway as the default ingress provider.
  * Added Gateway API routing for Grafana, Prometheus, Alertmanager, and OAuth proxy services.
  * Added custom-domain support with HTTPS certificates, redirects, telemetry tracing, configurable listeners, and proxy-protocol handling.
  * Added validation for unsupported Envoy configurations and reserved port names.

* **Bug Fixes**
  * Improved load balancer service selection and IP-preservation handling across ingress providers.

* **Documentation**
  * Documented Envoy migration behavior, limitations, breaking changes, and chart documentation requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->