### PR TITLE
feat(t8s-cluster): add cluster.x-k8s.io/cluster-cloud annotation to nodes

### DIFF
--- a/charts/t8s-cluster/templates/management-cluster/clusterClass/clusterClass.yaml
+++ b/charts/t8s-cluster/templates/management-cluster/clusterClass/clusterClass.yaml
@@ -11,6 +11,9 @@ metadata:
 spec:
   controlPlane:
     {{- if not .Values.controlPlane.hosted }}
+    metadata:
+      annotations:
+        cluster.x-k8s.io/cluster-cloud: {{ .Values.cloud }}
     healthCheck:
       remediation:
         triggerIf:
@@ -145,6 +148,8 @@ spec:
         metadata:
           labels:
             node-role.kubernetes.io/compute-plane: ""
+          annotations:
+            cluster.x-k8s.io/cluster-cloud: {{ $.Values.cloud }}
         healthCheck:
           checks:
             nodeStartupTimeoutSeconds: 480


### PR DESCRIPTION
## Summary
- Add `cluster.x-k8s.io/cluster-cloud` annotation (value from `.Values.cloud`) to `ClusterClass.spec.controlPlane.metadata` and both `workers.machineDeployments[].metadata` entries
- Cluster API syncs Machine annotations fully to the corresponding Node objects, so this lands on every control-plane and compute-plane node

## Test plan
- [x] `helm template` shows the annotation rendered on control-plane and both compute-plane/gpu-compute-plane classes
- [x] `go-task chart:test CHART=t8s-cluster` — 53/53 tests pass
- [x] `go-task chart:lint CHART=t8s-cluster` — all CI values variants (incl. hosted control plane) pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cloud metadata to non-hosted control-plane and worker machine deployments.
  * Enables improved identification and management of clusters by their configured cloud provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->