### PR TITLE
feat(t8s-cluster): enable StorageVersionMigrator feature gate for k8s >=1.36

### DIFF
--- a/charts/t8s-cluster/templates/management-cluster/clusterClass/_helpers.tpl
+++ b/charts/t8s-cluster/templates/management-cluster/clusterClass/_helpers.tpl
@@ -86,6 +86,9 @@ server = {{ printf "https://%s" .registry | quote }}
   {{- if semverCompare ">=1.34.0 <1.36.0" (include "t8s-cluster.k8s-version" .context) -}}
     {{- $featureGates = set $featureGates "MutatingAdmissionPolicy" (list "apiserver") -}}
   {{- end -}}
+  {{- if semverCompare ">=1.36.0" (include "t8s-cluster.k8s-version" .context) -}}
+    {{- $featureGates = set $featureGates "StorageVersionMigrator" (list "apiserver" "controllermanager") -}}
+  {{- end -}}
   {{- toYaml $featureGates -}}
 {{- end -}}
 
@@ -98,6 +101,17 @@ server = {{ printf "https://%s" .registry | quote }}
     {{- end -}}
   {{- end -}}
   {{- toYaml $featureGates -}}
+{{- end -}}
+
+{{- define "t8s-cluster.clusterClass.apiServer.runtimeConfig" -}}
+  {{- $runtimeConfig := dict -}}
+  {{- if semverCompare ">=1.34.0 <1.36.0" (include "t8s-cluster.k8s-version" .context) -}}
+    {{- $runtimeConfig = set $runtimeConfig "admissionregistration.k8s.io/v1beta1" true -}}
+  {{- end -}}
+  {{- if semverCompare ">=1.36.0" (include "t8s-cluster.k8s-version" .context) -}}
+    {{- $runtimeConfig = set $runtimeConfig "storagemigration.k8s.io/v1beta1" true -}}
+  {{- end -}}
+  {{- toYaml $runtimeConfig -}}
 {{- end -}}
 
 {{- define "t8s-cluster.clusterClass.containerdConfig.containerRegistryMirrorConfigs" -}}
@@ -167,6 +181,13 @@ server = {{ printf "https://%s" .registry | quote }}
   {{- if .Values.controlPlane.hosted -}}
     {{- $args = set $args "allocate-node-cidrs" "true" -}}
   {{- end }}
+  {{- $featureFlags := list -}}
+  {{- range $featureFlag, $enabled := include "t8s-cluster.featureGates.forComponent" (dict "component" "controllermanager" "context" .context) | fromYaml -}}
+    {{- $featureFlags = append $featureFlags (printf "%s=%t" $featureFlag $enabled) -}}
+  {{- end -}}
+  {{- if $featureFlags -}}
+    {{- $args = set $args "feature-gates" ($featureFlags | join ",") -}}
+  {{- end -}}
   {{- toYaml $args -}}
 {{- end }}
 
@@ -216,8 +237,12 @@ admission-control-config.yaml
   {{- $args = set $args "enable-admission-plugins" (include "t8s-cluster.clusterClass.apiServer.admissionPlugins" (dict "context" .context) | fromYamlArray | join ",") -}}
   {{- $args = set $args "event-ttl" "4h" -}}
   {{- $args = set $args "tls-cipher-suites" (include "t8s-cluster.clusterClass.tlsCipherSuites" (dict) | fromYamlArray | join ",") -}}
-  {{- if semverCompare ">=1.34.0 <1.36.0" (include "t8s-cluster.k8s-version" .context) -}}
-    {{- $args = set $args "runtime-config" "admissionregistration.k8s.io/v1beta1=true" -}}
+  {{- $runtimeConfigFlags := list -}}
+  {{- range $api, $enabled := include "t8s-cluster.clusterClass.apiServer.runtimeConfig" (dict "context" .context) | fromYaml -}}
+    {{- $runtimeConfigFlags = append $runtimeConfigFlags (printf "%s=%t" $api $enabled) -}}
+  {{- end -}}
+  {{- if $runtimeConfigFlags -}}
+    {{- $args = set $args "runtime-config" ($runtimeConfigFlags | join ",") -}}
   {{- end -}}
   {{- $featureFlags := list -}}
   {{- range $featureFlag, $enabled := include "t8s-cluster.featureGates.forComponent" (dict "component" "apiserver" "context" .context) | fromYaml -}}

--- a/charts/t8s-cluster/tests/control_plane_template_test.yaml
+++ b/charts/t8s-cluster/tests/control_plane_template_test.yaml
@@ -34,6 +34,70 @@ tests:
         hasDocuments:
           count: 0
 
+  - it: does not enable StorageVersionMigrator below k8s 1.36
+    set:
+      version:
+        major: 1
+        minor: 35
+        patch: 0
+    asserts:
+      - template: templates/management-cluster/clusterClass/kubeadmControlPlaneTemplate/kubeadmControlPlaneTemplate.yaml
+        notContains:
+          path: spec.template.spec.kubeadmConfigSpec.clusterConfiguration.controllerManager.extraArgs
+          content:
+            name: feature-gates
+            value: StorageVersionMigrator=true
+      - template: templates/management-cluster/clusterClass/kubeadmControlPlaneTemplate/kubeadmControlPlaneTemplate.yaml
+        contains:
+          path: spec.template.spec.kubeadmConfigSpec.clusterConfiguration.apiServer.extraArgs
+          content:
+            name: runtime-config
+            value: admissionregistration.k8s.io/v1beta1=true
+
+  - it: enables StorageVersionMigrator on apiserver and controller-manager from k8s 1.36
+    set:
+      version:
+        major: 1
+        minor: 36
+        patch: 0
+    asserts:
+      - template: templates/management-cluster/clusterClass/kubeadmControlPlaneTemplate/kubeadmControlPlaneTemplate.yaml
+        contains:
+          path: spec.template.spec.kubeadmConfigSpec.clusterConfiguration.apiServer.extraArgs
+          content:
+            name: feature-gates
+            value: ImageVolume=true,StorageVersionMigrator=true
+      - template: templates/management-cluster/clusterClass/kubeadmControlPlaneTemplate/kubeadmControlPlaneTemplate.yaml
+        contains:
+          path: spec.template.spec.kubeadmConfigSpec.clusterConfiguration.controllerManager.extraArgs
+          content:
+            name: feature-gates
+            value: StorageVersionMigrator=true
+      - template: templates/management-cluster/clusterClass/kubeadmControlPlaneTemplate/kubeadmControlPlaneTemplate.yaml
+        contains:
+          path: spec.template.spec.kubeadmConfigSpec.clusterConfiguration.apiServer.extraArgs
+          content:
+            name: runtime-config
+            value: storagemigration.k8s.io/v1beta1=true
+
+  - it: enables StorageVersionMigrator on the hosted control plane apiserver and controller-manager from k8s 1.36
+    set:
+      controlPlane:
+        hosted: true
+      version:
+        major: 1
+        minor: 36
+        patch: 0
+    asserts:
+      - template: templates/management-cluster/clusterClass/hostedControlPlaneTemplate/hostedControlPlaneTemplate.yaml
+        equal:
+          path: spec.template.spec.deployment.apiServer.args.feature-gates
+          value: ImageVolume=true,StorageVersionMigrator=true
+      - template: templates/management-cluster/clusterClass/hostedControlPlaneTemplate/hostedControlPlaneTemplate.yaml
+        equal:
+          path: spec.template.spec.deployment.controllerManager.args.feature-gates
+          value: StorageVersionMigrator=true
+
   - it: injects trusted CA certificates into the kubeadm control plane files and commands
     set:
       global:


### PR DESCRIPTION
## Summary
- Enables the Kubernetes [Storage Version Migration](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/storage-version-migration/) feature (beta in k8s 1.36) by turning on the `StorageVersionMigrator` feature gate on both the apiserver and controller-manager, and the `storagemigration.k8s.io/v1beta1` runtime-config, for clusters running k8s >= 1.36.
- Generalizes the apiserver's `runtime-config` construction into a dict-merge pattern (mirroring the existing feature-gates helper) so independently-conditioned entries compose correctly via comma-join instead of overwriting each other.
- Adds feature-gate plumbing to `t8s-cluster.clusterClass.args.controllerManager`, which previously had none, so gates can actually reach kube-controller-manager (needed since the migrator controller now runs in-tree there per KEP-4192).

## Test plan
- [x] `go-task chart:test CHART=t8s-cluster` — 56/56 passing, including new cases for k8s 1.35 (gate/runtime-config absent, admissionregistration runtime-config unaffected) and 1.36 (gate present on apiserver + controller-manager, runtime-config present) for both KubeadmControlPlaneTemplate and HostedControlPlaneTemplate.
- [x] `go-task chart:template CHART=t8s-cluster` — renders cleanly.
- [x] `go-task chart:lint CHART=t8s-cluster` — clean.