### PR TITLE
fix(base-cluster): read cluster-cloud annotation from node.cluster.x-k8s.io domain

### DIFF
--- a/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_helpers.yaml
+++ b/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_helpers.yaml
@@ -76,7 +76,7 @@ privileged: false
       {{- $annotations := dig "metadata" "annotations" (dict) $node -}}
       {{- $name = dig "cluster.x-k8s.io/cluster-name" "" $annotations -}}
       {{- $namespace = dig "cluster.x-k8s.io/cluster-namespace" "" $annotations -}}
-      {{- $cloud = dig "cluster.x-k8s.io/cluster-cloud" "" $annotations -}}
+      {{- $cloud = dig "node.cluster.x-k8s.io/cluster-cloud" "" $annotations -}}
     {{- end -}}
   {{- end -}}
   {{- $data = dict -}}

--- a/charts/base-cluster/tests/capi_cluster_identity_test.yaml
+++ b/charts/base-cluster/tests/capi_cluster_identity_test.yaml
@@ -52,7 +52,7 @@ tests:
             annotations:
               cluster.x-k8s.io/cluster-name: efac7c4c-b677-479e-a693-33a815e5adf9
               cluster.x-k8s.io/cluster-namespace: teuto-portal-clusters
-              cluster.x-k8s.io/cluster-cloud: ffm3
+              node.cluster.x-k8s.io/cluster-cloud: ffm3
     set:
       global.clusterName: test
       monitoring.grafana.adminPassword: test
@@ -94,7 +94,7 @@ tests:
             annotations:
               cluster.x-k8s.io/cluster-name: efac7c4c-b677-479e-a693-33a815e5adf9
               cluster.x-k8s.io/cluster-namespace: teuto-portal-clusters
-              cluster.x-k8s.io/cluster-cloud: ffm3
+              node.cluster.x-k8s.io/cluster-cloud: ffm3
     set:
       global.clusterName: test
       monitoring.grafana.adminPassword: test


### PR DESCRIPTION
## Summary
- Companion to teutonet/teutonet-helm-charts#2336: the `cluster.x-k8s.io/cluster-cloud` Node annotation the CAPI-identity lookup here relies on never actually reached Node objects (CAPI only syncs Machine annotations to Node under the `node.cluster.x-k8s.io/` domain).
- Updates the lookup key in `capi-cluster-identity` helper (and its test fixtures) to `node.cluster.x-k8s.io/cluster-cloud` to match.

## Test plan
- [x] `go-task chart:test CHART=base-cluster` passes