### PR TITLE
fix(ci): install licensee gem with --user-install

### DIFF
--- a/.github/workflows/check-license-links.yaml
+++ b/.github/workflows/check-license-links.yaml
@@ -23,5 +23,5 @@ jobs:
           sparse-checkout-cone-mode: false
           persist-credentials: false
       - run: pip install yq
-      - run: gem install licensee --no-document --version 10.0.0
+      - run: gem install licensee --no-document --version 10.0.0 --user-install
       - run: ./scripts/.github/scripts/check-license-links.sh


### PR DESCRIPTION
## Summary
- `gem install licensee` in check-license-links fails on ubuntu-latest with `Gem::FilePermissionError` — the runner user can't write to the system gem dir. `--user-install` puts it in the user gem home instead, which Ruby already has on its load path, so `ruby -rlicensee` still finds it.

## Test plan
- [ ] CI run of check-license-links passes