### PR TITLE
test(t8s-cluster): hoist shared kubernetesProvider scheme to suite level

### DIFF
--- a/charts/t8s-cluster/tests/autoscaler_test.yaml
+++ b/charts/t8s-cluster/tests/autoscaler_test.yaml
@@ -3,6 +3,19 @@ templates:
   - templates/management-cluster/autoscaler.yaml
 release:
   name: my-cluster
+kubernetesProvider:
+  scheme:
+    v1/Secret:
+      gvr:
+        version: v1
+        resource: secrets
+      namespaced: true
+    helm.toolkit.fluxcd.io/v2/HelmRelease:
+      gvr:
+        group: helm.toolkit.fluxcd.io
+        version: v2
+        resource: helmreleases
+      namespaced: true
 tests:
   - it: no output when no nodePool has maxReplicas above replicas
     set:
@@ -27,12 +40,6 @@ tests:
       nodePools.workers.replicas: 1
       nodePools.workers.maxReplicas: 3
     kubernetesProvider:
-      scheme:
-        v1/Secret:
-          gvr:
-            version: v1
-            resource: secrets
-          namespaced: true
       objects:
         - apiVersion: v1
           kind: Secret
@@ -51,12 +58,6 @@ tests:
       nodePools.workers.replicas: 1
       nodePools.workers.maxReplicas: 3
     kubernetesProvider:
-      scheme:
-        v1/Secret:
-          gvr:
-            version: v1
-            resource: secrets
-          namespaced: true
       objects:
         - apiVersion: v1
           kind: Secret
@@ -74,18 +75,6 @@ tests:
       nodePools.workers.replicas: 1
       nodePools.workers.maxReplicas: 3
     kubernetesProvider:
-      scheme:
-        v1/Secret:
-          gvr:
-            version: v1
-            resource: secrets
-          namespaced: true
-        helm.toolkit.fluxcd.io/v2/HelmRelease:
-          gvr:
-            group: helm.toolkit.fluxcd.io
-            version: v2
-            resource: helmreleases
-          namespaced: true
       objects:
         - apiVersion: v1
           kind: Secret
@@ -112,18 +101,6 @@ tests:
       nodePools.workers.replicas: 1
       nodePools.workers.maxReplicas: 3
     kubernetesProvider:
-      scheme:
-        v1/Secret:
-          gvr:
-            version: v1
-            resource: secrets
-          namespaced: true
-        helm.toolkit.fluxcd.io/v2/HelmRelease:
-          gvr:
-            group: helm.toolkit.fluxcd.io
-            version: v2
-            resource: helmreleases
-          namespaced: true
       objects:
         - apiVersion: v1
           kind: Secret

--- a/charts/t8s-cluster/tests/cinder_csi_plugin_test.yaml
+++ b/charts/t8s-cluster/tests/cinder_csi_plugin_test.yaml
@@ -3,6 +3,14 @@ templates:
   - templates/workload-cluster/cinder-csi-plugin/cinder-csi-plugin.yaml
 release:
   name: my-cluster
+kubernetesProvider:
+  scheme:
+    helm.toolkit.fluxcd.io/v2/HelmRelease:
+      gvr:
+        group: helm.toolkit.fluxcd.io
+        version: v2
+        resource: helmreleases
+      namespaced: true
 tests:
   - it: renders HelmRelease
     set:
@@ -25,13 +33,6 @@ tests:
     set:
       cni: cilium
     kubernetesProvider:
-      scheme:
-        helm.toolkit.fluxcd.io/v2/HelmRelease:
-          gvr:
-            group: helm.toolkit.fluxcd.io
-            version: v2
-            resource: helmreleases
-          namespaced: true
       objects:
         - apiVersion: helm.toolkit.fluxcd.io/v2
           kind: HelmRelease
@@ -51,13 +52,6 @@ tests:
     set:
       cni: cilium
     kubernetesProvider:
-      scheme:
-        helm.toolkit.fluxcd.io/v2/HelmRelease:
-          gvr:
-            group: helm.toolkit.fluxcd.io
-            version: v2
-            resource: helmreleases
-          namespaced: true
       objects:
         - apiVersion: helm.toolkit.fluxcd.io/v2
           kind: HelmRelease

--- a/charts/t8s-cluster/tests/cloud_controller_manager_test.yaml
+++ b/charts/t8s-cluster/tests/cloud_controller_manager_test.yaml
@@ -3,6 +3,14 @@ templates:
   - templates/workload-cluster/cloud-controller-manager.yaml
 release:
   name: my-cluster
+kubernetesProvider:
+  scheme:
+    helm.toolkit.fluxcd.io/v2/HelmRelease:
+      gvr:
+        group: helm.toolkit.fluxcd.io
+        version: v2
+        resource: helmreleases
+      namespaced: true
 tests:
   - it: renders HelmRelease
     set:
@@ -25,13 +33,6 @@ tests:
     set:
       cni: cilium
     kubernetesProvider:
-      scheme:
-        helm.toolkit.fluxcd.io/v2/HelmRelease:
-          gvr:
-            group: helm.toolkit.fluxcd.io
-            version: v2
-            resource: helmreleases
-          namespaced: true
       objects:
         - apiVersion: helm.toolkit.fluxcd.io/v2
           kind: HelmRelease
@@ -51,13 +52,6 @@ tests:
     set:
       cni: cilium
     kubernetesProvider:
-      scheme:
-        helm.toolkit.fluxcd.io/v2/HelmRelease:
-          gvr:
-            group: helm.toolkit.fluxcd.io
-            version: v2
-            resource: helmreleases
-          namespaced: true
       objects:
         - apiVersion: helm.toolkit.fluxcd.io/v2
           kind: HelmRelease

--- a/charts/t8s-cluster/tests/cni_test.yaml
+++ b/charts/t8s-cluster/tests/cni_test.yaml
@@ -3,6 +3,14 @@ templates:
   - templates/workload-cluster/cni-cilium.yaml
 release:
   name: my-cluster
+kubernetesProvider:
+  scheme:
+    helm.toolkit.fluxcd.io/v2/HelmRelease:
+      gvr:
+        group: helm.toolkit.fluxcd.io
+        version: v2
+        resource: helmreleases
+      namespaced: true
 tests:
   - it: renders HelmRelease when cni is cilium
     set:
@@ -25,13 +33,6 @@ tests:
     set:
       cni: cilium
     kubernetesProvider:
-      scheme:
-        helm.toolkit.fluxcd.io/v2/HelmRelease:
-          gvr:
-            group: helm.toolkit.fluxcd.io
-            version: v2
-            resource: helmreleases
-          namespaced: true
       objects:
         - apiVersion: helm.toolkit.fluxcd.io/v2
           kind: HelmRelease
@@ -51,13 +52,6 @@ tests:
     set:
       cni: cilium
     kubernetesProvider:
-      scheme:
-        helm.toolkit.fluxcd.io/v2/HelmRelease:
-          gvr:
-            group: helm.toolkit.fluxcd.io
-            version: v2
-            resource: helmreleases
-          namespaced: true
       objects:
         - apiVersion: helm.toolkit.fluxcd.io/v2
           kind: HelmRelease

--- a/charts/t8s-cluster/tests/etcd_test.yaml
+++ b/charts/t8s-cluster/tests/etcd_test.yaml
@@ -3,6 +3,14 @@ templates:
   - templates/workload-cluster/etcd-defrag.yaml
 release:
   name: my-cluster
+kubernetesProvider:
+  scheme:
+    helm.toolkit.fluxcd.io/v2/HelmRelease:
+      gvr:
+        group: helm.toolkit.fluxcd.io
+        version: v2
+        resource: helmreleases
+      namespaced: true
 tests:
   - it: no output when controlPlane is hosted
     set:
@@ -26,13 +34,6 @@ tests:
 
   - it: interval is 10s when the HelmRelease exists but is not ready
     kubernetesProvider:
-      scheme:
-        helm.toolkit.fluxcd.io/v2/HelmRelease:
-          gvr:
-            group: helm.toolkit.fluxcd.io
-            version: v2
-            resource: helmreleases
-          namespaced: true
       objects:
         - apiVersion: helm.toolkit.fluxcd.io/v2
           kind: HelmRelease
@@ -50,13 +51,6 @@ tests:
 
   - it: interval is 1h when the HelmRelease exists and is ready
     kubernetesProvider:
-      scheme:
-        helm.toolkit.fluxcd.io/v2/HelmRelease:
-          gvr:
-            group: helm.toolkit.fluxcd.io
-            version: v2
-            resource: helmreleases
-          namespaced: true
       objects:
         - apiVersion: helm.toolkit.fluxcd.io/v2
           kind: HelmRelease

--- a/charts/t8s-cluster/tests/gpu_operator_test.yaml
+++ b/charts/t8s-cluster/tests/gpu_operator_test.yaml
@@ -3,6 +3,14 @@ templates:
   - templates/workload-cluster/gpu-operator.yaml
 release:
   name: my-cluster
+kubernetesProvider:
+  scheme:
+    helm.toolkit.fluxcd.io/v2/HelmRelease:
+      gvr:
+        group: helm.toolkit.fluxcd.io
+        version: v2
+        resource: helmreleases
+      namespaced: true
 tests:
   - it: no output when no GPU flavors in nodePools
     asserts:
@@ -44,13 +52,6 @@ tests:
       nodePools.gpuworkers.flavor: m1.gpu-large
       nodePools.gpuworkers.replicas: 1
     kubernetesProvider:
-      scheme:
-        helm.toolkit.fluxcd.io/v2/HelmRelease:
-          gvr:
-            group: helm.toolkit.fluxcd.io
-            version: v2
-            resource: helmreleases
-          namespaced: true
       objects:
         - apiVersion: helm.toolkit.fluxcd.io/v2
           kind: HelmRelease
@@ -71,13 +72,6 @@ tests:
       nodePools.gpuworkers.flavor: m1.gpu-large
       nodePools.gpuworkers.replicas: 1
     kubernetesProvider:
-      scheme:
-        helm.toolkit.fluxcd.io/v2/HelmRelease:
-          gvr:
-            group: helm.toolkit.fluxcd.io
-            version: v2
-            resource: helmreleases
-          namespaced: true
       objects:
         - apiVersion: helm.toolkit.fluxcd.io/v2
           kind: HelmRelease


### PR DESCRIPTION
## Summary
- Removes per-test-case duplication of identical `kubernetesProvider.scheme` blocks across 6 t8s-cluster helm-unittest suites, hoisting each to the suite level.
- Relies on helm-unittest's suite-level `kubernetesProvider` merging its `scheme` into every test case (without forcing the fake client on for cases that don't define their own `objects`), so behavior is unchanged.

## Test plan
- [x] `go-task chart:test CHART=t8s-cluster` — 53/53 tests pass