### PR TITLE
feat(base-cluster): create a StorageVersionMigration per installed CRD

### DIFF
--- a/charts/base-cluster/templates/storage-version-migration/storageVersionMigrations.yaml
+++ b/charts/base-cluster/templates/storage-version-migration/storageVersionMigrations.yaml
@@ -1,0 +1,14 @@
+{{- if .Capabilities.APIVersions.Has "storagemigration.k8s.io/v1beta1/StorageVersionMigration" }}
+{{- range $crd := (lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "").items | default list }}
+---
+apiVersion: storagemigration.k8s.io/v1beta1
+kind: StorageVersionMigration
+metadata:
+  name: {{ $crd.metadata.name }}
+  labels: {{- include "common.labels.standard" $ | nindent 4 }}
+spec:
+  resource:
+    group: {{ $crd.spec.group }}
+    resource: {{ $crd.spec.names.plural }}
+{{- end }}
+{{- end }}

--- a/charts/base-cluster/tests/storage_version_migration_test.yaml
+++ b/charts/base-cluster/tests/storage_version_migration_test.yaml
@@ -1,0 +1,54 @@
+suite: storage version migration
+templates:
+  - templates/storage-version-migration/storageVersionMigrations.yaml
+release:
+  name: base-cluster
+tests:
+  - it: renders nothing when the StorageVersionMigration API is not available
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders nothing when the API is available but no CRDs exist
+    capabilities:
+      apiVersions:
+        - storagemigration.k8s.io/v1beta1/StorageVersionMigration
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: creates a StorageVersionMigration per installed CRD
+    capabilities:
+      apiVersions:
+        - storagemigration.k8s.io/v1beta1/StorageVersionMigration
+    kubernetesProvider:
+      scheme:
+        "apiextensions.k8s.io/v1/CustomResourceDefinition":
+          gvr:
+            group: apiextensions.k8s.io
+            version: v1
+            resource: customresourcedefinitions
+          namespaced: false
+      objects:
+        - apiVersion: apiextensions.k8s.io/v1
+          kind: CustomResourceDefinition
+          metadata:
+            name: widgets.example.com
+          spec:
+            group: example.com
+            names:
+              plural: widgets
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: StorageVersionMigration
+      - equal:
+          path: metadata.name
+          value: widgets.example.com
+      - equal:
+          path: spec.resource.group
+          value: example.com
+      - equal:
+          path: spec.resource.resource
+          value: widgets


### PR DESCRIPTION
## Summary
- Once `storagemigration.k8s.io/v1beta1` (the [Storage Version Migration](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/storage-version-migration/) API, enabled on management clusters by #2331 for k8s >=1.36) is available, loop over every installed `CustomResourceDefinition` and create a `StorageVersionMigration` object for it (`group`/`resource` from the CRD, reusing the CRD's own `metadata.name` since it's already `<plural>.<group>` and unique).
- API presence is gated via `.Capabilities.APIVersions.Has`, matching the existing `ServiceMonitor`/`CiliumNetworkPolicy` pattern in this repo, not a values.yaml toggle — no manual enablement needed once the cluster exposes the API.

## Test plan
- [x] `go-task chart:test CHART=base-cluster` — 129/129 passing, including new cases for API absent, API present with zero CRDs, and API present with a CRD (asserts name/group/resource on the rendered `StorageVersionMigration`).
- [x] `go-task chart:template CHART=base-cluster` — renders cleanly (correctly renders nothing under plain `helm template`, since no live-cluster `Capabilities.APIVersions` are available there).
- [x] `go-task chart:lint CHART=base-cluster` — clean.