### PR TITLE
feat(base-cluster): generify SLA alert labeling via generic sla label

### DIFF
--- a/charts/base-cluster/templates/global/rules/deprecated-apis.yaml
+++ b/charts/base-cluster/templates/global/rules/deprecated-apis.yaml
@@ -24,5 +24,5 @@ spec:
           for: 1d
           labels:
             severity: critical
-            period: WorkingHours
+            sla: WorkingHours
   {{- end -}}

--- a/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_prometheus_config.yaml
+++ b/charts/base-cluster/templates/monitoring/kube-prometheus-stack/_prometheus_config.yaml
@@ -53,9 +53,15 @@ prometheusSpec:
       replacement: kubernetes # TODO: really needed?
 
     - source_labels:
-        - __address__
-      target_label: teutosla
+        - sla
+      regex: ^$
+      target_label: sla
       replacement: {{ .Values.global.serviceLevelAgreement }}
+    - source_labels:
+        - sla
+      regex: (.+)
+      target_label: teutosla
+      replacement: $1
     - source_labels:
         - __address__
       target_label: cluster

--- a/charts/base-cluster/values.schema.json
+++ b/charts/base-cluster/values.schema.json
@@ -8,7 +8,7 @@
       "properties": {
         "serviceLevelAgreement": {
           "type": "string",
-          "description": "The ServiceLevelAgreement with teutonet, will be applied to all alerts as label `teutosla`",
+          "description": "The ServiceLevelAgreement with teutonet, will be applied to all alerts as label `sla` (mirrored to `teutosla`), unless an alert already sets its own `sla` label",
           "enum": [
             "None",
             "24x7",


### PR DESCRIPTION
## Summary
- Alert relabeling now writes the generic `sla` label from `global.serviceLevelAgreement` (only when an alert hasn't already set its own `sla`), and derives `teutosla` from `sla` instead of the other way around.
- `deprecated-apis` alert now pins `sla: WorkingHours` directly and drops its static `period: WorkingHours` label, so it stays business-hours-only regardless of the customer's actual SLA.

## Test plan
- [x] `go-task chart:test CHART=base-cluster` — 180/180 pass
- [x] `helm template` sanity check: default alerts get `sla`/`teutosla` from `global.serviceLevelAgreement`; `deprecated-apis` keeps `sla: WorkingHours` even when `global.serviceLevelAgreement=24x7`, with `teutosla` mirroring it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Monitoring**
  * Alert labels now use `sla` consistently for service-level agreement information.
  * Alerts with an existing SLA retain their specific value; alerts without one inherit the global SLA setting.
  * SLA values are mirrored to `teutosla` for consistent monitoring and alert processing.

* **Documentation**
  * Updated configuration guidance to describe the SLA label behavior and precedence rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->