### PR TITLE
feat(t8s-cluster): set HelmRelease intervals dynamically based on readiness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@ Try to keep this CLAUDE file up to date with any gotchas you encounter while wor
 - A scheme-registered GVR with a LIST-style `lookup` (empty name arg) and zero matching objects panics with the same error, even though the scheme entry exists. Fix: register at least one (even non-matching) dummy object of that kind, or skip the lookup entirely with an explicit override value.
 - GET-style `lookup` (name given) has no such restriction.
 - `kubernetesProvider.scheme` keys and `gvr.group/version/resource` values are unquoted by convention in this repo (e.g. `apps/v1/DaemonSet`, `group: apps`) — no quotes needed even for CRD groups with dots/slashes.
+- Testing "does resource X exist / is it ready" logic (a GET-style `lookup` by name) only needs `kubernetesProvider` on the specific `it:` cases that assert against a live object — the default (no `kubernetesProvider`) case already exercises the "doesn't exist" branch, since unmocked `lookup` returns nil.
 
 ## Go template gotchas
 

--- a/charts/t8s-cluster/templates/_helpers.tpl
+++ b/charts/t8s-cluster/templates/_helpers.tpl
@@ -15,6 +15,19 @@
   {{- $hasGPUFlavor | ternary true "" -}}
 {{- end -}}
 
+{{- define "t8s-cluster.helm.dynamicInterval" -}}
+  {{- $existing := lookup "helm.toolkit.fluxcd.io/v2" "HelmRelease" .namespace .name -}}
+  {{- $ready := false -}}
+  {{- if $existing -}}
+    {{- range (dig "status" "conditions" (list) $existing) -}}
+      {{- if and (eq .type "Ready") (eq .status "True") -}}
+        {{- $ready = true -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+  {{- $ready | ternary "1h" "10s" -}}
+{{- end -}}
+
 {{- define "t8s-cluster.cni" -}}
   {{- if eq .Values.cni "auto" -}}
     {{- if lookup "kustomize.toolkit.fluxcd.io/v1" "Kustomization" .Release.Namespace (printf "%s-cni" .Release.Name) -}}

--- a/charts/t8s-cluster/templates/management-cluster/autoscaler.yaml
+++ b/charts/t8s-cluster/templates/management-cluster/autoscaler.yaml
@@ -6,17 +6,19 @@
     {{- $enabled = true -}}
   {{- end }}
 {{- end }}
-{{- if $enabled -}}
+{{- $kubeconfigSecret := printf "%s-kubeconfig" .Release.Name -}}
+{{- if and $enabled (lookup "v1" "Secret" .Release.Namespace $kubeconfigSecret) -}}
+{{- $name := printf "%s-autoscaler" .Release.Name -}}
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: {{ printf "%s-autoscaler" .Release.Name }}
+  name: {{ $name }}
   namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
 spec:
   chart:
     spec: {{- include "common.helm.chartSpec" (dict "repo" "autoscaler" "repoNamespace" "flux-system" "chart" "cluster-autoscaler" "context" $) | nindent 6 }}
-  interval: 1h
+  interval: {{ include "t8s-cluster.helm.dynamicInterval" (dict "name" $name "namespace" .Release.Namespace) }}
   driftDetection:
     mode: enabled
   values:
@@ -26,7 +28,7 @@ spec:
     cloudProvider: clusterapi
     # workload-management
     clusterAPIMode: kubeconfig-incluster
-    clusterAPIKubeconfigSecret: {{ .Release.Name }}-kubeconfig
+    clusterAPIKubeconfigSecret: {{ $kubeconfigSecret }}
     extraArgs:
       scale-down-utilization-threshold: 0.8
       skip-nodes-with-local-storage: false

--- a/charts/t8s-cluster/templates/workload-cluster/_helmRelease.yaml
+++ b/charts/t8s-cluster/templates/workload-cluster/_helmRelease.yaml
@@ -1,9 +1,10 @@
 {{- define "t8s-cluster.helm.resourceIntoCluster" -}}
   {{- $_ := mustMerge . (pick .context "Values" "Release" "Chart") -}}
+  {{- $name := printf "%s-%s" .Release.Name .name -}}
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: {{ printf "%s-%s" .Release.Name .name }}
+  name: {{ $name }}
   namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- with .additionalLabels }}{{- toYaml . | nindent 4 }}{{- end }}
@@ -16,7 +17,7 @@ spec:
         kind: HelmRepository
         name: cetic
         namespace: flux-system
-  interval: 1h
+  interval: {{ include "t8s-cluster.helm.dynamicInterval" (dict "name" $name "namespace" .Release.Namespace) }}
   driftDetection:
     mode: enabled
   {{- with .dependsOn }}

--- a/charts/t8s-cluster/templates/workload-cluster/cinder-csi-plugin/cinder-csi-plugin.yaml
+++ b/charts/t8s-cluster/templates/workload-cluster/cinder-csi-plugin/cinder-csi-plugin.yaml
@@ -1,9 +1,10 @@
 {{- $repoCharts := (index .Values.global.helmRepositories "cloud-provider-openstack").charts -}}
 {{- $selectedVersion := default (index $repoCharts "openstack-cinder-csi") (index $repoCharts (printf "openstack-cinder-csi 2.%d.x" ($.Values.version.minor | int))) -}}
+{{- $name := printf "%s-csi" .Release.Name -}}
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: {{ printf "%s-csi" .Release.Name }}
+  name: {{ $name }}
   namespace: {{ .Release.Namespace}}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: cinder-csi
@@ -16,7 +17,7 @@ spec:
         name: cloud-provider-openstack
         namespace: flux-system
       version: {{ $selectedVersion | quote }}
-  interval: 1h
+  interval: {{ include "t8s-cluster.helm.dynamicInterval" (dict "name" $name "namespace" .Release.Namespace) }}
   driftDetection:
     mode: enabled
   {{- if eq (include "t8s-cluster.cni" .) "cilium" }}

--- a/charts/t8s-cluster/templates/workload-cluster/cloud-controller-manager.yaml
+++ b/charts/t8s-cluster/templates/workload-cluster/cloud-controller-manager.yaml
@@ -1,9 +1,10 @@
 {{- $repoCharts := (index .Values.global.helmRepositories "cloud-provider-openstack").charts -}}
 {{- $selectedVersion := default (index $repoCharts "openstack-cloud-controller-manager") (index $repoCharts (printf "openstack-cloud-controller-manager 2.%d.x" ($.Values.version.minor | int))) -}}
+{{- $name := printf "%s-ccm" .Release.Name -}}
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: {{ printf "%s-ccm" .Release.Name }}
+  name: {{ $name }}
   namespace: {{ .Release.Namespace}}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
 spec:
@@ -15,7 +16,7 @@ spec:
         name: cloud-provider-openstack
         namespace: flux-system
       version: {{ $selectedVersion | quote }}
-  interval: 1h
+  interval: {{ include "t8s-cluster.helm.dynamicInterval" (dict "name" $name "namespace" .Release.Namespace) }}
   driftDetection:
     mode: enabled
   {{- if eq (include "t8s-cluster.cni" .) "cilium" }}

--- a/charts/t8s-cluster/templates/workload-cluster/cni-cilium.yaml
+++ b/charts/t8s-cluster/templates/workload-cluster/cni-cilium.yaml
@@ -1,14 +1,15 @@
 {{- if eq (include "t8s-cluster.cni" .) "cilium" }}
+{{- $name := printf "%s-cni" .Release.Name }}
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: {{ printf "%s-cni" .Release.Name }}
+  name: {{ $name }}
   namespace: {{ .Release.Namespace}}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
 spec:
   chart:
     spec: {{- include "common.helm.chartSpec" (dict "repo" "cilium" "repoNamespace" "flux-system" "chart" "cilium" "context" $) | nindent 6 }}
-  interval: 1h
+  interval: {{ include "t8s-cluster.helm.dynamicInterval" (dict "name" $name "namespace" .Release.Namespace) }}
   driftDetection:
     mode: enabled
   kubeConfig:

--- a/charts/t8s-cluster/templates/workload-cluster/gpu-operator.yaml
+++ b/charts/t8s-cluster/templates/workload-cluster/gpu-operator.yaml
@@ -1,14 +1,15 @@
 {{- if eq (include "t8s-cluster.hasGPUNodes" (dict "context" $)) "true" }}
+{{- $name := printf "%s-gpu-operator" .Release.Name }}
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: {{ printf "%s-gpu-operator" .Release.Name }}
+  name: {{ $name }}
   namespace: {{ .Release.Namespace}}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
 spec:
   chart:
     spec: {{- include "common.helm.chartSpec" (dict "repo" "nvidia" "repoNamespace" "flux-system" "chart" "gpu-operator" "context" $) | nindent 6 }}
-  interval: 1h
+  interval: {{ include "t8s-cluster.helm.dynamicInterval" (dict "name" $name "namespace" .Release.Namespace) }}
   driftDetection:
     mode: enabled
   kubeConfig:

--- a/charts/t8s-cluster/tests/autoscaler_test.yaml
+++ b/charts/t8s-cluster/tests/autoscaler_test.yaml
@@ -1,0 +1,145 @@
+suite: autoscaler gating and interval
+templates:
+  - templates/management-cluster/autoscaler.yaml
+release:
+  name: my-cluster
+tests:
+  - it: no output when no nodePool has maxReplicas above replicas
+    set:
+      nodePools.workers.flavor: m1.medium
+      nodePools.workers.replicas: 3
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: no output when enabled but the kubeconfig secret does not exist
+    set:
+      nodePools.workers.flavor: m1.medium
+      nodePools.workers.replicas: 1
+      nodePools.workers.maxReplicas: 3
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders HelmRelease when enabled and the kubeconfig secret exists
+    set:
+      nodePools.workers.flavor: m1.medium
+      nodePools.workers.replicas: 1
+      nodePools.workers.maxReplicas: 3
+    kubernetesProvider:
+      scheme:
+        v1/Secret:
+          gvr:
+            version: v1
+            resource: secrets
+          namespaced: true
+      objects:
+        - apiVersion: v1
+          kind: Secret
+          metadata:
+            name: my-cluster-kubeconfig
+            namespace: NAMESPACE
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HelmRelease
+
+  - it: interval is 10s when the HelmRelease does not exist yet
+    set:
+      nodePools.workers.flavor: m1.medium
+      nodePools.workers.replicas: 1
+      nodePools.workers.maxReplicas: 3
+    kubernetesProvider:
+      scheme:
+        v1/Secret:
+          gvr:
+            version: v1
+            resource: secrets
+          namespaced: true
+      objects:
+        - apiVersion: v1
+          kind: Secret
+          metadata:
+            name: my-cluster-kubeconfig
+            namespace: NAMESPACE
+    asserts:
+      - equal:
+          path: spec.interval
+          value: 10s
+
+  - it: interval is 10s when the HelmRelease exists but is not ready
+    set:
+      nodePools.workers.flavor: m1.medium
+      nodePools.workers.replicas: 1
+      nodePools.workers.maxReplicas: 3
+    kubernetesProvider:
+      scheme:
+        v1/Secret:
+          gvr:
+            version: v1
+            resource: secrets
+          namespaced: true
+        helm.toolkit.fluxcd.io/v2/HelmRelease:
+          gvr:
+            group: helm.toolkit.fluxcd.io
+            version: v2
+            resource: helmreleases
+          namespaced: true
+      objects:
+        - apiVersion: v1
+          kind: Secret
+          metadata:
+            name: my-cluster-kubeconfig
+            namespace: NAMESPACE
+        - apiVersion: helm.toolkit.fluxcd.io/v2
+          kind: HelmRelease
+          metadata:
+            name: my-cluster-autoscaler
+            namespace: NAMESPACE
+          status:
+            conditions:
+              - type: Ready
+                status: "False"
+    asserts:
+      - equal:
+          path: spec.interval
+          value: 10s
+
+  - it: interval is 1h when the HelmRelease exists and is ready
+    set:
+      nodePools.workers.flavor: m1.medium
+      nodePools.workers.replicas: 1
+      nodePools.workers.maxReplicas: 3
+    kubernetesProvider:
+      scheme:
+        v1/Secret:
+          gvr:
+            version: v1
+            resource: secrets
+          namespaced: true
+        helm.toolkit.fluxcd.io/v2/HelmRelease:
+          gvr:
+            group: helm.toolkit.fluxcd.io
+            version: v2
+            resource: helmreleases
+          namespaced: true
+      objects:
+        - apiVersion: v1
+          kind: Secret
+          metadata:
+            name: my-cluster-kubeconfig
+            namespace: NAMESPACE
+        - apiVersion: helm.toolkit.fluxcd.io/v2
+          kind: HelmRelease
+          metadata:
+            name: my-cluster-autoscaler
+            namespace: NAMESPACE
+          status:
+            conditions:
+              - type: Ready
+                status: "True"
+    asserts:
+      - equal:
+          path: spec.interval
+          value: 1h

--- a/charts/t8s-cluster/tests/cinder_csi_plugin_test.yaml
+++ b/charts/t8s-cluster/tests/cinder_csi_plugin_test.yaml
@@ -1,10 +1,10 @@
-suite: CNI cilium explicit selection
+suite: cinder-csi-plugin
 templates:
-  - templates/workload-cluster/cni-cilium.yaml
+  - templates/workload-cluster/cinder-csi-plugin/cinder-csi-plugin.yaml
 release:
   name: my-cluster
 tests:
-  - it: renders HelmRelease when cni is cilium
+  - it: renders HelmRelease
     set:
       cni: cilium
     asserts:
@@ -36,7 +36,7 @@ tests:
         - apiVersion: helm.toolkit.fluxcd.io/v2
           kind: HelmRelease
           metadata:
-            name: my-cluster-cni
+            name: my-cluster-csi
             namespace: NAMESPACE
           status:
             conditions:
@@ -62,7 +62,7 @@ tests:
         - apiVersion: helm.toolkit.fluxcd.io/v2
           kind: HelmRelease
           metadata:
-            name: my-cluster-cni
+            name: my-cluster-csi
             namespace: NAMESPACE
           status:
             conditions:
@@ -72,33 +72,3 @@ tests:
       - equal:
           path: spec.interval
           value: 1h
-
-  - it: no output when cni is calico
-    set:
-      cni: calico
-    asserts:
-      - hasDocuments:
-          count: 0
-
----
-suite: CNI calico explicit selection
-templates:
-  - templates/workload-cluster/cni-calico.yaml
-release:
-  name: my-cluster
-tests:
-  - it: renders Kustomization when cni is calico
-    set:
-      cni: calico
-    asserts:
-      - hasDocuments:
-          count: 1
-      - isKind:
-          of: Kustomization
-
-  - it: no output when cni is cilium
-    set:
-      cni: cilium
-    asserts:
-      - hasDocuments:
-          count: 0

--- a/charts/t8s-cluster/tests/cloud_controller_manager_test.yaml
+++ b/charts/t8s-cluster/tests/cloud_controller_manager_test.yaml
@@ -1,10 +1,10 @@
-suite: CNI cilium explicit selection
+suite: cloud-controller-manager
 templates:
-  - templates/workload-cluster/cni-cilium.yaml
+  - templates/workload-cluster/cloud-controller-manager.yaml
 release:
   name: my-cluster
 tests:
-  - it: renders HelmRelease when cni is cilium
+  - it: renders HelmRelease
     set:
       cni: cilium
     asserts:
@@ -36,7 +36,7 @@ tests:
         - apiVersion: helm.toolkit.fluxcd.io/v2
           kind: HelmRelease
           metadata:
-            name: my-cluster-cni
+            name: my-cluster-ccm
             namespace: NAMESPACE
           status:
             conditions:
@@ -62,7 +62,7 @@ tests:
         - apiVersion: helm.toolkit.fluxcd.io/v2
           kind: HelmRelease
           metadata:
-            name: my-cluster-cni
+            name: my-cluster-ccm
             namespace: NAMESPACE
           status:
             conditions:
@@ -72,33 +72,3 @@ tests:
       - equal:
           path: spec.interval
           value: 1h
-
-  - it: no output when cni is calico
-    set:
-      cni: calico
-    asserts:
-      - hasDocuments:
-          count: 0
-
----
-suite: CNI calico explicit selection
-templates:
-  - templates/workload-cluster/cni-calico.yaml
-release:
-  name: my-cluster
-tests:
-  - it: renders Kustomization when cni is calico
-    set:
-      cni: calico
-    asserts:
-      - hasDocuments:
-          count: 1
-      - isKind:
-          of: Kustomization
-
-  - it: no output when cni is cilium
-    set:
-      cni: cilium
-    asserts:
-      - hasDocuments:
-          count: 0

--- a/charts/t8s-cluster/tests/etcd_test.yaml
+++ b/charts/t8s-cluster/tests/etcd_test.yaml
@@ -18,6 +18,60 @@ tests:
       - isKind:
           of: HelmRelease
 
+  - it: interval is 10s when the HelmRelease does not exist yet
+    asserts:
+      - equal:
+          path: spec.interval
+          value: 10s
+
+  - it: interval is 10s when the HelmRelease exists but is not ready
+    kubernetesProvider:
+      scheme:
+        helm.toolkit.fluxcd.io/v2/HelmRelease:
+          gvr:
+            group: helm.toolkit.fluxcd.io
+            version: v2
+            resource: helmreleases
+          namespaced: true
+      objects:
+        - apiVersion: helm.toolkit.fluxcd.io/v2
+          kind: HelmRelease
+          metadata:
+            name: my-cluster-etcd-defrag
+            namespace: NAMESPACE
+          status:
+            conditions:
+              - type: Ready
+                status: "False"
+    asserts:
+      - equal:
+          path: spec.interval
+          value: 10s
+
+  - it: interval is 1h when the HelmRelease exists and is ready
+    kubernetesProvider:
+      scheme:
+        helm.toolkit.fluxcd.io/v2/HelmRelease:
+          gvr:
+            group: helm.toolkit.fluxcd.io
+            version: v2
+            resource: helmreleases
+          namespaced: true
+      objects:
+        - apiVersion: helm.toolkit.fluxcd.io/v2
+          kind: HelmRelease
+          metadata:
+            name: my-cluster-etcd-defrag
+            namespace: NAMESPACE
+          status:
+            conditions:
+              - type: Ready
+                status: "True"
+    asserts:
+      - equal:
+          path: spec.interval
+          value: 1h
+
 ---
 suite: etcd-backup gating
 templates:

--- a/charts/t8s-cluster/tests/gpu_operator_test.yaml
+++ b/charts/t8s-cluster/tests/gpu_operator_test.yaml
@@ -29,3 +29,66 @@ tests:
     asserts:
       - hasDocuments:
           count: 1
+
+  - it: interval is 10s when the HelmRelease does not exist yet
+    set:
+      nodePools.gpuworkers.flavor: m1.gpu-large
+      nodePools.gpuworkers.replicas: 1
+    asserts:
+      - equal:
+          path: spec.interval
+          value: 10s
+
+  - it: interval is 10s when the HelmRelease exists but is not ready
+    set:
+      nodePools.gpuworkers.flavor: m1.gpu-large
+      nodePools.gpuworkers.replicas: 1
+    kubernetesProvider:
+      scheme:
+        helm.toolkit.fluxcd.io/v2/HelmRelease:
+          gvr:
+            group: helm.toolkit.fluxcd.io
+            version: v2
+            resource: helmreleases
+          namespaced: true
+      objects:
+        - apiVersion: helm.toolkit.fluxcd.io/v2
+          kind: HelmRelease
+          metadata:
+            name: my-cluster-gpu-operator
+            namespace: NAMESPACE
+          status:
+            conditions:
+              - type: Ready
+                status: "False"
+    asserts:
+      - equal:
+          path: spec.interval
+          value: 10s
+
+  - it: interval is 1h when the HelmRelease exists and is ready
+    set:
+      nodePools.gpuworkers.flavor: m1.gpu-large
+      nodePools.gpuworkers.replicas: 1
+    kubernetesProvider:
+      scheme:
+        helm.toolkit.fluxcd.io/v2/HelmRelease:
+          gvr:
+            group: helm.toolkit.fluxcd.io
+            version: v2
+            resource: helmreleases
+          namespaced: true
+      objects:
+        - apiVersion: helm.toolkit.fluxcd.io/v2
+          kind: HelmRelease
+          metadata:
+            name: my-cluster-gpu-operator
+            namespace: NAMESPACE
+          status:
+            conditions:
+              - type: Ready
+                status: "True"
+    asserts:
+      - equal:
+          path: spec.interval
+          value: 1h


### PR DESCRIPTION
## Summary
- New/not-yet-ready HelmReleases (install path, or existing but not `Ready`) reconcile every 10s instead of the static 1h; once `Ready=True` they settle back to 1h. Applies to all 6 places `t8s-cluster` renders a `HelmRelease` (shared `_helmRelease.yaml` helper, `autoscaler.yaml`, `cni-cilium.yaml`, `gpu-operator.yaml`, `cloud-controller-manager.yaml`, `cinder-csi-plugin.yaml`).
- The autoscaler `HelmRelease` is now only rendered once its referenced kubeconfig secret actually exists, in addition to the existing nodePool-scaling gate.

## Test plan
- [x] `helm unittest charts/t8s-cluster` — 53/53 passing (new + extended suites cover not-exists / exists-not-ready / exists-ready interval states, and the autoscaler secret gating)
- [x] `helm lint charts/t8s-cluster` clean
- [x] Manual `helm template` render confirms `interval: 10s` with no live cluster, and autoscaler absent without a kubeconfig secret

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Helm-based components now reconcile every 10 seconds while unavailable or not ready, improving responsiveness during startup and recovery.
  * Reconciliation automatically changes to a 1-hour interval once components report ready.
  * Autoscaler resources are created only when scaling is enabled and required credentials are available.

* **Tests**
  * Added coverage for readiness-based intervals, resource prerequisites, and HelmRelease rendering across cluster components.

* **Documentation**
  * Documented testing guidance for resource existence and readiness scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->