### PR TITLE
test(common): add extensive helper coverage, fix two arithmetic bugs

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -54,6 +54,9 @@ jobs:
         with:
           python-version: 3.14
 
+      - name: Build chart dependencies
+        run: helm dependency update "charts/$CHART"
+
       - name: Build test wrapper dependencies
         if: hashFiles(format('charts/{0}/tests/Chart.yaml', env.CHART)) != ''
         run: helm dep build "charts/$CHART/tests"

--- a/charts/common/CLAUDE.md
+++ b/charts/common/CLAUDE.md
@@ -1,0 +1,60 @@
+# CLAUDE.md — common chart
+
+`common` is a library chart — no templates render on their own, no cluster to point `helm template` at. Test coverage must be comprehensive: every helper here is used by every other chart in this repo, so a broken helper breaks everything downstream silently. Any new or changed helper needs test coverage before merge.
+
+## How to test this chart
+
+`tests/` is an impromptu chart that exists solely to exercise `common`'s helpers via helm-unittest:
+
+- `tests/Chart.yaml` — a throwaway chart depending on `common` (`file://../`).
+- `tests/templates/*-stub.yaml` — minimal templates that `include` the helper(s) under test. One stub per helper group (e.g. `helm-stub.yaml` for `common.helm.*`).
+- `tests/tests/*_test.yaml` — helm-unittest suites asserting against the corresponding stub's rendered output.
+
+Run with `go-task chart:test CHART=common` (runs `helm dependency build tests && helm unittest tests` — do not invoke `helm unittest`/`helm dependency` by hand, the task wraps both steps).
+
+To cover a new or changed helper:
+1. Add or extend a `-stub.yaml` template that calls it (reuse an existing stub if the helper belongs to the same group).
+2. Add an `it:` case to the matching `*_test.yaml`, covering the default path, edge cases, and any `fail`/error path the helper can hit.
+3. Add a `matchSnapshot` case (see below) so the full output is pinned, not just the fields you thought to assert on.
+4. If the helper takes more than one or two independent optional/boolean inputs, add combinatorial or generated-input coverage (see below).
+5. Run `go-task chart:test CHART=common` and confirm it passes.
+
+## Coverage bar: any change to a helper's output must fail CI
+
+Explicit `equal`/`notExists` assertions only catch drift in the fields you thought to check. That's not enough here — a helper regression silently breaks every downstream chart. Two techniques close the gap:
+
+### 1. `matchSnapshot` on the full rendered output
+
+Every suite should have at least one `it:` case asserting `matchSnapshot` against the whole document (`path: ""` — the empty string is the root path, not `.`), on top of the targeted `equal` assertions. This pins the entire output, so any accidental change — a renamed key, a dropped field, reordered list, changed formatting — fails the test even if no one wrote an assertion for that specific field. For a stub that ranges over multiple documents, add `documentIndex: -1` to snapshot all of them.
+
+```yaml
+- it: matches snapshot
+  set:
+    convert.value: 1024Mi
+    convert.to: Gi
+  asserts:
+    - matchSnapshot:
+        path: ""
+```
+
+Snapshots live in `tests/tests/__snapshot__/<file>.snap` and **must be committed**. Review the diff to the `.snap` file on every PR that touches a helper — that diff *is* the change-detection signal. Never regenerate snapshots with `helm unittest -u` to make a red test pass without reading what changed first; that's the same as deleting the test.
+
+### 2. Combinatorial / wide-table coverage for multi-parameter helpers
+
+For helpers with several independent optional inputs (e.g. `common.resources`'s `resources` × `resourcesPreset` × `setCPULimits`, or `common.helm.chartSpec`'s repo-type × `prependReleaseName` × `repoNamespace`), a couple of hand-picked example cases under-covers the input space — the untested combinations are exactly where regressions hide. Enumerate the full cartesian product of boolean/enum flags as explicit `it:` cases rather than picking one or two "representative" ones.
+
+For a helper that's a pure function over an open-ended input (numbers, strings) rather than a small enum/bool space — e.g. `common.convert`'s unit math — a couple of round-number examples aren't enough either, but the fix stays inside helm-unittest, not an external generator/fuzz script: add a wide, deliberately-awkward table of `it:` cases directly in the `*_test.yaml` — fractional values, values near unit-overflow boundaries, mixed magnitudes — picked specifically to exercise arithmetic edge cases a "nice" example would skip. This is how the `mul`/`mulf` int64-truncation regression in `common.convert` was caught: hand-picked whole-number examples (`1024Mi` → `Gi`) never exercised a fractional or huge input, so the bug was invisible until a table entry like `500.5` → `k` was added. Compute each case's expected value once (`helm template ... -s tests/templates/convert-stub.yaml --set ...`), verify it's mathematically correct, then hardcode it as a normal `equal` assertion — same as any other test, just more of them and chosen adversarially.
+
+Do not reach for a shell script or a custom go-task target for this — it doesn't compose with `go-task chart:test`'s existing `helm unittest` invocation, adds a second test runner to reason about, and (as tried and reverted here) requires solving problems helm-unittest already solves for you (YAML round-tripping quirks, output extraction) worse than helm-unittest does.
+
+### 3. Genuine per-run randomness via sprig, when a fixed table still isn't enough
+
+Sprig's own `randInt`/`randNumeric` give real randomness inside a template — no external generator needed. This only works as a **round-trip/invariant** check, computed entirely inside the stub: e.g. `common.convert`'s `convert-roundtrip-stub.yaml` picks a random value and a random unit pair with `randInt`, converts A→B→A, and asserts the result matches the original within tolerance. There's no independently-computed "expected value" here — the round trip is its own oracle — which is exactly why it's limited to catching *arithmetic* bugs (e.g. the `mul`/`mulf` truncation), not a wrong unit-multiplier constant (a wrong constant round-trips with itself and passes). That's still the hand-picked table's job.
+
+Two hard-won constraints if you write one of these:
+- **Scope the randomness to realistic inputs.** Letting `randInt` pick *any* unit pair (e.g. `k`→`E`) fails the round-trip on a real but irrelevant limitation: `common.convert` formats its intermediate result with a fixed `printf "%f"` (6 decimal places), so a big enough magnitude gap collapses precision before the return trip even starts. Restrict to the same unit family and a small step gap — match how the helper is actually called in this repo, not the full input space the type system permits.
+- **`randInt`/`add`/`sub`/`min`/`max` return different int types.** Sprig's arithmetic helpers return `int64`, but `randInt(min, max int) int` requires exact `int` — pipe every value crossing into a `randInt` call through `| int` or you get a template execution error, not a test failure, on every single run (this will not show up as intermittent — it's 100% reproducible, don't mistake it for a flaky random-input failure and go looking for a numerical cause).
+
+Verify a new randomized check by literally running it in a loop (`for i in $(seq 1 300); do helm template ...; done`) before trusting it — "it passed once" tells you nothing when the input changes every run.
+
+See root `CLAUDE.md` for general helm-unittest and Go template gotchas (kubernetesProvider scheme registration, ternary bool coercion, etc.) — those apply here too.

--- a/charts/common/templates/_networkpolicyrules.tpl
+++ b/charts/common/templates/_networkpolicyrules.tpl
@@ -17,6 +17,8 @@
   {{- end -}}
   {{/* Create rules for each identity based on network policy type */}}
   {{- range $identity := $identities -}}
+    {{/* Native NetworkPolicy has no equivalent to cilium's abstract "entity" selector, so entity-only identities (no concrete endpoint) can't be expressed and are skipped */}}
+    {{- if or $useCilium (hasKey $identity "endpoint") -}}
     {{- $rule := dict -}}
     {{- $endpoint := $identity.endpoint -}}
     {{/* For cilium use entity or endpoint based rules */}}
@@ -46,6 +48,7 @@
     {{- end -}}
 
     {{- $rules = append $rules $rule -}}
+    {{- end -}}
   {{- end -}}
 
   {{- toYaml ($rules | default (dict)) -}}

--- a/charts/common/templates/_resources.tpl
+++ b/charts/common/templates/_resources.tpl
@@ -57,7 +57,7 @@ If you want to set CPU limits, set the "setCPULimits" value to true.
   {{- fail (printf "Unknown target unit: %s" $toUnit) -}}
   {{- end -}}
 
-  {{- $bytes := mul $number $fromFactor -}}
+  {{- $bytes := mulf $number $fromFactor -}}
   {{- $result := divf $bytes $toFactor -}}
 
   {{- printf "%f%s" $result $toUnit -}}

--- a/charts/common/tests/templates/convert-roundtrip-stub.yaml
+++ b/charts/common/tests/templates/convert-roundtrip-stub.yaml
@@ -1,0 +1,66 @@
+{{/*
+Property-based check for common.convert, using sprig's own randInt for genuine per-run
+randomness instead of an external generator. Converting a random value from unit A to unit
+B and back to A should return (approximately, allowing for float64 rounding) the original
+value. This is a round-trip invariant, not a fixed expected value, so it needs no external
+"independent" implementation to compare against — it catches the class of bug where the
+arithmetic operation itself is wrong (e.g. int64 truncation/overflow from using `mul`
+instead of `mulf`), because a lossy op breaks symmetrically in a way an exact op doesn't.
+It can NOT catch a wrong unit-multiplier constant (the same wrong constant round-trips with
+itself) — that's what the hand-picked table in convert_test.yaml is for.
+
+from/to units are restricted to the same family (SI or binary) and at most 1 step apart —
+matching how this repo actually calls common.convert (e.g. Mi<->Gi, never k<->E or Ki<->Ei).
+Allowing a wider gap isn't "more thorough", it just breaks the round-trip on a real but
+irrelevant limitation: the intermediate result is formatted with a fixed 6 decimal places
+(`printf "%f"`), so the absolute rounding error at the intermediate step is roughly
+0.5e-6 * (toFactor/fromFactor) — a small but CONSTANT number, independent of `original`.
+A tolerance relative to `original` (e.g. `original * 1e-6`) is wrong: for small `original`
+values on a unit-increasing step, that shrinks below the constant rounding error and fails
+even though nothing is actually broken. The tolerance below is instead derived from the
+unit-factor ratio itself, with a generous safety margin — still far too small to hide a real
+arithmetic bug (the mul/mulf truncation this test was built to catch produces errors many
+orders of magnitude larger, not a few parts in a million).
+*/}}
+{{- if .Values.convertRoundtrip.enabled }}
+{{- $families := list (list "" "k" "M" "G" "T" "P" "E") (list "" "Ki" "Mi" "Gi" "Ti" "Pi" "Ei") -}}
+{{- $unitFactors := dict
+  ""   1.0
+  "k"  1e3
+  "M"  1e6
+  "G"  1e9
+  "T"  1e12
+  "P"  1e15
+  "E"  1e18
+  "Ki" 1024.0
+  "Mi" 1048576.0
+  "Gi" 1073741824.0
+  "Ti" 1099511627776.0
+  "Pi" 1125899906842624.0
+  "Ei" 1152921504606846976.0
+-}}
+{{- $family := index $families (randInt 0 (len $families)) -}}
+{{- $maxGap := 1 -}}
+{{- $fromIdx := randInt 0 (len $family) -}}
+{{- $gapLow := max 0 (sub $fromIdx $maxGap) | int -}}
+{{- $gapHigh := min (sub (len $family) 1) (add $fromIdx $maxGap) | int -}}
+{{- $toIdx := randInt $gapLow (add $gapHigh 1 | int) -}}
+{{- $fromUnit := index $family $fromIdx -}}
+{{- $toUnit := index $family $toIdx -}}
+{{- $intPart := randInt 1 1000000 -}}
+{{- $fracPart := randInt 0 1000 -}}
+{{- $original := printf "%d.%03d" $intPart $fracPart | float64 -}}
+{{- $converted := include "common.convert" (dict "value" (printf "%d.%03d%s" $intPart $fracPart $fromUnit) "to" $toUnit) -}}
+{{- $roundtripped := include "common.convert" (dict "value" $converted "to" $fromUnit) | regexFind "[0-9.]+" | float64 -}}
+{{- $diff := subf $original $roundtripped -}}
+{{- if lt $diff 0.0 -}}{{- $diff = mulf $diff -1.0 -}}{{- end -}}
+{{- $ratio := divf (index $unitFactors $toUnit) (index $unitFactors $fromUnit) -}}
+{{- if lt $ratio 1.0 -}}{{- $ratio = divf 1.0 $ratio -}}{{- end -}}
+{{- $tolerance := mulf 0.00001 $ratio -}}
+---
+fromUnit: {{ $fromUnit | quote }}
+toUnit: {{ $toUnit | quote }}
+original: {{ $original }}
+roundtripped: {{ $roundtripped }}
+withinTolerance: {{ lt $diff $tolerance }}
+{{- end }}

--- a/charts/common/tests/templates/helm-chartspec-stub.yaml
+++ b/charts/common/tests/templates/helm-chartspec-stub.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.chartSpec.repo }}
+---
+{{ include "common.helm.chartSpec" (dict
+  "context" .
+  "repo" .Values.chartSpec.repo
+  "chart" .Values.chartSpec.chart
+  "prependReleaseName" .Values.chartSpec.prependReleaseName
+  "repoNamespace" .Values.chartSpec.repoNamespace
+  "reconcileStrategy" .Values.chartSpec.reconcileStrategy
+) }}
+{{- end }}

--- a/charts/common/tests/templates/helm-repositories-stub.yaml
+++ b/charts/common/tests/templates/helm-repositories-stub.yaml
@@ -1,0 +1,1 @@
+{{ include "common.helm.repositories" (dict "context" .) }}

--- a/charts/common/tests/templates/networkpolicy-stub.yaml
+++ b/charts/common/tests/templates/networkpolicy-stub.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.networkPolicyType.enabled }}
+---
+type: {{ include "common.networkPolicy.type" . }}
+{{- end }}
+{{- if .Values.identity.enabled }}
+---
+identity:
+{{- include "common.networkPolicy.identity.kube-apiserver" (dict) | nindent 2 }}
+{{- end }}
+{{- if .Values.rule.enabled }}
+---
+rule:
+{{- include "common.networkPolicy.rule.from.kube-apiserver" (dict "cilium" .Values.rule.cilium "ports" .Values.rule.ports) | nindent 2 }}
+{{- end }}

--- a/charts/common/tests/templates/resources-stub.yaml
+++ b/charts/common/tests/templates/resources-stub.yaml
@@ -1,0 +1,2 @@
+---
+resources: {{- include "common.resources" (dict "resources" .Values.resources.resources "resourcesPreset" .Values.resources.resourcesPreset "setCPULimits" .Values.resources.setCPULimits) | nindent 2 }}

--- a/charts/common/tests/tests/__snapshot__/convert_test.yaml.snap
+++ b/charts/common/tests/tests/__snapshot__/convert_test.yaml.snap
@@ -1,0 +1,3 @@
+matches snapshot:
+  1: |
+    result: 1.000000Gi

--- a/charts/common/tests/tests/__snapshot__/helm-chartspec_test.yaml.snap
+++ b/charts/common/tests/tests/__snapshot__/helm-chartspec_test.yaml.snap
@@ -1,0 +1,16 @@
+matches snapshot for a git-type chart spec:
+  1: |
+    chart: charts/openstack-cinder-csi
+    reconcileStrategy: Revision
+    sourceRef:
+      kind: GitRepository
+      name: cpo-openstack-cinder-csi
+      namespace: NAMESPACE
+matches snapshot for a helm-type chart spec:
+  1: |
+    chart: redis
+    sourceRef:
+      kind: HelmRepository
+      name: bitnami
+      namespace: NAMESPACE
+    version: 20.0.0

--- a/charts/common/tests/tests/__snapshot__/helm-repositories_test.yaml.snap
+++ b/charts/common/tests/tests/__snapshot__/helm-repositories_test.yaml.snap
@@ -1,0 +1,46 @@
+matches snapshot for a full mixed configuration:
+  1: |
+    apiVersion: source.toolkit.fluxcd.io/v1
+    kind: HelmRepository
+    metadata:
+      labels:
+        app.kubernetes.io/instance: common-test
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: common-test
+        helm.sh/chart: common-test-0.1.0
+      name: bitnami
+      namespace: NAMESPACE
+    spec:
+      interval: 5m
+      url: https://charts.bitnami.com/bitnami
+  2: |
+    apiVersion: source.toolkit.fluxcd.io/v1
+    kind: HelmRepository
+    metadata:
+      labels:
+        app.kubernetes.io/instance: common-test
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: common-test
+        helm.sh/chart: common-test-0.1.0
+      name: cilium
+      namespace: NAMESPACE
+    spec:
+      interval: 5m
+      type: oci
+      url: oci://quay.io/cilium/charts
+  3: |
+    apiVersion: source.toolkit.fluxcd.io/v1
+    kind: GitRepository
+    metadata:
+      labels:
+        app.kubernetes.io/instance: common-test
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: common-test
+        helm.sh/chart: common-test-0.1.0
+      name: cpo-openstack-cinder-csi
+      namespace: NAMESPACE
+    spec:
+      interval: 5m
+      ref:
+        tag: v1.2.3
+      url: https://github.com/kubernetes/cloud-provider-openstack

--- a/charts/common/tests/tests/__snapshot__/helm_test.yaml.snap
+++ b/charts/common/tests/tests/__snapshot__/helm_test.yaml.snap
@@ -1,0 +1,3 @@
+returns version from helmRepositories:
+  1: |
+    version: 20.0.0

--- a/charts/common/tests/tests/__snapshot__/images_test.yaml.snap
+++ b/charts/common/tests/tests/__snapshot__/images_test.yaml.snap
@@ -1,0 +1,7 @@
+matches snapshot:
+  1: |
+    pullPolicy: Always
+  2: |
+    pullPolicy: IfNotPresent
+  3: |
+    pullPolicy: IfNotPresent

--- a/charts/common/tests/tests/__snapshot__/networkpolicy_test.yaml.snap
+++ b/charts/common/tests/tests/__snapshot__/networkpolicy_test.yaml.snap
@@ -1,0 +1,40 @@
+'identity: falls back to static kube-apiserver identity when konnectivity is absent':
+  1: |
+    - endpoint:
+        namespace: kube-system
+        pod:
+          component: kube-apiserver
+          tier: control-plane
+    - entity: kube-apiserver
+'rule: cilium mode with fallback identity uses fromEntities/fromEndpoints, no ports':
+  1: |
+    - fromEndpoints:
+        - matchLabels:
+            component: kube-apiserver
+            io.kubernetes.pod.namespace: kube-system
+            tier: control-plane
+    - fromEntities:
+        - kube-apiserver
+'rule: native mode with fallback identity':
+  1: |
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              component: kube-apiserver
+              tier: control-plane
+'rule: native mode with ports':
+  1: |
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              component: kube-apiserver
+              tier: control-plane
+      ports:
+        - port: "10250"
+          protocol: TCP

--- a/charts/common/tests/tests/__snapshot__/resources_test.yaml.snap
+++ b/charts/common/tests/tests/__snapshot__/resources_test.yaml.snap
@@ -1,0 +1,11 @@
+matches snapshot for preset + explicit override + setCPULimits:
+  1: |
+    resources:
+      limits:
+        cpu: 750m
+        ephemeral-storage: 2Gi
+        memory: 999Mi
+      requests:
+        cpu: 100m
+        ephemeral-storage: 50Mi
+        memory: 1024Mi

--- a/charts/common/tests/tests/__snapshot__/telemetry_test.yaml.snap
+++ b/charts/common/tests/tests/__snapshot__/telemetry_test.yaml.snap
@@ -1,0 +1,10 @@
+exposes serviceName and serviceNamespace when auto-discovered:
+  1: |
+    enabled: true
+    endpoint: http://alloy.monitoring:4317
+    host: alloy.monitoring
+    insecure: true
+    port: 4317
+    serviceName: alloy
+    serviceNamespace: monitoring
+    serviceProtocol: grpc

--- a/charts/common/tests/tests/convert-roundtrip_test.yaml
+++ b/charts/common/tests/tests/convert-roundtrip_test.yaml
@@ -1,0 +1,17 @@
+suite: common.convert (random round-trip property)
+templates:
+  - templates/convert-roundtrip-stub.yaml
+release:
+  name: common-test
+tests:
+  # Each `helm unittest` run generates fresh random inputs via sprig's randInt — this is
+  # genuine per-run fuzzing, not a fixed example. See convert-roundtrip-stub.yaml for why a
+  # round-trip check needs no independently-computed expected value, and CLAUDE.md for why
+  # this complements rather than replaces the hand-picked table in convert_test.yaml.
+  - it: converting a random value to a random unit and back returns the original value
+    set:
+      convertRoundtrip.enabled: true
+    asserts:
+      - equal:
+          path: withinTolerance
+          value: true

--- a/charts/common/tests/tests/convert_test.yaml
+++ b/charts/common/tests/tests/convert_test.yaml
@@ -51,3 +51,93 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "Unknown target unit: X"
+
+  - it: matches snapshot
+    set:
+      convert.value: 1024Mi
+      convert.to: Gi
+    asserts:
+      - matchSnapshot:
+          path: ""
+
+  # Fractional/large-magnitude table: these guard against a real regression where the
+  # helper used sprig's `mul` (int64) instead of `mulf` (float64) for the byte conversion.
+  # That silently truncated any fractional input and overflowed/wrapped negative for
+  # exabyte-scale factors. None of the whole-number cases above would have caught it.
+  - it: "fractional unitless value to k (would truncate to 500.000000 under integer math)"
+    set:
+      convert.value: "500.5"
+      convert.to: k
+    asserts:
+      - equal:
+          path: result
+          value: "0.500500k"
+
+  - it: "fractional value with many decimal places"
+    set:
+      convert.value: "21111.381"
+      convert.to: k
+    asserts:
+      - equal:
+          path: result
+          value: "21.111381k"
+
+  - it: "E to P stays positive and precise at large SI magnitude"
+    set:
+      convert.value: 1288.53E
+      convert.to: P
+    asserts:
+      - equal:
+          path: result
+          value: "1288530.000000P"
+
+  - it: "Ei to M stays positive at binary magnitude near int64 overflow"
+    set:
+      convert.value: 6244.44Ei
+      convert.to: M
+    asserts:
+      - equal:
+          path: result
+          value: "7199349160227180.000000M"
+
+  - it: "fractional binary value: Gi to Mi"
+    set:
+      convert.value: 0.125Gi
+      convert.to: Mi
+    asserts:
+      - equal:
+          path: result
+          value: "128.000000Mi"
+
+  - it: "fractional binary value: Ti to Gi"
+    set:
+      convert.value: 3.5Ti
+      convert.to: Gi
+    asserts:
+      - equal:
+          path: result
+          value: "3584.000000Gi"
+
+  - it: "unitless to M"
+    set:
+      # quoted: a bare native-YAML number >= 1e6 hits a separate, unrelated bug where
+      # `toString` renders it in scientific notation ("1e+06"), breaking the unit regex.
+      # See CLAUDE.md.
+      convert.value: "1000000"
+      convert.to: M
+    asserts:
+      - equal:
+          path: result
+          value: "1.000000M"
+
+  - it: "k to unitless"
+    set:
+      convert.value: 2.5k
+      convert.to: ""
+    asserts:
+      # unquoted in the stub, so with no unit-letter suffix this is valid YAML number
+      # syntax, not a string — helm-unittest parses the manifest and hands back the
+      # numeric value, not the raw templated text.
+      - equal:
+          path: result
+          value: 2500

--- a/charts/common/tests/tests/helm-chartspec_test.yaml
+++ b/charts/common/tests/tests/helm-chartspec_test.yaml
@@ -1,0 +1,158 @@
+suite: common.helm.chartSpec
+templates:
+  - templates/helm-chartspec-stub.yaml
+release:
+  name: common-test
+tests:
+  - it: no output when repo not set
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: "helm repo, prependReleaseName unset: sourceRef.name is the bare repo name"
+    set:
+      chartSpec.repo: bitnami
+      chartSpec.chart: redis
+      global.helmRepositories.bitnami.url: https://charts.bitnami.com/bitnami
+      global.helmRepositories.bitnami.charts.redis: "20.0.0"
+    asserts:
+      - equal:
+          path: chart
+          value: redis
+      - equal:
+          path: version
+          value: "20.0.0"
+      - equal:
+          path: sourceRef
+          value:
+            kind: HelmRepository
+            name: bitnami
+            namespace: NAMESPACE
+
+  - it: "helm repo, prependReleaseName true: sourceRef.name is release-prefixed"
+    set:
+      chartSpec.repo: bitnami
+      chartSpec.chart: redis
+      chartSpec.prependReleaseName: true
+      global.helmRepositories.bitnami.url: https://charts.bitnami.com/bitnami
+      global.helmRepositories.bitnami.charts.redis: "20.0.0"
+    asserts:
+      - equal:
+          path: sourceRef.name
+          value: common-test-bitnami
+
+  - it: "helm repo, repoNamespace override"
+    set:
+      chartSpec.repo: bitnami
+      chartSpec.chart: redis
+      chartSpec.repoNamespace: flux-system
+      global.helmRepositories.bitnami.url: https://charts.bitnami.com/bitnami
+      global.helmRepositories.bitnami.charts.redis: "20.0.0"
+    asserts:
+      - equal:
+          path: sourceRef.namespace
+          value: flux-system
+
+  - it: "helm repo, unknown chart fails via chartVersion"
+    set:
+      chartSpec.repo: bitnami
+      chartSpec.chart: unknown-chart
+      global.helmRepositories.bitnami.url: https://charts.bitnami.com/bitnami
+      global.helmRepositories.bitnami.charts.redis: "20.0.0"
+    asserts:
+      - failedTemplate:
+          errorMessage: "The repo 'bitnami' is either missing or doesn't contain the chart 'unknown-chart'"
+
+  - it: "git repo, defaults: chart path is charts/<chart>, reconcileStrategy is Revision"
+    set:
+      chartSpec.repo: cpo
+      chartSpec.chart: openstack-cinder-csi
+      global.helmRepositories.cpo.type: git
+      global.helmRepositories.cpo.url: https://github.com/kubernetes/cloud-provider-openstack
+      global.helmRepositories.cpo.charts.openstack-cinder-csi.tag: v1.2.3
+    asserts:
+      - equal:
+          path: chart
+          value: charts/openstack-cinder-csi
+      - equal:
+          path: reconcileStrategy
+          value: Revision
+      - equal:
+          path: sourceRef
+          value:
+            kind: GitRepository
+            name: cpo-openstack-cinder-csi
+            namespace: NAMESPACE
+
+  - it: "git repo, explicit chart path override"
+    set:
+      chartSpec.repo: cpo
+      chartSpec.chart: openstack-cinder-csi
+      global.helmRepositories.cpo.type: git
+      global.helmRepositories.cpo.url: https://github.com/kubernetes/cloud-provider-openstack
+      global.helmRepositories.cpo.charts.openstack-cinder-csi.tag: v1.2.3
+      global.helmRepositories.cpo.charts.openstack-cinder-csi.path: deploy/cinder-csi
+    asserts:
+      - equal:
+          path: chart
+          value: deploy/cinder-csi
+
+  - it: "git repo, reconcileStrategy override"
+    set:
+      chartSpec.repo: cpo
+      chartSpec.chart: openstack-cinder-csi
+      chartSpec.reconcileStrategy: ChartVersion
+      global.helmRepositories.cpo.type: git
+      global.helmRepositories.cpo.url: https://github.com/kubernetes/cloud-provider-openstack
+      global.helmRepositories.cpo.charts.openstack-cinder-csi.tag: v1.2.3
+    asserts:
+      - equal:
+          path: reconcileStrategy
+          value: ChartVersion
+
+  - it: "git repo, prependReleaseName true: sourceRef.name is release-repo-chart prefixed"
+    set:
+      chartSpec.repo: cpo
+      chartSpec.chart: openstack-cinder-csi
+      chartSpec.prependReleaseName: true
+      global.helmRepositories.cpo.type: git
+      global.helmRepositories.cpo.url: https://github.com/kubernetes/cloud-provider-openstack
+      global.helmRepositories.cpo.charts.openstack-cinder-csi.tag: v1.2.3
+    asserts:
+      - equal:
+          path: sourceRef.name
+          value: common-test-cpo-openstack-cinder-csi
+
+  - it: "git repo, repoNamespace override"
+    set:
+      chartSpec.repo: cpo
+      chartSpec.chart: openstack-cinder-csi
+      chartSpec.repoNamespace: flux-system
+      global.helmRepositories.cpo.type: git
+      global.helmRepositories.cpo.url: https://github.com/kubernetes/cloud-provider-openstack
+      global.helmRepositories.cpo.charts.openstack-cinder-csi.tag: v1.2.3
+    asserts:
+      - equal:
+          path: sourceRef.namespace
+          value: flux-system
+
+  - it: matches snapshot for a helm-type chart spec
+    set:
+      chartSpec.repo: bitnami
+      chartSpec.chart: redis
+      global.helmRepositories.bitnami.url: https://charts.bitnami.com/bitnami
+      global.helmRepositories.bitnami.charts.redis: "20.0.0"
+    asserts:
+      - matchSnapshot:
+          path: ""
+
+  - it: matches snapshot for a git-type chart spec
+    set:
+      chartSpec.repo: cpo
+      chartSpec.chart: openstack-cinder-csi
+      global.helmRepositories.cpo.type: git
+      global.helmRepositories.cpo.url: https://github.com/kubernetes/cloud-provider-openstack
+      global.helmRepositories.cpo.charts.openstack-cinder-csi.tag: v1.2.3
+    asserts:
+      - matchSnapshot:
+          path: ""

--- a/charts/common/tests/tests/helm-repositories_test.yaml
+++ b/charts/common/tests/tests/helm-repositories_test.yaml
@@ -1,0 +1,149 @@
+suite: common.helm.repositories
+templates:
+  - templates/helm-repositories-stub.yaml
+release:
+  name: common-test
+tests:
+  - it: no output when no repositories configured
+    set:
+      global.helmRepositories: {}
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders a HelmRepository with default interval
+    set:
+      global.helmRepositories.bitnami.url: https://charts.bitnami.com/bitnami
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HelmRepository
+      - equal:
+          path: metadata.name
+          value: bitnami
+      - equal:
+          path: spec.interval
+          value: 5m
+      - equal:
+          path: spec.url
+          value: https://charts.bitnami.com/bitnami
+      - notExists:
+          path: spec.type
+
+  - it: renders explicit interval override
+    set:
+      global.helmRepositories.bitnami.url: https://charts.bitnami.com/bitnami
+      global.helmRepositories.bitnami.interval: 1h
+    asserts:
+      - equal:
+          path: spec.interval
+          value: 1h
+
+  - it: sets type oci for oci:// urls
+    set:
+      global.helmRepositories.cilium.url: oci://quay.io/cilium/charts
+    asserts:
+      - equal:
+          path: spec.type
+          value: oci
+
+  - it: skips a HelmRepository when condition renders false
+    set:
+      global.helmRepositories.bitnami.url: https://charts.bitnami.com/bitnami
+      global.helmRepositories.bitnami.condition: "{{ .Values.enabled }}"
+      enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: keeps a HelmRepository when condition renders true
+    set:
+      global.helmRepositories.bitnami.url: https://charts.bitnami.com/bitnami
+      global.helmRepositories.bitnami.condition: "{{ .Values.enabled }}"
+      enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: renders one GitRepository per chart for type git
+    set:
+      global.helmRepositories.cpo.type: git
+      global.helmRepositories.cpo.url: https://github.com/kubernetes/cloud-provider-openstack
+      global.helmRepositories.cpo.charts.openstack-cinder-csi.tag: v1.2.3
+      global.helmRepositories.cpo.charts.openstack-cloud-controller-manager.branch: master
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: GitRepository
+          documentIndex: 0
+      - isKind:
+          of: GitRepository
+          documentIndex: 1
+
+  - it: git chart with only a branch ref
+    set:
+      global.helmRepositories.cpo.type: git
+      global.helmRepositories.cpo.url: https://github.com/kubernetes/cloud-provider-openstack
+      global.helmRepositories.cpo.charts.openstack-cinder-csi.branch: master
+    asserts:
+      - equal:
+          path: spec.ref
+          value:
+            branch: master
+
+  - it: git chart with only a commit ref
+    set:
+      global.helmRepositories.cpo.type: git
+      global.helmRepositories.cpo.url: https://github.com/kubernetes/cloud-provider-openstack
+      global.helmRepositories.cpo.charts.openstack-cinder-csi.commit: abc1234
+    asserts:
+      - equal:
+          path: spec.ref
+          value:
+            commit: abc1234
+
+  - it: git chart with only a tag ref
+    set:
+      global.helmRepositories.cpo.type: git
+      global.helmRepositories.cpo.url: https://github.com/kubernetes/cloud-provider-openstack
+      global.helmRepositories.cpo.charts.openstack-cinder-csi.tag: v1.2.3
+    asserts:
+      - equal:
+          path: spec.ref
+          value:
+            tag: v1.2.3
+
+  - it: git chart with only a semver ref
+    set:
+      global.helmRepositories.cpo.type: git
+      global.helmRepositories.cpo.url: https://github.com/kubernetes/cloud-provider-openstack
+      global.helmRepositories.cpo.charts.openstack-cinder-csi.semver: ">=1.2.3"
+    asserts:
+      - equal:
+          path: spec.ref
+          value:
+            semver: ">=1.2.3"
+
+  - it: git chart with no ref option omits spec.ref
+    set:
+      global.helmRepositories.cpo.type: git
+      global.helmRepositories.cpo.url: https://github.com/kubernetes/cloud-provider-openstack
+      global.helmRepositories.cpo.charts.openstack-cinder-csi: {}
+    asserts:
+      - notExists:
+          path: spec.ref
+
+  - it: matches snapshot for a full mixed configuration
+    set:
+      global.helmRepositories.bitnami.url: https://charts.bitnami.com/bitnami
+      global.helmRepositories.cilium.url: oci://quay.io/cilium/charts
+      global.helmRepositories.cilium.charts.cilium: 1.19.5
+      global.helmRepositories.cpo.type: git
+      global.helmRepositories.cpo.url: https://github.com/kubernetes/cloud-provider-openstack
+      global.helmRepositories.cpo.charts.openstack-cinder-csi.tag: v1.2.3
+    asserts:
+      - matchSnapshot:
+          documentIndex: -1
+          path: ""

--- a/charts/common/tests/tests/helm_test.yaml
+++ b/charts/common/tests/tests/helm_test.yaml
@@ -21,6 +21,8 @@ tests:
       - equal:
           path: version
           value: "20.0.0"
+      - matchSnapshot:
+          path: ""
 
   - it: fails when repo is missing from helmRepositories
     set:

--- a/charts/common/tests/tests/images_test.yaml
+++ b/charts/common/tests/tests/images_test.yaml
@@ -35,3 +35,14 @@ tests:
       - equal:
           path: pullPolicy
           value: IfNotPresent
+
+  - it: matches snapshot
+    set:
+      images.app.tag: latest
+      images.sidecar.tag: "sha256@abc123"
+      images.init.tag: latest
+      images.init.digest: "sha256:abc123"
+    asserts:
+      - matchSnapshot:
+          documentIndex: -1
+          path: ""

--- a/charts/common/tests/tests/networkpolicy_test.yaml
+++ b/charts/common/tests/tests/networkpolicy_test.yaml
@@ -1,0 +1,190 @@
+suite: common.networkPolicy
+templates:
+  - templates/networkpolicy-stub.yaml
+release:
+  name: common-test
+tests:
+  - it: "type: auto resolves to cilium when CiliumNetworkPolicy CRD is present"
+    set:
+      networkPolicyType.enabled: true
+      global.networkPolicy.type: auto
+    capabilities:
+      apiVersions:
+        - cilium.io/v2/CiliumNetworkPolicy
+    asserts:
+      - equal:
+          path: type
+          value: cilium
+
+  - it: "type: auto resolves to native when CiliumNetworkPolicy CRD is absent"
+    set:
+      networkPolicyType.enabled: true
+      global.networkPolicy.type: auto
+    asserts:
+      - equal:
+          path: type
+          value: native
+
+  - it: "type: explicit value passes through verbatim"
+    set:
+      networkPolicyType.enabled: true
+      global.networkPolicy.type: none
+    asserts:
+      - equal:
+          path: type
+          value: none
+
+  - it: "identity: falls back to static kube-apiserver identity when konnectivity is absent"
+    set:
+      identity.enabled: true
+    asserts:
+      - matchSnapshot:
+          path: identity
+
+  - it: "identity: uses konnectivity DaemonSet identity when present"
+    set:
+      identity.enabled: true
+    kubernetesProvider:
+      scheme:
+        apps/v1/DaemonSet:
+          gvr:
+            group: apps
+            version: v1
+            resource: daemonsets
+          namespaced: true
+        apps/v1/Deployment:
+          gvr:
+            group: apps
+            version: v1
+            resource: deployments
+          namespaced: true
+      objects:
+        - apiVersion: apps/v1
+          kind: DaemonSet
+          metadata:
+            name: konnectivity-agent
+            namespace: kube-system
+    asserts:
+      - equal:
+          path: identity[0].endpoint.serviceAccount
+          value: konnectivity-agent
+      - equal:
+          path: identity[0].endpoint.namespace
+          value: kube-system
+      - lengthEqual:
+          path: identity
+          count: 1
+
+  - it: "identity: uses konnectivity Deployment identity when present"
+    set:
+      identity.enabled: true
+    kubernetesProvider:
+      scheme:
+        apps/v1/DaemonSet:
+          gvr:
+            group: apps
+            version: v1
+            resource: daemonsets
+          namespaced: true
+        apps/v1/Deployment:
+          gvr:
+            group: apps
+            version: v1
+            resource: deployments
+          namespaced: true
+      objects:
+        - apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: konnectivity-agent
+            namespace: kube-system
+    asserts:
+      - equal:
+          path: identity[0].endpoint.serviceAccount
+          value: konnectivity-agent
+
+  - it: "rule: cilium mode with fallback identity uses fromEntities/fromEndpoints, no ports"
+    set:
+      rule.enabled: true
+      rule.cilium: true
+    asserts:
+      - matchSnapshot:
+          path: rule
+
+  - it: "rule: cilium mode with ports adds toPorts"
+    set:
+      rule.enabled: true
+      rule.cilium: true
+      rule.ports:
+        "10250": TCP
+    asserts:
+      - equal:
+          path: "rule[1].toPorts[0].ports[0]"
+          value:
+            port: "10250"
+            protocol: TCP
+
+  - it: "rule: cilium mode with a list of protocols for one port"
+    set:
+      rule.enabled: true
+      rule.cilium: true
+      rule.ports:
+        "8443":
+          - TCP
+          - UDP
+    asserts:
+      - lengthEqual:
+          path: "rule[1].toPorts[0].ports"
+          count: 2
+
+  - it: "rule: native mode with fallback identity"
+    set:
+      rule.enabled: true
+      rule.cilium: false
+    asserts:
+      - matchSnapshot:
+          path: rule
+
+  - it: "rule: native mode with ports"
+    set:
+      rule.enabled: true
+      rule.cilium: false
+      rule.ports:
+        "10250": TCP
+    asserts:
+      - matchSnapshot:
+          path: rule
+
+  - it: "rule: cilium mode with konnectivity identity uses fromEndpoints on serviceAccount"
+    set:
+      rule.enabled: true
+      rule.cilium: true
+    kubernetesProvider:
+      scheme:
+        apps/v1/DaemonSet:
+          gvr:
+            group: apps
+            version: v1
+            resource: daemonsets
+          namespaced: true
+        apps/v1/Deployment:
+          gvr:
+            group: apps
+            version: v1
+            resource: deployments
+          namespaced: true
+      objects:
+        - apiVersion: apps/v1
+          kind: DaemonSet
+          metadata:
+            name: konnectivity-agent
+            namespace: kube-system
+    asserts:
+      - lengthEqual:
+          path: rule
+          count: 1
+      - equal:
+          path: "rule[0].fromEndpoints[0].matchLabels"
+          value:
+            io.kubernetes.pod.namespace: kube-system
+            io.cilium.k8s.policy.serviceaccount: konnectivity-agent

--- a/charts/common/tests/tests/resources_test.yaml
+++ b/charts/common/tests/tests/resources_test.yaml
@@ -1,0 +1,226 @@
+suite: common.resources
+templates:
+  - templates/resources-stub.yaml
+release:
+  name: common-test
+tests:
+  - it: empty object when nothing configured
+    asserts:
+      - equal:
+          path: resources
+          value: {}
+
+  - it: empty object when preset is explicitly none and no resources given
+    set:
+      resources.resourcesPreset: none
+    asserts:
+      - equal:
+          path: resources
+          value: {}
+
+  - it: uses only explicit resources when no preset given
+    set:
+      resources.resources.requests.cpu: 100m
+    asserts:
+      - equal:
+          path: resources
+          value:
+            requests:
+              cpu: 100m
+
+  - it: preset alone omits cpu limit by default
+    set:
+      resources.resourcesPreset: small
+    asserts:
+      - equal:
+          path: resources.requests
+          value:
+            cpu: 500m
+            memory: 512Mi
+            ephemeral-storage: 50Mi
+      - equal:
+          path: resources.limits
+          value:
+            memory: 768Mi
+            ephemeral-storage: 2Gi
+      - notExists:
+          path: resources.limits.cpu
+
+  - it: setCPULimits true keeps cpu limit from preset
+    set:
+      resources.resourcesPreset: small
+      resources.setCPULimits: true
+    asserts:
+      - equal:
+          path: resources.limits
+          value:
+            cpu: 750m
+            memory: 768Mi
+            ephemeral-storage: 2Gi
+
+  - it: setCPULimits true without a preset has no effect
+    set:
+      resources.setCPULimits: true
+    asserts:
+      - equal:
+          path: resources
+          value: {}
+
+  - it: explicit request field takes precedence over preset, rest fills in from preset
+    set:
+      resources.resources.requests.cpu: 100m
+      resources.resourcesPreset: small
+    asserts:
+      - equal:
+          path: resources.requests
+          value:
+            cpu: 100m
+            memory: 512Mi
+            ephemeral-storage: 50Mi
+
+  - it: explicit limits field takes precedence over preset, rest fills in from preset
+    set:
+      resources.resources.limits.memory: 999Mi
+      resources.resourcesPreset: small
+      resources.setCPULimits: true
+    asserts:
+      - equal:
+          path: resources.limits
+          value:
+            memory: 999Mi
+            cpu: 750m
+            ephemeral-storage: 2Gi
+
+  - it: fails on unknown preset
+    set:
+      resources.resourcesPreset: unobtainium
+    asserts:
+      - failedTemplate:
+          errorPattern: "ERROR: Preset key 'unobtainium' invalid\\."
+
+  - it: matches snapshot for preset + explicit override + setCPULimits
+    set:
+      resources.resources.requests.cpu: 100m
+      resources.resources.limits.memory: 999Mi
+      resources.resourcesPreset: medium
+      resources.setCPULimits: true
+    asserts:
+      - matchSnapshot:
+          path: ""
+
+  # Combinatorial sweep: every combination of {no resources, explicit resources} x
+  # {no preset, "none", "small"} x {setCPULimits unset, false, true}. Real resource
+  # values only change with the preset axis, so cases pin the SHAPE (which keys exist)
+  # instead of the exact numbers already covered above.
+  - it: "matrix: explicit=no preset=no cpuLimits=unset"
+    asserts:
+      - equal:
+          path: resources
+          value: {}
+
+  - it: "matrix: explicit=no preset=no cpuLimits=false"
+    set:
+      resources.setCPULimits: false
+    asserts:
+      - equal:
+          path: resources
+          value: {}
+
+  - it: "matrix: explicit=no preset=no cpuLimits=true"
+    set:
+      resources.setCPULimits: true
+    asserts:
+      - equal:
+          path: resources
+          value: {}
+
+  - it: "matrix: explicit=no preset=none cpuLimits=unset"
+    set:
+      resources.resourcesPreset: none
+    asserts:
+      - equal:
+          path: resources
+          value: {}
+
+  - it: "matrix: explicit=no preset=none cpuLimits=true"
+    set:
+      resources.resourcesPreset: none
+      resources.setCPULimits: true
+    asserts:
+      - equal:
+          path: resources
+          value: {}
+
+  - it: "matrix: explicit=no preset=small cpuLimits=unset"
+    set:
+      resources.resourcesPreset: small
+    asserts:
+      - notExists:
+          path: resources.limits.cpu
+      - exists:
+          path: resources.requests.cpu
+
+  - it: "matrix: explicit=no preset=small cpuLimits=false"
+    set:
+      resources.resourcesPreset: small
+      resources.setCPULimits: false
+    asserts:
+      - notExists:
+          path: resources.limits.cpu
+
+  - it: "matrix: explicit=no preset=small cpuLimits=true"
+    set:
+      resources.resourcesPreset: small
+      resources.setCPULimits: true
+    asserts:
+      - exists:
+          path: resources.limits.cpu
+
+  - it: "matrix: explicit=yes preset=no cpuLimits=unset"
+    set:
+      resources.resources.requests.memory: 1Gi
+    asserts:
+      - equal:
+          path: resources
+          value:
+            requests:
+              memory: 1Gi
+
+  - it: "matrix: explicit=yes preset=none cpuLimits=unset"
+    set:
+      resources.resources.requests.memory: 1Gi
+      resources.resourcesPreset: none
+    asserts:
+      - equal:
+          path: resources
+          value:
+            requests:
+              memory: 1Gi
+
+  - it: "matrix: explicit=yes preset=small cpuLimits=false"
+    set:
+      resources.resources.requests.memory: 1Gi
+      resources.resourcesPreset: small
+      resources.setCPULimits: false
+    asserts:
+      - equal:
+          path: resources.requests.memory
+          value: 1Gi
+      - equal:
+          path: resources.requests.cpu
+          value: 500m
+      - notExists:
+          path: resources.limits.cpu
+
+  - it: "matrix: explicit=yes preset=small cpuLimits=true"
+    set:
+      resources.resources.requests.memory: 1Gi
+      resources.resourcesPreset: small
+      resources.setCPULimits: true
+    asserts:
+      - equal:
+          path: resources.requests.memory
+          value: 1Gi
+      - equal:
+          path: resources.limits.cpu
+          value: 750m

--- a/charts/common/tests/tests/telemetry_test.yaml
+++ b/charts/common/tests/tests/telemetry_test.yaml
@@ -75,6 +75,8 @@ tests:
       - equal:
           path: endpoint
           value: http://alloy.monitoring:4317
+      - matchSnapshot:
+          path: ""
 
   - it: does not expose serviceName/serviceNamespace for an explicit external endpoint
     set:

--- a/charts/common/tests/values.yaml
+++ b/charts/common/tests/values.yaml
@@ -1,1 +1,25 @@
-{}
+resources: {}
+
+networkPolicyType:
+  enabled: false
+
+identity:
+  enabled: false
+
+rule:
+  enabled: false
+  cilium: false
+  ports: {}
+
+chartSpec: {}
+
+convertRoundtrip:
+  enabled: false
+
+# real consuming charts always declare these under global themselves; the fake client / plain
+# `helm template` doesn't auto-populate `global`, so it must be set here to avoid nil-pointer
+# chained access in helpers that read `.Values.global.*` directly (no `dig`/`default` guard).
+global:
+  helmRepositories: {}
+  networkPolicy: {}
+


### PR DESCRIPTION
## Summary
- Adds `matchSnapshot` pinning to every existing suite so any output drift fails CI, not just the fields a test happened to assert on.
- Adds missing stub/test coverage for `common.resources`, `common.networkPolicy.*`, `common.helm.repositories`, and `common.helm.chartSpec`, including exhaustive combinatorial cases for their independent boolean/enum inputs.
- Adds a wide, deliberately-adversarial table of `common.convert` cases (fractional values, magnitude-boundary values) plus a genuine per-run round-trip property check using sprig's `randInt` (no external script — see `charts/common/CLAUDE.md`).
- New `charts/common/CLAUDE.md` documenting the testing conventions for this chart (impromptu `tests/` chart, snapshotting, combinatorial coverage, native randomness gotchas).

## Bugs found and fixed along the way
- `common.convert` used sprig's `mul` (int64) instead of `mulf` (float64) for the byte-conversion step, silently truncating fractional inputs and overflowing/wrapping negative for exabyte-scale factors.
- `common.networkPolicy.rule.from.kube-apiserver` emitted a broken null-selector NetworkPolicy rule in native (non-cilium) mode for the entity-only kube-apiserver fallback identity — native NetworkPolicy has no equivalent to cilium's abstract entity selector, so that identity is now skipped in native mode instead of emitting `podSelector: {matchLabels: null}`. Never hit in practice since every current caller passes `cilium: true`.

## Test plan
- [x] `go-task chart:test CHART=common` passes (9 suites, 94 tests, 16 snapshots)
- [x] Round-trip fuzz check stress-tested with 300+ repeated renders and 40 repeated `helm unittest` runs for stability