### PR TITLE
fix(t8s-cluster): add PodDisruptionBudgets for cilium-operator, hubble-ui and cinder-csi controller plugin

### DIFF
--- a/charts/t8s-cluster/templates/workload-cluster/cinder-csi-plugin/podDisruptionBudget.yaml
+++ b/charts/t8s-cluster/templates/workload-cluster/cinder-csi-plugin/podDisruptionBudget.yaml
@@ -1,0 +1,17 @@
+{{- include "t8s-cluster.helm.resourceIntoCluster" (dict "name" "openstack-cinder-csi-pdb" "resource" (include "t8s-cluster.podDisruptionBudget.cinder-csi" (dict)) "context" $ "additionalLabels" (dict "app.kubernetes.io/component" "cinder-csi") "dependsOn" (list (dict "name" (printf "%s-csi" $.Release.Name) "namespace" $.Release.Namespace))) | nindent 0 }}
+
+{{- define "t8s-cluster.podDisruptionBudget.cinder-csi" -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: openstack-cinder-csi-controllerplugin
+  namespace: kube-system
+  labels: {{- include "common.helm.labels" (dict) | nindent 4 }}
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: openstack-cinder-csi
+      component: controllerplugin
+      release: csi
+{{- end -}}

--- a/charts/t8s-cluster/templates/workload-cluster/cni-cilium.yaml
+++ b/charts/t8s-cluster/templates/workload-cluster/cni-cilium.yaml
@@ -103,6 +103,8 @@ spec:
       ui:
         rollOutPods: true
         enabled: true
+        podDisruptionBudget:
+          enabled: true
       export:
         static:
           enabled: true
@@ -112,6 +114,8 @@ spec:
     operator:
       rollOutPods: true
       prometheus:
+        enabled: true
+      podDisruptionBudget:
         enabled: true
     {{- if .Values.controlPlane.hosted }}
       tolerations:

--- a/charts/t8s-cluster/tests/cinder_csi_plugin_test.yaml
+++ b/charts/t8s-cluster/tests/cinder_csi_plugin_test.yaml
@@ -66,3 +66,32 @@ tests:
       - equal:
           path: spec.interval
           value: 1h
+
+---
+suite: openstack-cinder-csi PodDisruptionBudget
+templates:
+  - templates/workload-cluster/cinder-csi-plugin/podDisruptionBudget.yaml
+release:
+  name: my-cluster
+tests:
+  - it: renders HelmRelease wrapping a PodDisruptionBudget for the controller plugin
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HelmRelease
+      - matchRegex:
+          path: spec.values.static
+          pattern: "kind: PodDisruptionBudget"
+      - matchRegex:
+          path: spec.values.static
+          pattern: "maxUnavailable: 1"
+      - matchRegex:
+          path: spec.values.static
+          pattern: "app: openstack-cinder-csi"
+      - matchRegex:
+          path: spec.values.static
+          pattern: "component: controllerplugin"
+      - matchRegex:
+          path: spec.values.static
+          pattern: "release: csi"

--- a/charts/t8s-cluster/tests/cni_test.yaml
+++ b/charts/t8s-cluster/tests/cni_test.yaml
@@ -74,6 +74,17 @@ tests:
       - hasDocuments:
           count: 0
 
+  - it: enables PodDisruptionBudgets for cilium-operator and hubble-ui
+    set:
+      cni: cilium
+    asserts:
+      - equal:
+          path: spec.values.operator.podDisruptionBudget.enabled
+          value: true
+      - equal:
+          path: spec.values.hubble.ui.podDisruptionBudget.enabled
+          value: true
+
 ---
 suite: CNI calico explicit selection
 templates:


### PR DESCRIPTION
## Summary
- On hosted-control-plane clusters (`controlPlane.hosted: true`), cilium-operator, hubble-ui, and openstack-cinder-csi-controllerplugin run as Deployments on worker nodes with no PodDisruptionBudget, spread one-per-node via anti-affinity — cluster-autoscaler's default `--skip-nodes-with-system-pods=true` then treats every node they land on as permanently unevictable, blocking scale-down entirely.
- `cilium-operator` and `hubble-ui` both get the chart-native toggles: `operator.podDisruptionBudget.enabled: true` and `hubble.ui.podDisruptionBudget.enabled: true` (both default to `maxUnavailable: 1`).
- `openstack-cinder-csi-controllerplugin` has no PDB support in its upstream chart (checked `helm show values` for the pinned version — no toggle, no generic `extraDeploy`/`extraManifests` escape hatch either), so a raw `PodDisruptionBudget` is injected via the existing `t8s-cluster.helm.resourceIntoCluster` pattern — same mechanism already used in this chart for the cinder-csi `CiliumNetworkPolicy`. Selector verified against a live cluster.
- The cinder-csi PDB applies unconditionally (both CNIs), the cilium ones only apply when cilium is selected (that HelmRelease only exists then).

Confirmed live on cluster `efac7c4c-b677-479e-a693-33a815e5adf9` (prod, customer cwr) where this was blocking scale-down.

## Test plan
- [x] `go-task chart:test CHART=t8s-cluster` — 58 tests pass, including new assertions for both cilium PDB toggles and the injected cinder-csi PDB
- [x] `go-task chart:lint CHART=t8s-cluster` — all CI values files lint clean