### PR TITLE
fix(t8s-cluster): move cluster-cloud annotation to node.cluster.x-k8s.io domain

### DIFF
--- a/charts/t8s-cluster/templates/management-cluster/clusterClass/clusterClass.yaml
+++ b/charts/t8s-cluster/templates/management-cluster/clusterClass/clusterClass.yaml
@@ -13,7 +13,7 @@ spec:
     {{- if not .Values.controlPlane.hosted }}
     metadata:
       annotations:
-        cluster.x-k8s.io/cluster-cloud: {{ .Values.cloud }}
+        node.cluster.x-k8s.io/cluster-cloud: {{ .Values.cloud }}
     healthCheck:
       remediation:
         triggerIf:
@@ -149,7 +149,7 @@ spec:
           labels:
             node-role.kubernetes.io/compute-plane: ""
           annotations:
-            cluster.x-k8s.io/cluster-cloud: {{ $.Values.cloud }}
+            node.cluster.x-k8s.io/cluster-cloud: {{ $.Values.cloud }}
         healthCheck:
           checks:
             nodeStartupTimeoutSeconds: 480


### PR DESCRIPTION
## Summary
- Cluster API only mirrors Machine annotations onto the resulting Node when they're under the `node.cluster.x-k8s.io/` domain (`cluster-name`/`cluster-namespace` are the exception — those are hardcoded bookkeeping annotations CAPI always syncs).
- The `cluster.x-k8s.io/cluster-cloud` annotation added in #2322 landed on the ClusterClass's `controlPlane`/`machineDeployments` metadata (i.e. on the Machine objects) but never reached the actual Node — renamed it to `node.cluster.x-k8s.io/cluster-cloud` so it does.
- Companion fix in base-cluster (separate PR) updates the consumer to read the new key.

## Test plan
- [x] `go-task chart:test CHART=t8s-cluster` passes