### PR TITLE
chore(renovate): remove GitLab registry hostRules

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -47,19 +47,6 @@
       "registryUrlTemplate": "https://{{{ociUrl}}}"
     }
   ],
-  "hostRules": [
-    {
-      "matchHost": "registry-gitlab.teuto.net",
-      "username": "github-renovate",
-      "password": "{{ secrets.TEUTONET_GITLAB_PULL_PASSWORD }}"
-    },
-    {
-      "matchHost": "https://registry-gitlab.teuto.net/4teuto/dev/teuto-portal/teuto-portal-k8s-worker/teuto-portal-k8s-worker",
-      "hostType": "docker",
-      "username": "github-renovate",
-      "password": "{{ secrets.TEUTONET_GITLAB_PULL_PASSWORD }}"
-    }
-  ],
   "packageRules": [
     {
       "matchFileNames": [


### PR DESCRIPTION
## Summary
- Removes the two `hostRules` entries for `registry-gitlab.teuto.net` from `.github/renovate.json`
- Credentials/host rules for that registry are being configured directly on the Mend developer portal instead

## Test plan
- [ ] Confirm the equivalent hostRules (including the JWT auth host `gitlab.teuto.net`, with a token scoped to project `teuto-portal-k8s-worker` at Reporter role or higher) are configured on the Mend developer portal before/at merge, so digest lookups for `teuto-portal-k8s-worker` keep working

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed automated registry authentication configuration.
  * No user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->