### PR TITLE
fix(ci): dedup CVE scan failure issues instead of creating duplicates

### DIFF
--- a/.github/workflows/scan-for-cves.yaml
+++ b/.github/workflows/scan-for-cves.yaml
@@ -5,6 +5,9 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch: {}
 
+env:
+  TITLE: CVE Scan failed
+
 jobs:
   getAllCharts:
     uses: ./.github/workflows/get-all-charts.yaml
@@ -51,7 +54,17 @@ jobs:
       issues: write
     name: Create Issue
     steps:
-      - run: |
+      - name: Check for existing open issue
+        id: existing
+        run: |
+          count="$(gh issue list --search "\"$TITLE\" in:title" --state open --json title --jq "[.[] | select(.title == \"$TITLE\")] | length")"
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+      - name: Create issue
+        if: ${{ steps.existing.outputs.count == '0' }}
+        run: |
           gh issue create \
             --title "$TITLE" \
             --assignee "$ASSIGNEES" \
@@ -60,8 +73,23 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
-          TITLE: CVE Scan failed
           ASSIGNEES: cwrau,marvinWolff,tasches
           LABELS: bug
           BODY: |
             Last run of CVE scanning failed.
+
+  closeIssue:
+    runs-on: ubuntu-latest
+    if: ${{ always() && needs.generateSarifReports.result == 'success' }}
+    needs: generateSarifReports
+    permissions:
+      issues: write
+    name: Close Issue
+    steps:
+      - name: Close stale CVE Scan failed issue
+        run: |
+          gh issue list --search "\"$TITLE\" in:title" --state open --json number,title --jq "[.[] | select(.title == \"$TITLE\")] | .[].number" \
+            | xargs -r -n1 -I{} gh issue close {} --comment "CVE scan is passing again."
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary
- 70/206 issues (34%) in this repo are exact-duplicate "CVE Scan failed" issues, created because `createIssue` in `scan-for-cves.yaml` ran `gh issue create` unconditionally on every failed scan run, with no check for an already-open issue.
- `createIssue` now checks for an existing open "CVE Scan failed" issue first and skips creation if one is already open.
- New `closeIssue` job auto-closes any open "CVE Scan failed" issue once the scan passes again.
- Net effect: duplicate-per-failed-run -> at most one open issue at a time, closed automatically on recovery.

No production/customer impact — CI/repo hygiene only.

## Test plan
- [x] `actionlint` clean on the modified workflow
- [ ] Observe next scheduled run (daily cron) — confirm no duplicate issue created if one is already open, and existing issue gets closed once scan is green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate open CVE scan failure issues from being created.
  - Automatically closes existing CVE scan failure issues when a scan completes successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->