### PR TITLE
fix(t8s-cluster): HR reconciliation cannot be relied upon

### DIFF
--- a/charts/t8s-cluster/templates/management-cluster/autoscaler.yaml
+++ b/charts/t8s-cluster/templates/management-cluster/autoscaler.yaml
@@ -7,7 +7,7 @@
   {{- end }}
 {{- end }}
 {{- $kubeconfigSecret := printf "%s-kubeconfig" .Release.Name -}}
-{{- if and $enabled (lookup "v1" "Secret" .Release.Namespace $kubeconfigSecret) -}}
+{{- if $enabled -}}
 {{- $name := printf "%s-autoscaler" .Release.Name -}}
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/charts/t8s-cluster/templates/management-cluster/storageVersionMigration.yaml
+++ b/charts/t8s-cluster/templates/management-cluster/storageVersionMigration.yaml
@@ -1,0 +1,119 @@
+{{- $kubeconfigSecret := printf "%s-kubeconfig" .Release.Name -}}
+{{- if and (semverCompare ">=1.36.0" (include "t8s-cluster.k8s-version" .)) (semverCompare ">=1.36.0" .Capabilities.KubeVersion.Version) -}}
+{{- $name := printf "%s-storage-version-migration" .Release.Name -}}
+{{- $minute := mod (atoi (adler32sum (printf "%s/%s" .Release.Namespace .Release.Name))) 60 -}}
+{{- $managedByLabel := "t8s-cluster-storage-version-migration" -}}
+{{- $busyboxImage := include "common.images.image" (dict "imageRoot" .Values.global.busybox.image "global" .Values.global) -}}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: storage-version-migration
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 5
+  successfulJobsHistoryLimit: 1
+  schedule: {{ printf "%d * * * *" $minute | quote }}
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        spec:
+          restartPolicy: Never
+          automountServiceAccountToken: false
+          securityContext:
+            runAsNonRoot: true
+            runAsGroup: 1000
+            runAsUser: 1000
+            fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          initContainers:
+            - name: plan-create
+              image: {{ $busyboxImage }}
+              imagePullPolicy: {{ include "common.images.pullPolicy" .Values.global.busybox.image }}
+              securityContext: &toolSecurityContext
+                readOnlyRootFilesystem: true
+                privileged: false
+                capabilities:
+                  drop:
+                    - ALL
+                allowPrivilegeEscalation: false
+                seccompProfile:
+                  type: RuntimeDefault
+              volumeMounts: &toolVolumeMounts
+                - mountPath: /.kube/config
+                  name: workload-kubeconfig
+                  subPath: value
+                - mountPath: /opt/kubectl-bin
+                  name: kubectl-bin
+                  subPath: bin
+                - mountPath: /opt/jq-bin
+                  name: jq-bin
+                - mountPath: /shared
+                  name: shared
+              command:
+                - sh
+                - -exc
+                - |-
+                  /opt/kubectl-bin/kubectl get customresourcedefinitions.apiextensions.k8s.io -o json \
+                    | /opt/jq-bin/jq '{apiVersion:"v1",kind:"List",items:[.items[] | select((.status.storedVersions // []) | length >= 2) | {apiVersion:"storagemigration.k8s.io/v1beta1",kind:"StorageVersionMigration",metadata:{name:.metadata.name,labels:{"app.kubernetes.io/managed-by":{{ $managedByLabel | quote }}}},spec:{resource:{group:.spec.group,resource:.spec.names.plural}}}]}' \
+                    > /shared/create.json
+            - name: plan-delete
+              image: {{ $busyboxImage }}
+              imagePullPolicy: {{ include "common.images.pullPolicy" .Values.global.busybox.image }}
+              securityContext: *toolSecurityContext
+              volumeMounts: *toolVolumeMounts
+              command:
+                - sh
+                - -exc
+                - |-
+                  /opt/kubectl-bin/kubectl get storageversionmigrations.storagemigration.k8s.io -l {{ printf "app.kubernetes.io/managed-by=%s" $managedByLabel }} -o json \
+                    | /opt/jq-bin/jq '{apiVersion:"v1",kind:"List",items:[.items[] | select(any(.status.conditions[]?; .type == "Succeeded" and .status == "True")) | {apiVersion:"storagemigration.k8s.io/v1beta1",kind:"StorageVersionMigration",metadata:{name:.metadata.name}}]}' \
+                    > /shared/delete.json
+          containers:
+            - name: create
+              image: {{ $busyboxImage }}
+              imagePullPolicy: {{ include "common.images.pullPolicy" .Values.global.busybox.image }}
+              securityContext: *toolSecurityContext
+              volumeMounts: *toolVolumeMounts
+              command:
+                - sh
+                - -exc
+                - |-
+                  if [ "$(/opt/jq-bin/jq '.items | length' /shared/create.json)" -gt 0 ]; then
+                    /opt/kubectl-bin/kubectl apply -f /shared/create.json
+                  else
+                    echo "nothing to create"
+                  fi
+            - name: delete
+              image: {{ $busyboxImage }}
+              imagePullPolicy: {{ include "common.images.pullPolicy" .Values.global.busybox.image }}
+              securityContext: *toolSecurityContext
+              volumeMounts: *toolVolumeMounts
+              command:
+                - sh
+                - -exc
+                - |-
+                  if [ "$(/opt/jq-bin/jq '.items | length' /shared/delete.json)" -gt 0 ]; then
+                    /opt/kubectl-bin/kubectl delete -f /shared/delete.json
+                  else
+                    echo "nothing to delete"
+                  fi
+          volumes:
+            - name: workload-kubeconfig
+              secret:
+                secretName: {{ $kubeconfigSecret }}
+            - name: shared
+              emptyDir: {}
+            - name: kubectl-bin
+              image:
+                reference: {{ include "common.images.image" (dict "imageRoot" (mustMerge (dict "tag" (include "t8s-cluster.k8s-version" .)) .Values.global.kubectl.image) "global" .Values.global) }}
+                pullPolicy: {{ include "common.images.pullPolicy" .Values.global.kubectl.image }}
+            - name: jq-bin
+              image:
+                reference: {{ include "common.images.image" (dict "imageRoot" .Values.global.jq.image "global" .Values.global) }}
+                pullPolicy: {{ include "common.images.pullPolicy" .Values.global.jq.image }}
+{{- end -}}

--- a/charts/t8s-cluster/tests/autoscaler_test.yaml
+++ b/charts/t8s-cluster/tests/autoscaler_test.yaml
@@ -25,14 +25,16 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: no output when enabled but the kubeconfig secret does not exist
+  - it: renders HelmRelease when enabled even when the kubeconfig secret does not exist
     set:
       nodePools.workers.flavor: m1.medium
       nodePools.workers.replicas: 1
       nodePools.workers.maxReplicas: 3
     asserts:
       - hasDocuments:
-          count: 0
+          count: 1
+      - isKind:
+          of: HelmRelease
 
   - it: renders HelmRelease when enabled and the kubeconfig secret exists
     set:

--- a/charts/t8s-cluster/tests/storage_version_migration_test.yaml
+++ b/charts/t8s-cluster/tests/storage_version_migration_test.yaml
@@ -1,0 +1,148 @@
+suite: storage version migration cronjob gating
+templates:
+  - templates/management-cluster/storageVersionMigration.yaml
+release:
+  name: my-cluster
+kubernetesProvider:
+  scheme:
+    v1/Secret:
+      gvr:
+        version: v1
+        resource: secrets
+      namespaced: true
+tests:
+  - it: no output below k8s 1.36 even when the kubeconfig secret exists
+    set:
+      version:
+        major: 1
+        minor: 35
+        patch: 0
+    kubernetesProvider:
+      objects:
+        - apiVersion: v1
+          kind: Secret
+          metadata:
+            name: my-cluster-kubeconfig
+            namespace: NAMESPACE
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders a CronJob from k8s 1.36 even when the kubeconfig secret does not exist
+    set:
+      version:
+        major: 1
+        minor: 36
+        patch: 0
+    capabilities:
+      majorVersion: "1"
+      minorVersion: "36"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: CronJob
+
+  - it: no output when the management cluster itself is below k8s 1.36, even if the workload cluster is 1.36
+    set:
+      version:
+        major: 1
+        minor: 36
+        patch: 0
+    capabilities:
+      majorVersion: "1"
+      minorVersion: "35"
+    kubernetesProvider:
+      objects:
+        - apiVersion: v1
+          kind: Secret
+          metadata:
+            name: my-cluster-kubeconfig
+            namespace: NAMESPACE
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders a CronJob from k8s 1.36 when the kubeconfig secret exists
+    set:
+      version:
+        major: 1
+        minor: 36
+        patch: 0
+    capabilities:
+      majorVersion: "1"
+      minorVersion: "36"
+    kubernetesProvider:
+      objects:
+        - apiVersion: v1
+          kind: Secret
+          metadata:
+            name: my-cluster-kubeconfig
+            namespace: NAMESPACE
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: CronJob
+      - equal:
+          path: metadata.name
+          value: my-cluster-storage-version-migration
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.volumes[0].secret.secretName
+          value: my-cluster-kubeconfig
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.volumes[2].image.reference
+          value: registry.k8s.io/kubectl:v1.36.0
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.volumes[3].image.reference
+          value: ghcr.io/jqlang/jq:1.8.1@sha256:4f34c6d23f4b1372ac789752cc955dc67c2ae177eb1b5860b75cdc5091ce6f91
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.initContainers[0].name
+          value: plan-create
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.initContainers[1].name
+          value: plan-delete
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].name
+          value: create
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[1].name
+          value: delete
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.initContainers[0].volumeMounts[0]
+          value:
+            mountPath: /.kube/config
+            name: workload-kubeconfig
+            subPath: value
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.initContainers[0].volumeMounts[1]
+          value:
+            mountPath: /opt/kubectl-bin
+            name: kubectl-bin
+            subPath: bin
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.initContainers[0].volumeMounts[2]
+          value:
+            mountPath: /opt/jq-bin
+            name: jq-bin
+
+  - it: schedule minute is stable for a given cluster namespace and name
+    set:
+      version:
+        major: 1
+        minor: 36
+        patch: 0
+    capabilities:
+      majorVersion: "1"
+      minorVersion: "36"
+    kubernetesProvider:
+      objects:
+        - apiVersion: v1
+          kind: Secret
+          metadata:
+            name: my-cluster-kubeconfig
+            namespace: NAMESPACE
+    asserts:
+      - matchRegex:
+          path: spec.schedule
+          pattern: "^[0-9]+ \\* \\* \\* \\*$"

--- a/charts/t8s-cluster/values.yaml
+++ b/charts/t8s-cluster/values.yaml
@@ -30,16 +30,26 @@ global:
         cluster-autoscaler: 9.59.0
     cetic:
       url: https://cetic.github.io/helm-charts
+  busybox:
+    image:
+      registry: docker.io
+      repository: busybox
+      tag: 1.37.0@sha256:9db7b59979c38555a39def84a31fb98b5296952f9e3afd4f6f11f05b07adfab0
   etcd:
     image:
       registry: registry.k8s.io
       repository: etcd
       tag: 3.7.1-0@sha256:a9983dd6d9283138ab926daa307c6c25623636703ecf5645d5df4d666ce9eba2
+  jq:
+    image:
+      registry: ghcr.io
+      repository: jqlang/jq
+      tag: 1.8.1@sha256:4f34c6d23f4b1372ac789752cc955dc67c2ae177eb1b5860b75cdc5091ce6f91
   kubectl:
     image:
-      registry: docker.io
-      repository: bitnami/kubectl
-      tag: 1.31.4-debian-12-r1@sha256:64614ef8290f3fb27fed5164b338debeeb79a1e5e26c93eb920770b71abd7c48
+      registry: registry.k8s.io
+      repository: kubectl
+      tag: 1.33.4@sha256:261a9ed843eb68e3d50da132245e2221d75ca19504130e47bd32788c0ff339a0
   s3:
     image:
       registry: docker.io


### PR DESCRIPTION
Dynamically doing stuff based on the kubeconfig secret just basically
never happened, so let's disable it, same goes for the
StorageVersionMigration in base-cluster; moved here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated storage version migration for Kubernetes 1.36 and later, helping manage CRD storage transitions on a scheduled basis.
  - Added configurable, pinned images for migration tooling and updated the kubectl image source and version.

- **Bug Fixes**
  - Improved cluster autoscaler deployment so it is rendered whenever autoscaling is configured, without requiring a pre-existing kubeconfig secret.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->