### PR TITLE
fix(base-cluster): switch ACME http01 solver to gatewayHTTPRoute for envoy

### DIFF
--- a/charts/base-cluster/templates/cert-manager/clusterissuer.yaml
+++ b/charts/base-cluster/templates/cert-manager/clusterissuer.yaml
@@ -32,8 +32,18 @@ spec:
         {{- end }}
       {{- end }}
       - http01:
+          {{- if eq (include "base-cluster.ingress.hasEnvoy" .) "true" }}
+          gatewayHTTPRoute:
+            serviceType: ClusterIP
+            parentRefs:
+              - name: ingress-controller
+                namespace: ingress
+                sectionName: http
+                kind: Gateway
+          {{- else }}
           ingress:
             serviceType: ClusterIP
+          {{- end }}
     privateKeySecretRef:
       name: letsencrypt-{{ .name }}-account
     server: {{ .url | quote }}

--- a/charts/base-cluster/tests/ingress_cert_manager_clusterissuer_test.yaml
+++ b/charts/base-cluster/tests/ingress_cert_manager_clusterissuer_test.yaml
@@ -1,0 +1,49 @@
+suite: cert-manager ClusterIssuer http01 solver
+templates:
+  - templates/cert-manager/clusterissuer.yaml
+release:
+  name: base-cluster
+set:
+  certManager.email: admin@example.com
+tests:
+  - it: uses ingress http01 solver when provider is nginx
+    set:
+      ingress.provider: nginx
+    asserts:
+      - hasDocuments:
+          count: 2
+      - matchRegex:
+          path: spec.values.static
+          pattern: "http01:\\n\\s+ingress:\\n\\s+serviceType: ClusterIP"
+      - notMatchRegex:
+          path: spec.values.static
+          pattern: "gatewayHTTPRoute"
+
+  - it: uses ingress http01 solver when provider is traefik
+    set:
+      ingress.provider: traefik
+    asserts:
+      - matchRegex:
+          path: spec.values.static
+          pattern: "http01:\\n\\s+ingress:\\n\\s+serviceType: ClusterIP"
+      - notMatchRegex:
+          path: spec.values.static
+          pattern: "gatewayHTTPRoute"
+
+  - it: uses gatewayHTTPRoute http01 solver when provider is envoy
+    set:
+      ingress.provider: envoy
+    asserts:
+      - matchRegex:
+          path: spec.values.static
+          pattern: "http01:\\n\\s+gatewayHTTPRoute:\\n\\s+serviceType: ClusterIP\\n\\s+parentRefs:\\n\\s+- name: ingress-controller\\n\\s+namespace: ingress\\n\\s+sectionName: http\\n\\s+kind: Gateway"
+      - notMatchRegex:
+          path: spec.values.static
+          pattern: "http01:\\n\\s+ingress:"
+
+  - it: does not render when provider is none
+    set:
+      ingress.provider: none
+    asserts:
+      - hasDocuments:
+          count: 0


### PR DESCRIPTION
## Summary
- The envoy migration flipped cert-manager's `enableGatewayAPI` config flag but never updated the `ClusterIssuer` HTTP01 solver, which was still hardcoded to the plain `ingress` solver form.
- Under `ingress.provider: envoy` there is no Ingress controller watching `Ingress` objects, so ACME HTTP01 validation could not actually succeed for that provider.
- The solver now branches on `base-cluster.ingress.hasEnvoy`: uses `http01.gatewayHTTPRoute` (pointing at the `ingress-controller` Gateway's `http` listener) when envoy, otherwise keeps the existing `http01.ingress` solver for nginx/traefik.

## Test plan
- [x] Added `tests/ingress_cert_manager_clusterissuer_test.yaml` covering nginx/traefik (unchanged `ingress` solver), envoy (`gatewayHTTPRoute` solver), and `none` (no render).
- [x] `go-task chart:test CHART=base-cluster` — 37 suites / 184 tests pass.
- [x] `helm template` with `ingress.provider=envoy` manually verified the rendered `ClusterIssuer` solver.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cert-manager HTTP-01 challenges now support Gateway API routing when Envoy ingress is enabled.
  * Gateway-based validation targets the ingress controller’s HTTP listener.

* **Bug Fixes**
  * Preserved ClusterIP service configuration for HTTP-01 validation with NGINX and Traefik ingress providers.
  * Cert-manager resources are no longer rendered when ingress is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->