### PR TITLE
feat(teuto-portal-k8s-worker): allow CiliumNetworkPolicy egress to IP kube-apiserver via /32 CIDR

### DIFF
--- a/charts/teuto-portal-k8s-worker/templates/ciliumNetworkPolicy.yaml
+++ b/charts/teuto-portal-k8s-worker/templates/ciliumNetworkPolicy.yaml
@@ -22,8 +22,9 @@ spec:
             dns:
               - matchPattern: "*"
     {{- end }}
-    - toFQDNs:
-        - matchName: {{ .Values.worker.database.host }}
+    - toServices:
+        - k8sService:
+            serviceName: {{ .Values.worker.database.host }}
       toPorts:
         - ports:
             - port: {{ .Values.worker.database.port | quote }}
@@ -36,8 +37,14 @@ spec:
         {{- $serverPart := $server | trimPrefix "https://" | trimPrefix "http://" }}
         {{- $serverHost := $serverPart | splitList ":" | first }}
         {{- $serverPort := $serverPart | splitList ":" | last | splitList "/" | first }}
-    - toFQDNs:
+        {{- $serverIsIP := regexMatch "^((25[0-5]|(2[0-4]|1\\d|[1-9]|)\\d)\\.?\\b){4}$" $serverHost }}
+    - {{- if $serverIsIP }}
+      toCIDR:
+        - {{ $serverHost }}/32
+      {{- else }}
+      toFQDNs:
         - matchName: {{ $serverHost }}
+      {{- end }}
       toPorts:
         - ports:
             - port: {{ $serverPort | quote }}


### PR DESCRIPTION
## Summary
- kube-apiserver egress rule was always emitted as `toFQDNs`, which cannot match a bare IP address
- if the kubeconfig's server host is an IP, emit `toCIDR` with a `/32` instead; DNS names still use `toFQDNs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database access policy matching for configured Kubernetes services.
  * Updated kubeconfig server access to correctly support both IP addresses and hostnames.
  * IP-based endpoints now use precise network matching, while hostname-based endpoints retain domain matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->