### PR TITLE
fix(t8s-cluster): make KubeadmControlPlaneTemplate spec hash deterministic

### DIFF
--- a/charts/t8s-cluster/templates/management-cluster/clusterClass/kubeadmControlPlaneTemplate/_helpers.tpl
+++ b/charts/t8s-cluster/templates/management-cluster/clusterClass/kubeadmControlPlaneTemplate/_helpers.tpl
@@ -26,7 +26,7 @@
   {{- range $file := $files -}}
     {{- $file = set $file "content" (get $file "content" | trim) -}}
   {{- end -}}
-  {{- $dynamicFiles := include "t8s-cluster.clusterClass.apiServer.dynamicFiles" (dict "context" .) | fromYaml | values -}}
+  {{- $dynamicFiles := include "t8s-cluster.clusterClass.apiServer.dynamicFiles" (dict "context" .) | fromYaml -}}
   {{- range $name, $file := $dynamicFiles -}}
     {{- if hasKey $file "contentFrom" -}}
       {{- $files = append $files (dict "contentFrom" (get $file "contentFrom") "path" (get $file "path" | required (printf "missing path for %s" $name))) -}}

--- a/charts/t8s-cluster/tests/kubeadm_control_plane_template_hash_test.yaml
+++ b/charts/t8s-cluster/tests/kubeadm_control_plane_template_hash_test.yaml
@@ -1,0 +1,220 @@
+# regression test: apiServer.dynamicFiles used to be turned into a list via
+# the sprig `values` function, which ranges over a Go map without the
+# deterministic key-sort that the template `range` action applies, so the
+# `files` order (and therefore the name hash) was random per evaluation.
+# controlPlane.audit: true is what makes dynamicFiles hold more than one
+# entry, which is required to make that ordering ambiguity observable.
+# helm-unittest has no way to repeat a single `it:` case, and each `it:`
+# case is an independent template render, so the case below is duplicated
+# to fuzz for non-determinism across many renders in one `helm unittest` run.
+suite: KubeadmControlPlaneTemplate spec hash determinism
+templates:
+  - templates/management-cluster/clusterClass/clusterClass.yaml
+  - templates/management-cluster/clusterClass/kubeadmControlPlaneTemplate/kubeadmControlPlaneTemplate.yaml
+release:
+  name: my-cluster
+set:
+  cloud: my-cloud
+  controlPlane:
+    audit: true
+tests:
+  - it: hashes the same name in the ClusterClass templateRef and the KubeadmControlPlaneTemplate itself (attempt 1)
+    asserts:
+      - template: templates/management-cluster/clusterClass/clusterClass.yaml
+        equal:
+          path: spec.controlPlane.templateRef.name
+          value: my-cluster-e8678655
+      - template: templates/management-cluster/clusterClass/kubeadmControlPlaneTemplate/kubeadmControlPlaneTemplate.yaml
+        equal:
+          path: metadata.name
+          value: my-cluster-e8678655
+  - it: hashes the same name in the ClusterClass templateRef and the KubeadmControlPlaneTemplate itself (attempt 2)
+    asserts:
+      - template: templates/management-cluster/clusterClass/clusterClass.yaml
+        equal:
+          path: spec.controlPlane.templateRef.name
+          value: my-cluster-e8678655
+      - template: templates/management-cluster/clusterClass/kubeadmControlPlaneTemplate/kubeadmControlPlaneTemplate.yaml
+        equal:
+          path: metadata.name
+          value: my-cluster-e8678655
+  - it: hashes the same name in the ClusterClass templateRef and the KubeadmControlPlaneTemplate itself (attempt 3)
+    asserts:
+      - template: templates/management-cluster/clusterClass/clusterClass.yaml
+        equal:
+          path: spec.controlPlane.templateRef.name
+          value: my-cluster-e8678655
+      - template: templates/management-cluster/clusterClass/kubeadmControlPlaneTemplate/kubeadmControlPlaneTemplate.yaml
+        equal:
+          path: metadata.name
+          value: my-cluster-e8678655
+  - it: hashes the same name in the ClusterClass templateRef and the KubeadmControlPlaneTemplate itself (attempt 4)
+    asserts:
+      - template: templates/management-cluster/clusterClass/clusterClass.yaml
+        equal:
+          path: spec.controlPlane.templateRef.name
+          value: my-cluster-e8678655
+      - template: templates/management-cluster/clusterClass/kubeadmControlPlaneTemplate/kubeadmControlPlaneTemplate.yaml
+        equal:
+          path: metadata.name
+          value: my-cluster-e8678655
+  - it: hashes the same name in the ClusterClass templateRef and the KubeadmControlPlaneTemplate itself (attempt 5)
+    asserts:
+      - template: templates/management-cluster/clusterClass/clusterClass.yaml
+        equal:
+          path: spec.controlPlane.templateRef.name
+          value: my-cluster-e8678655
+      - template: templates/management-cluster/clusterClass/kubeadmControlPlaneTemplate/kubeadmControlPlaneTemplate.yaml
+        equal:
+          path: metadata.name
+          value: my-cluster-e8678655
+  - it: hashes the same name in the ClusterClass templateRef and the KubeadmControlPlaneTemplate itself (attempt 6)
+    asserts:
+      - template: templates/management-cluster/clusterClass/clusterClass.yaml
+        equal:
+          path: spec.controlPlane.templateRef.name
+          value: my-cluster-e8678655
+      - template: templates/management-cluster/clusterClass/kubeadmControlPlaneTemplate/kubeadmControlPlaneTemplate.yaml
+        equal:
+          path: metadata.name
+          value: my-cluster-e8678655
+  - it: hashes the same name in the ClusterClass templateRef and the KubeadmControlPlaneTemplate itself (attempt 7)
+    asserts:
+      - template: templates/management-cluster/clusterClass/clusterClass.yaml
+        equal:
+          path: spec.controlPlane.templateRef.name
+          value: my-cluster-e8678655
+      - template: templates/management-cluster/clusterClass/kubeadmControlPlaneTemplate/kubeadmControlPlaneTemplate.yaml
+        equal:
+          path: metadata.name
+          value: my-cluster-e8678655
+  - it: hashes the same name in the ClusterClass templateRef and the KubeadmControlPlaneTemplate itself (attempt 8)
+    asserts:
+      - template: templates/management-cluster/clusterClass/clusterClass.yaml
+        equal:
+          path: spec.controlPlane.templateRef.name
+          value: my-cluster-e8678655
+      - template: templates/management-cluster/clusterClass/kubeadmControlPlaneTemplate/kubeadmControlPlaneTemplate.yaml
+        equal:
+          path: metadata.name
+          value: my-cluster-e8678655
+  - it: hashes the same name in the ClusterClass templateRef and the KubeadmControlPlaneTemplate itself (attempt 9)
+    asserts:
+      - template: templates/management-cluster/clusterClass/clusterClass.yaml
+        equal:
+          path: spec.controlPlane.templateRef.name
+          value: my-cluster-e8678655
+      - template: templates/management-cluster/clusterClass/kubeadmControlPlaneTemplate/kubeadmControlPlaneTemplate.yaml
+        equal:
+          path: metadata.name
+          value: my-cluster-e8678655
+  - it: hashes the same name in the ClusterClass templateRef and the KubeadmControlPlaneTemplate itself (attempt 10)
+    asserts:
+      - template: templates/management-cluster/clusterClass/clusterClass.yaml
+        equal:
+          path: spec.controlPlane.templateRef.name
+          value: my-cluster-e8678655
+      - template: templates/management-cluster/clusterClass/kubeadmControlPlaneTemplate/kubeadmControlPlaneTemplate.yaml
+        equal:
+          path: metadata.name
+          value: my-cluster-e8678655
+  - it: hashes the same name in the ClusterClass templateRef and the KubeadmControlPlaneTemplate itself (attempt 11)
+    asserts:
+      - template: templates/management-cluster/clusterClass/clusterClass.yaml
+        equal:
+          path: spec.controlPlane.templateRef.name
+          value: my-cluster-e8678655
+      - template: templates/management-cluster/clusterClass/kubeadmControlPlaneTemplate/kubeadmControlPlaneTemplate.yaml
+        equal:
+          path: metadata.name
+          value: my-cluster-e8678655
+  - it: hashes the same name in the ClusterClass templateRef and the KubeadmControlPlaneTemplate itself (attempt 12)
+    asserts:
+      - template: templates/management-cluster/clusterClass/clusterClass.yaml
+        equal:
+          path: spec.controlPlane.templateRef.name
+          value: my-cluster-e8678655
+      - template: templates/management-cluster/clusterClass/kubeadmControlPlaneTemplate/kubeadmControlPlaneTemplate.yaml
+        equal:
+          path: metadata.name
+          value: my-cluster-e8678655
+  - it: hashes the same name in the ClusterClass templateRef and the KubeadmControlPlaneTemplate itself (attempt 13)
+    asserts:
+      - template: templates/management-cluster/clusterClass/clusterClass.yaml
+        equal:
+          path: spec.controlPlane.templateRef.name
+          value: my-cluster-e8678655
+      - template: templates/management-cluster/clusterClass/kubeadmControlPlaneTemplate/kubeadmControlPlaneTemplate.yaml
+        equal:
+          path: metadata.name
+          value: my-cluster-e8678655
+  - it: hashes the same name in the ClusterClass templateRef and the KubeadmControlPlaneTemplate itself (attempt 14)
+    asserts:
+      - template: templates/management-cluster/clusterClass/clusterClass.yaml
+        equal:
+          path: spec.controlPlane.templateRef.name
+          value: my-cluster-e8678655
+      - template: templates/management-cluster/clusterClass/kubeadmControlPlaneTemplate/kubeadmControlPlaneTemplate.yaml
+        equal:
+          path: metadata.name
+          value: my-cluster-e8678655
+  - it: hashes the same name in the ClusterClass templateRef and the KubeadmControlPlaneTemplate itself (attempt 15)
+    asserts:
+      - template: templates/management-cluster/clusterClass/clusterClass.yaml
+        equal:
+          path: spec.controlPlane.templateRef.name
+          value: my-cluster-e8678655
+      - template: templates/management-cluster/clusterClass/kubeadmControlPlaneTemplate/kubeadmControlPlaneTemplate.yaml
+        equal:
+          path: metadata.name
+          value: my-cluster-e8678655
+  - it: hashes the same name in the ClusterClass templateRef and the KubeadmControlPlaneTemplate itself (attempt 16)
+    asserts:
+      - template: templates/management-cluster/clusterClass/clusterClass.yaml
+        equal:
+          path: spec.controlPlane.templateRef.name
+          value: my-cluster-e8678655
+      - template: templates/management-cluster/clusterClass/kubeadmControlPlaneTemplate/kubeadmControlPlaneTemplate.yaml
+        equal:
+          path: metadata.name
+          value: my-cluster-e8678655
+  - it: hashes the same name in the ClusterClass templateRef and the KubeadmControlPlaneTemplate itself (attempt 17)
+    asserts:
+      - template: templates/management-cluster/clusterClass/clusterClass.yaml
+        equal:
+          path: spec.controlPlane.templateRef.name
+          value: my-cluster-e8678655
+      - template: templates/management-cluster/clusterClass/kubeadmControlPlaneTemplate/kubeadmControlPlaneTemplate.yaml
+        equal:
+          path: metadata.name
+          value: my-cluster-e8678655
+  - it: hashes the same name in the ClusterClass templateRef and the KubeadmControlPlaneTemplate itself (attempt 18)
+    asserts:
+      - template: templates/management-cluster/clusterClass/clusterClass.yaml
+        equal:
+          path: spec.controlPlane.templateRef.name
+          value: my-cluster-e8678655
+      - template: templates/management-cluster/clusterClass/kubeadmControlPlaneTemplate/kubeadmControlPlaneTemplate.yaml
+        equal:
+          path: metadata.name
+          value: my-cluster-e8678655
+  - it: hashes the same name in the ClusterClass templateRef and the KubeadmControlPlaneTemplate itself (attempt 19)
+    asserts:
+      - template: templates/management-cluster/clusterClass/clusterClass.yaml
+        equal:
+          path: spec.controlPlane.templateRef.name
+          value: my-cluster-e8678655
+      - template: templates/management-cluster/clusterClass/kubeadmControlPlaneTemplate/kubeadmControlPlaneTemplate.yaml
+        equal:
+          path: metadata.name
+          value: my-cluster-e8678655
+  - it: hashes the same name in the ClusterClass templateRef and the KubeadmControlPlaneTemplate itself (attempt 20)
+    asserts:
+      - template: templates/management-cluster/clusterClass/clusterClass.yaml
+        equal:
+          path: spec.controlPlane.templateRef.name
+          value: my-cluster-e8678655
+      - template: templates/management-cluster/clusterClass/kubeadmControlPlaneTemplate/kubeadmControlPlaneTemplate.yaml
+        equal:
+          path: metadata.name
+          value: my-cluster-e8678655


### PR DESCRIPTION
## Summary
- The `KubeadmControlPlaneTemplate` name hash could differ between the `ClusterClass`'s `templateRef` and the actual `KubeadmControlPlaneTemplate` object on the same render (observed on mgmt-dev, chart 9.12.0), and even changed between separate renders.
- Root cause: `apiServer.dynamicFiles` was piped through Sprig's `values` function to turn the dict into a list before ranging over it. `values` iterates the Go map natively (not via the template `range` action), so it does not get Go template's automatic sorted-key ordering — the resulting order was Go's randomized map iteration, different on every evaluation. That order fed into the `files:` list of the KCPT spec, which is hashed for the name suffix.
- Fix: range directly over the dict instead, restoring deterministic sorted-key ordering (and giving meaningful `$name` values in error messages, instead of list indices).
- Only reproduces when `apiServer.dynamicFiles` has more than one entry, e.g. `controlPlane.audit: true`.

## Test plan
- [x] Added `charts/t8s-cluster/tests/kubeadm_control_plane_template_hash_test.yaml`: asserts the `ClusterClass` templateRef name matches the actual `KubeadmControlPlaneTemplate` object name with `controlPlane.audit: true`, duplicated across 20 independent `it:` cases (helm-unittest has no repeat/seed flag, and each `it:` case is an independently fresh render, so duplication fuzzes for the map-ordering non-determinism).
- [x] Verified the new test reliably fails against the pre-fix code (9/20 failures observed reintroducing the bug) and passes reliably with the fix (multiple full `helm unittest` runs, 76/76 passing).
- [x] `go-task chart:lint CHART=t8s-cluster` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistent KubeadmControlPlaneTemplate naming when multiple dynamic configuration files are present.
  * Ensured generated template names remain deterministic across repeated renders.

* **Tests**
  * Added regression coverage to verify stable names for both the control plane template reference and metadata across repeated renderings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->