### PR TITLE
fix(t8s-cluster): add missing dependsOn on cinder-csi CiliumNetworkPolicy HelmRelease

### DIFF
--- a/charts/t8s-cluster/templates/workload-cluster/_helmRelease.yaml
+++ b/charts/t8s-cluster/templates/workload-cluster/_helmRelease.yaml
@@ -19,6 +19,9 @@ spec:
   interval: 1h
   driftDetection:
     mode: enabled
+  {{- with .dependsOn }}
+  dependsOn: {{ toYaml . | nindent 4 }}
+  {{- end }}
   kubeConfig:
     secretRef:
       name: {{ .Release.Name }}-kubeconfig

--- a/charts/t8s-cluster/templates/workload-cluster/cinder-csi-plugin/ciliumNetworkPolicy.yaml
+++ b/charts/t8s-cluster/templates/workload-cluster/cinder-csi-plugin/ciliumNetworkPolicy.yaml
@@ -1,5 +1,5 @@
 {{- if eq (include "t8s-cluster.cni" .) "cilium" -}}
-  {{- include "t8s-cluster.helm.resourceIntoCluster" (dict "name" "openstack-cinder-csi" "resource" (include "t8s-cluster.networkPolicy.cinder-csi" (dict)) "context" $ "additionalLabels" (dict "app.kubernetes.io/component" "cinder-csi")) | nindent 0 }}
+  {{- include "t8s-cluster.helm.resourceIntoCluster" (dict "name" "openstack-cinder-csi" "resource" (include "t8s-cluster.networkPolicy.cinder-csi" (dict)) "context" $ "additionalLabels" (dict "app.kubernetes.io/component" "cinder-csi") "dependsOn" (list (dict "name" (printf "%s-cni" $.Release.Name) "namespace" $.Release.Namespace))) | nindent 0 }}
 {{- end }}
 
 {{- define "t8s-cluster.networkPolicy.cinder-csi" -}}


### PR DESCRIPTION
## Summary
- The sub-`HelmRelease` created by `ciliumNetworkPolicy.yaml` for `openstack-cinder-csi` had no `dependsOn` on the CNI HelmRelease, so Flux could reconcile it before Cilium's CRDs exist on a fresh workload cluster, failing with `no matches for kind "CiliumNetworkPolicy" in version "cilium.io/v2"`.
- The sub-release self-heals via infinite retries, but often only after the umbrella `t8s-cluster` HelmRelease's 5-minute install timeout has already fired, tearing down an otherwise-healthy cluster. This is believed to be the primary cause of flaky nightly t8s KaaS certification failures.
- Extended the shared `_helmRelease.yaml` partial (`t8s-cluster.helm.resourceIntoCluster`) to emit `spec.dependsOn` when a `dependsOn` key is passed, and pass it from `ciliumNetworkPolicy.yaml`, mirroring the sibling `cinder-csi-plugin.yaml` HelmRelease.

## Test plan
- [x] `helm template` on `charts/t8s-cluster` confirms `test-openstack-cinder-csi` HelmRelease now renders `dependsOn: [{name: test-cni, namespace: default}]`
- [x] Confirmed other call sites of the shared partial (e.g. `etcd-defrag`, `teuto-rbac`) are unaffected — no `dependsOn` emitted when not passed
- [x] `CHART=t8s-cluster go-task chart:test` passes (pre-existing unrelated failures in `cluster_guards_test.yaml` targeting `management-cluster/cluster.yaml` are untouched by this change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved workload cluster deployment reliability by honoring configured component dependencies.
  - Ensured the Cinder CSI plugin is deployed after its required CNI component in the same namespace.
  - Added support for rendering release dependencies when they are specified in the cluster configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->