### PR TITLE
fix(t8s-cluster): don't let stuck Jobs block cilium HelmRelease readiness

### DIFF
--- a/charts/t8s-cluster/templates/workload-cluster/cni-cilium.yaml
+++ b/charts/t8s-cluster/templates/workload-cluster/cni-cilium.yaml
@@ -16,6 +16,10 @@ spec:
     secretRef:
       name: {{ .Release.Name }}-kubeconfig
   healthCheckExprs:
+    - apiVersion: batch/v1
+      kind: Job
+      current: "true"
+      inProgress: "false"
     - apiVersion: apps/v1
       kind: DaemonSet
       current: status.numberAvailable == status.desiredNumberScheduled


### PR DESCRIPTION
## Summary
- Jobs (e.g. `hubble-generate-certs`) can get stuck pending on tainted/uninitialized nodes, which previously blocked the whole `cni` HelmRelease from ever reporting ready and stalled the rest of the reconciliation chain
- Add a `healthCheckExprs` entry for `Job` (batch/v1) that always reports `current: true` / `inProgress: false`, so Jobs no longer gate HelmRelease readiness

## Test plan
- [x] `go-task chart:lint CHART=t8s-cluster` passes
- [x] Verified against the `t8s-smoke-test` cluster, which was stuck exactly this way (hubble cert Job pending on tainted initial nodes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HelmRelease health monitoring by recognizing completed Jobs as healthy.
  * Prevented in-progress Jobs from being incorrectly treated as current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->